### PR TITLE
Issue #25163 Cannot post/Print checks

### DIFF
--- a/guiclient/postCheck.cpp
+++ b/guiclient/postCheck.cpp
@@ -29,6 +29,7 @@ postCheck::postCheck(QWidget* parent, const char* name, bool modal, Qt::WFlags f
   _check->setAllowNull(TRUE);
 
   _bankaccnt->setType(XComboBox::APBankAccounts);
+  sHandleBankAccount(_bankaccnt->id());
 }
 
 postCheck::~postCheck()
@@ -100,14 +101,15 @@ void postCheck::sHandleBankAccount(int pBankaccntid)
 {
   XSqlQuery postHandleBankAccount;
   postHandleBankAccount.prepare( "SELECT checkhead_id,"
-	     "       (TEXT(checkhead_number) || '-' || checkrecip_name) "
+	     "     (CASE WHEN(checkhead_number=-1) THEN TEXT('Unspecified')"
+             "           ELSE TEXT(checkhead_number) "
+             "      END || '-' || checkrecip_name) "
              "FROM checkhead LEFT OUTER JOIN"
 	     "     checkrecip ON ((checkhead_recip_id=checkrecip_id)"
 	     "                AND (checkhead_recip_type=checkrecip_type))"
              "     JOIN bankaccnt ON (checkhead_bankaccnt_id=bankaccnt_id)  "
              " WHERE ((NOT checkhead_void)"
              "  AND  (NOT checkhead_posted)"
-             "  AND  CASE WHEN (bankaccnt_prnt_check) THEN checkhead_printed ELSE 1=1 END" 
              "  AND  (checkhead_bankaccnt_id=:bankaccnt_id) ) "
              "ORDER BY checkhead_number;" );
   postHandleBankAccount.bindValue(":bankaccnt_id", pBankaccntid);

--- a/guiclient/postChecks.cpp
+++ b/guiclient/postChecks.cpp
@@ -118,7 +118,6 @@ void postChecks::sHandleBankAccount(int pBankaccntid)
              "JOIN bankaccnt ON (bankaccnt_id=checkhead_bankaccnt_id) "
              "WHERE ( (NOT checkhead_void)"
              " AND (NOT checkhead_posted)"
-             " AND CASE WHEN (bankaccnt_prnt_check) THEN checkhead_printed ELSE 1=1 END"
              " AND (checkhead_bankaccnt_id=:bankaccnt_id) );" );
   postHandleBankAccount.bindValue(":bankaccnt_id", pBankaccntid);
   postHandleBankAccount.exec();

--- a/guiclient/printCheck.cpp
+++ b/guiclient/printCheck.cpp
@@ -45,6 +45,7 @@ printCheck::printCheck(QWidget* parent, const char* name, Qt::WFlags fl)
   _check->setAllowNull(TRUE);
 
   _bankaccnt->setType(XComboBox::APBankAccounts);
+  sHandleBankAccount(_bankaccnt->id());
 
   _createEFT->setVisible(_metrics->boolean("ACHSupported") && _metrics->boolean("ACHEnabled"));
 }


### PR DESCRIPTION
Looks like the initial population of the Bank Account was not triggering the signal to update the payments combo.  Added an explicit call to sHandleBankAccount function to resolve this issue.

Plus there was a logic bug introduced with the 4.8 non-check printing Bank Account logic also resolved here.