### PR TITLE
Issue #25072: Purchased xTuple licenses are consumed by non xTuple DB connections.

### DIFF
--- a/common/login2.cpp
+++ b/common/login2.cpp
@@ -171,6 +171,10 @@ int login2::set(const ParameterList &pParams, QSplashScreen *pSplash)
   if (valid)
     _setSearchPath = true;
 
+  param = pParams.value("applicationName", &valid);
+  if (valid)
+    _connAppName = param.toString().trimmed();
+
   if(pParams.inList("login"))
     sLogin();
 
@@ -329,7 +333,7 @@ void login2::sLogin()
   int methodidx; // not declared in for () because we'll need it later
   for (methodidx = 0; methodidx < method.size(); methodidx++)
   {
-    db.setConnectOptions(method.at(methodidx).first);
+    db.setConnectOptions(QString("application_name='%1';%2").arg(_connAppName).arg(method.at(methodidx).first));
     db.setPassword(method.at(methodidx).second);
     if (db.open())
       break;  // break instead of for-loop condition to preserve methodidx

--- a/common/login2.cpp
+++ b/common/login2.cpp
@@ -172,8 +172,11 @@ int login2::set(const ParameterList &pParams, QSplashScreen *pSplash)
     _setSearchPath = true;
 
   param = pParams.value("applicationName", &valid);
-  if (valid)
+  if (valid) {
     _connAppName = param.toString().trimmed();
+  } else {
+    _connAppName = "xTuple ERP (unknown)";
+  }
 
   if(pParams.inList("login"))
     sLogin();

--- a/common/login2.h
+++ b/common/login2.h
@@ -74,6 +74,7 @@ class login2 : public QDialog, public Ui::login2
     QString _cPort;
     QString _cloudDatabaseURL;
     QString _cCompany;
+    QString _connAppName;
 };
 
 #endif

--- a/guiclient/company.cpp
+++ b/guiclient/company.cpp
@@ -19,6 +19,7 @@
 
 #include "login2.h"
 #include "currcluster.h"
+#include "version.h"
 
 #define DEBUG false
 
@@ -383,6 +384,7 @@ void company::sTest()
   ParameterList params;
   params.append("databaseURL", dbURL);
   params.append("multipleConnections");
+  params.append("applicationName", _ConnAppName);
 
   login2 newdlg(this, "testLogin", false);
   newdlg.set(params);

--- a/guiclient/databaseInformation.cpp
+++ b/guiclient/databaseInformation.cpp
@@ -14,6 +14,7 @@
 
 #include <dbtools.h>
 #include "xtupleproductkey.h"
+#include "version.h"
 
 databaseInformation::databaseInformation(QWidget* parent, const char* name, bool modal, Qt::WFlags fl)
     : XAbstractConfigure(parent, fl)
