### PR TITLE
Record individual payments without printing

### DIFF
--- a/guiclient/printCheck.cpp
+++ b/guiclient/printCheck.cpp
@@ -38,6 +38,7 @@ printCheck::printCheck(QWidget* parent, const char* name, Qt::WFlags fl)
   connect(_check,     SIGNAL(newID(int)), this, SLOT(sEnableCreateEFT()));
   connect(_createEFT, SIGNAL(clicked()),  this, SLOT(sCreateEFT()));
   connect(_print,     SIGNAL(clicked()),  this, SLOT(sPrint()));
+  connect(_printed,   SIGNAL(clicked()),  this, SLOT(sPrintedAlready()));
 
   _captive = FALSE;
   _setCheckNumber = -1;
@@ -80,6 +81,16 @@ enum SetResponse printCheck::set(const ParameterList &pParams)
 
 void printCheck::sPrint()
 {
+  sPrintImpl(false);
+}
+
+void printCheck::sPrintedAlready()
+{
+  sPrintImpl(true);
+}
+
+void printCheck::sPrintImpl(bool printedAlready)
+{
   XSqlQuery printPrint;
   if(_setCheckNumber != -1 && _setCheckNumber != _nextCheckNum->text().toInt())
   {
@@ -106,6 +117,7 @@ void printCheck::sPrint()
   }
 
   if (_createEFT->isEnabled() &&
+      !printedAlready &&
       QMessageBox::question(this, tr("Print Anyway?"),
                             tr("<p>The recipient of this check has been "
                                "configured for EFT transactions. Do you want "
@@ -193,6 +205,12 @@ void printCheck::sPrint()
     if (printPrint.lastError().type() != QSqlError::NoError)
     {
       systemError(this, printPrint.lastError().databaseText(), __FILE__, __LINE__);
+      return;
+    }
+
+    if(printedAlready)
+    {
+      markCheckAsPrinted(_check->id());
       return;
     }
 

--- a/guiclient/printCheck.h
+++ b/guiclient/printCheck.h
@@ -35,6 +35,7 @@ public slots:
     virtual void sEnableCreateEFT();
     virtual void sHandleBankAccount( int pBankaccntid );
     virtual void sPrint();
+    virtual void sPrintedAlready();
     virtual void populate( int pcheckid );
 
 protected slots:
@@ -48,6 +49,7 @@ private:
     int  _setCheckNumber;
 
     virtual void markCheckAsPrinted(const int);
+    virtual void sPrintImpl(bool printedAlready);
 
 };
 

--- a/guiclient/printCheck.ui
+++ b/guiclient/printCheck.ui
@@ -131,6 +131,16 @@ to be bound by its terms.</comment>
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="_printed">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>&amp;Already Printed/Paid</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="_createEFT">
        <property name="enabled">
         <bool>false</bool>
@@ -179,6 +189,7 @@ to be bound by its terms.</comment>
   <tabstop>_check</tabstop>
   <tabstop>_nextCheckNum</tabstop>
   <tabstop>_print</tabstop>
+  <tabstop>_printed</tabstop>
   <tabstop>_close</tabstop>
  </tabstops>
  <resources/>
@@ -203,6 +214,22 @@ to be bound by its terms.</comment>
    <sender>_check</sender>
    <signal>notNull(bool)</signal>
    <receiver>_print</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>245</x>
+     <y>66</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>348</x>
+     <y>58</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>_check</sender>
+   <signal>notNull(bool)</signal>
+   <receiver>_printed</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">


### PR DESCRIPTION
If a check has been written by hand, or if an electronic payment sent from an account, this allows the user to fill in the check number or electronic transaction number as the document number without actually printing any check.