### PR TITLE
Issue #25165: Add user-friendly error message for missing PO number

### DIFF
--- a/guiclient/purchaseOrder.cpp
+++ b/guiclient/purchaseOrder.cpp
@@ -1618,6 +1618,14 @@ void purchaseOrder::sCurrencyChanged()
 
 void purchaseOrder::sTabChanged(int pIndex)
 {
+  if (_orderNumber->text() == "" && _purchaseOrderInformation->currentIndex() > 0)
+  {
+    QMessageBox::information(this, tr("Missing Order Number"), tr("Please enter a Purchase Order number before proceeding"));
+    _orderNumber->setFocus();
+    _purchaseOrderInformation->setCurrentIndex(0);
+    return;
+  }
+
   if (pIndex != _cachedTabIndex &&
       _cachedTabIndex == _purchaseOrderInformation->indexOf(_quickEntryTab) &&
       _qeitem->isDirty())


### PR DESCRIPTION
Not entirely sure if this completely resolves the constraint based error message as it only appeared once for me then I did not get the error again despite logging out and in again.

This should catch the problem before the error initiates.