### PR TITLE
Make Print button more generic on check run tab

### DIFF
--- a/guiclient/viewCheckRun.ui
+++ b/guiclient/viewCheckRun.ui
@@ -206,7 +206,7 @@ to be bound by its terms.</comment>
                  <bool>true</bool>
                 </property>
                 <property name="text" >
-                 <string>Pri&amp;nt</string>
+                 <string>Pri&amp;nt/Written/Paid</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
This makes the button more generic, as it is not always used to print if EFT is used or if some checks are written by hand.