### PR TITLE
Issue #25003: CurrCluster size issue on Linux OS.

### DIFF
--- a/widgets/currCluster.cpp
+++ b/widgets/currCluster.cpp
@@ -29,7 +29,7 @@
 #define EPSILON(d) (pow(10.0, -1 * (1 + d + decimals())) * 5)
 #define ABS(f)	((f) > 0 ? (f) : 0 - (f))
 
-#define MINWIDTH       120
+#define MINWIDTH       155
 #define MAXWIDTH       200
 #define MAXHEIGHT    32767
 #define MAXCURRWIDTH    80	/* max width of _currency combobox */


### PR DESCRIPTION
Tweak minimum size so that the curr dropdown does not overlap the money edit.

Need regression testing on Windows and Mac OS (I don't have the build environment for that)  but cannot envisage an issue.