@@ -76,8 +77,14 @@ databaseInformation::databaseInformation(QWidget* parent, const char* name, bool
   _disableAutoComplete->setChecked(_metrics->boolean("DisableAutoComplete"));
   _enableGapless->setChecked(_metrics->boolean("EnableGaplessNumbering"));
   
-  databasedatabaseInformation.exec( "SELECT numOfDatabaseUsers() AS databaseusers,"
-          "       numOfServerUsers() AS serverusers;" );
+  databasedatabaseInformation.exec(
+    QString(
+      "SELECT"
+      " numOfDatabaseUsers('%1') AS databaseusers,"
+      " numOfServerUsers() AS serverusers;"
+    ).arg(_ConnAppName)
+  );
+
   if (databasedatabaseInformation.first())
   {
     _numOfDatabaseUsers->setText(databasedatabaseInformation.value("databaseusers").toString());

--- a/guiclient/main.cpp
+++ b/guiclient/main.cpp
@@ -326,27 +326,12 @@ int main(int argc, char *argv[])
     _splash->showMessage(QObject::tr("Checking License Key"), SplashTextAlignment, SplashTextColor);
     qApp->processEvents();
 	
-
-    // PostgreSQL changed the column "procpid" to just "pid" in 9.2.0+ Incident #21852
-    QString pidColName = "pid";
-    XSqlQuery checkVersion(QString("select compareversion('9.2.0');"));
-
-    if(checkVersion.first() && (checkVersion.value("compareversion").toInt() > 0))
-    {
-      pidColName = "procpid";
-    }
-
     metric.exec(
       QString(
         "SELECT"
-        "   COUNT(*) AS xt_client_count,"
-        "   (SELECT COUNT(*) FROM pg_stat_activity WHERE datname=current_database()) AS total_client_count"
-        " FROM pg_locks"
-        "  LEFT JOIN pg_stat_activity ON pg_stat_activity.%1 = pg_locks.pid"
-        "  WHERE pg_locks.objsubid = 2"
-        "  AND pg_stat_activity.datname=current_database()"
-        "  AND application_name = '%2'"
-      ).arg(pidColName).arg(_ConnAppName)
+        "   numOfDatabaseUsers('%1') AS xt_client_count,"
+        "   numOfServerUsers() as total_client_count"
+      ).arg(_ConnAppName)
     );
 
     int cnt = 50000;

--- a/guiclient/main.cpp
+++ b/guiclient/main.cpp
@@ -326,16 +326,27 @@ int main(int argc, char *argv[])
     _splash->showMessage(QObject::tr("Checking License Key"), SplashTextAlignment, SplashTextColor);
     qApp->processEvents();
 	
+
+    // PostgreSQL changed the column "procpid" to just "pid" in 9.2.0+ Incident #21852
+    QString pidColName = "pid";
+    XSqlQuery checkVersion(QString("select compareversion('9.2.0');"));
+
+    if(checkVersion.first() && (checkVersion.value("compareversion").toInt() > 0))
+    {
+      pidColName = "procpid";
+    }
+
     metric.exec(
       QString(
         "SELECT"
-        "  COUNT(*) AS xt_client_count,"
-        "  (SELECT COUNT(*) FROM pg_stat_activity WHERE datname = current_database()) AS total_client_count"
-        " FROM pg_stat_activity"
-        " WHERE"
-        "  datname = current_database()"
-        "  AND application_name = '%1'"
-      ).arg(_ConnAppName)
+        "   COUNT(*) AS xt_client_count,"
+        "   (SELECT COUNT(*) FROM pg_stat_activity WHERE datname=current_database()) AS total_client_count"
+        " FROM pg_locks"
+        "  LEFT JOIN pg_stat_activity ON pg_stat_activity.%1 = pg_locks.pid"
+        "  WHERE pg_locks.objsubid = 2"
+        "  AND pg_stat_activity.datname=current_database()"
+        "  AND application_name = '%2'"
+      ).arg(pidColName).arg(_ConnAppName)
     );
 
     int cnt = 50000;

--- a/guiclient/main.cpp
+++ b/guiclient/main.cpp
@@ -254,6 +254,7 @@ int main(int argc, char *argv[])
     params.append("copyright", _Copyright);
     params.append("version",   _Version);
     params.append("build",     _Build.arg(__DATE__).arg(__TIME__));
+    params.append("applicationName", _ConnAppName);
     params.append("setSearchPath", true);
 
     if (haveUsername)
@@ -325,37 +326,24 @@ int main(int argc, char *argv[])
     _splash->showMessage(QObject::tr("Checking License Key"), SplashTextAlignment, SplashTextColor);
     qApp->processEvents();
 	
-	// PostgreSQL changed the column "procpid" to just "pid" in 9.2.0+ Incident #21852
-	XSqlQuery checkVersion(QString("select compareversion('9.2.0');"));
+    metric.exec(
+      QString(
+        "SELECT"
+        "  COUNT(*) AS xt_client_count,"
+        "  (SELECT COUNT(*) FROM pg_stat_activity WHERE datname = current_database()) AS total_client_count"
+        " FROM pg_stat_activity"
+        " WHERE"
+        "  datname = current_database()"
+        "  AND application_name = '%1'"
+      ).arg(_ConnAppName)
+    );
 
-    if(checkVersion.first())
-    {
-      if(checkVersion.value("compareversion").toInt() > 0)
-      {
-	   metric.exec("SELECT count(*) AS registered, (SELECT count(*) FROM pg_stat_activity WHERE datname=current_database()) AS total"
-			"  FROM pg_stat_activity, pg_locks"
-			" WHERE((database=datid)"
-			"   AND (classid=datid)"
-			"   AND (objsubid=2)"
-			"   AND (procpid = pg_backend_pid()));");
-      }
-	  else
-	  {
-	   metric.exec("SELECT count(*) AS registered, (SELECT count(*) FROM pg_stat_activity WHERE datname=current_database()) AS total"
-			"  FROM pg_stat_activity, pg_locks"
-			" WHERE((database=datid)"
-			"   AND (classid=datid)"
-			"   AND (objsubid=2)"
-			"   AND (pg_stat_activity.pid = pg_backend_pid()));");
-      }
-    }
-	
     int cnt = 50000;
     int tot = 50000;
     if(metric.first())
-    {
-      cnt = metric.value("registered").toInt();
-      tot = metric.value("total").toInt();
+    {        
+      cnt = metric.value("xt_client_count").toInt();
+      tot = metric.value("total_client_count").toInt();
     }
     metric.exec("SELECT packageIsEnabled('drupaluserinfo') AS result;");
     bool xtweb = false;
@@ -415,8 +403,13 @@ int main(int argc, char *argv[])
       }
       else if(pkey.users() != 0 && (pkey.users() < cnt || (!xtweb && (pkey.users() * 2 < tot))))
       {
+        if (pkey.users() < cnt) {
+            checkPassReason = QObject::tr("<p>You have exceeded the number of allowed concurrent xTuple users for your license.</p>");
+        } else {
+            checkPassReason = QObject::tr("<p>You have exceeded the number of allowed concurrent database connections for your license.</p>");
+        }
+
         checkPass = false;
-        checkPassReason = QObject::tr("<p>You have exceeded the number of allowed concurrent users for your license.");
         checkLock = forced = forceLimit;
       }
       else

--- a/guiclient/syncCompanies.cpp
+++ b/guiclient/syncCompanies.cpp
@@ -25,6 +25,7 @@
 
 #include "login2.h"
 #include "storedProcErrorLookup.h"
+#include "version.h"
 
 #define DEBUG   false
 
@@ -234,6 +235,7 @@ void syncCompanies::sSync()
     ParameterList params;
     params.append("databaseURL", dbURL);
     params.append("multipleConnections");
+    params.append("applicationName", _ConnAppName);
 
     login2 newdlg(this, "testLogin", false);
     // disallow changing connection info

--- a/guiclient/version.cpp
+++ b/guiclient/version.cpp
@@ -10,10 +10,11 @@
 
 #include "version.h"
 
-QString _Name      = "xTuple ERP: %1 Edition";
-QString _Version   = "4.9.0Beta";
-QString _dbVersion = "4.9.0Beta";
-QString _Copyright = "Copyright (c) 1999-2015, OpenMFG, LLC.";
+QString _Name        = "xTuple ERP: %1 Edition";
+QString _Version     = "4.9.0Beta";
+QString _dbVersion   = "4.9.0Beta";
+QString _Copyright   = "Copyright (c) 1999-2015, OpenMFG, LLC.";
+QString _ConnAppName = "xTuple ERP (qt-client)";
 
 #ifdef __USEALTVERSION__
 #include "altVersion.cpp"

--- a/guiclient/version.h
+++ b/guiclient/version.h
@@ -18,5 +18,6 @@ extern QString _Version;
 extern QString _dbVersion;
 extern QString _Copyright;
 extern QString _Build;
+extern QString _ConnAppName;
 
 #endif // __XTUPLE_VERSION_H__


### PR DESCRIPTION
This pull request is to present the work that has been started and to begin discussion for the changes necessary to completely resolve [Issue #25072](http://www.xtuple.org/xtincident/view/bugs/25072).

Requires PR xtuple/xtuple#2242.

This patch implements database connection naming using the "application_name" connection parameter to help identify the client connections. Once that was in place I was able to simplify the connection counting routine to focus only on activity reported in "pg_stat_activity". The previous process was going through the extra effort to explicitly count the advisory locks acquired by the application, at this point I'm not sure which one is preferred so I am starting with the simplest.

I have verified that the license enforcement works properly based on the following rules:

 * No more than the licensed number of users may be connected to one xTuple database at a time using the xTuple client.

 * No more than twice the number of licensed users may be connected to one xTuple database at a time. This includes xTuple clients, pgAdmin, and any other external connection sources.

From my understanding of the initial report from the customer this should address any counting errors which was causing the licensing to be enforced for 4 client and 2 pgAdmin connections when using a 5 user license. 

However the error report also contained the following statement: 

> A purchased 5 user license should allow all 5 users to each open one xTuple client connection, regardless of other background server tasks.

I didn't see any comments on the ticket to indicate that this type of change should be made but I see no problem in making the adjustment if that is the new desired behavior.

Once this has been finalized I can address any mismatch in the client / server connection counts that are being reported on the System -> Setup screen.
