### PR TITLE
first pass at exposing QApplication singleton

### DIFF
--- a/scriptapi/qapplicationproto.cpp
+++ b/scriptapi/qapplicationproto.cpp
@@ -10,11 +10,9 @@
 
 #include "qapplicationproto.h"
 
-#include <QInputContext>
-#include <QString>
-#include <QSymbianEvent>
-#include <QStyle>
 #include <QRgb>
+#include <QString>
+#include <QStyle>
 
 QScriptValue QApplicationtoScriptValue(QScriptEngine *engine, QApplication* const &item)
 { return engine->newQObject(item); }
@@ -52,21 +50,6 @@ QApplicationProto::QApplicationProto(QObject *parent)
 {
 }
 
-void QApplicationProto::commitData(QSessionManager &manager)
-{
-  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
-  if (item)
-    item->commitData(manager);
-}
-
-QInputContext *QApplicationProto::inputContext() const
-{
-  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
-  if (item)
-    return item->inputContext();
-  return 0;
-}
-
 bool QApplicationProto::isSessionRestored() const
 {
   QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
@@ -75,46 +58,12 @@ bool QApplicationProto::isSessionRestored() const
   return false;
 }
 
-#ifdef Q_WS_MAC
-bool QApplicationProto::macEventFilter(EventHandlerCallRef caller, EventRef event)
-{
-  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
-  if (item)
-    return item->macEventFilter(caller, event);
-  return false;
-}
-#endif
-
 bool QApplicationProto::notify(QObject *receiver, QEvent *e)
 {
   QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
   if (item)
     return item->notify(receiver, e);
   return false;
-}
-
-#ifdef Q_WS_QWS
-bool QApplicationProto::qwsEventFilter(QWSEvent *event)
-{
-  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
-  if (item)
-    return item->qwsEventFilter(event);
-  return false;
-}
-
-void QApplicationProto::qwsSetCustomColors(QRgb *colorTable, int start, int numColors)
-{
-  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
-  if (item)
-    item->qwsSetCustomColors(colorTable, start, numColors);
-}
-#endif
-
-void QApplicationProto::saveState(QSessionManager &manager)
-{
-  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
-  if (item)
-    item->saveState(manager);
 }
 
 QString QApplicationProto::sessionId() const
@@ -132,49 +81,6 @@ QString QApplicationProto::sessionKey() const
     return item->sessionKey();
   return QString();
 }
-
-void QApplicationProto::setInputContext(QInputContext* inputContext)
-{
-  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
-  if (item)
-    item->setInputContext(inputContext);
-}
-
-#ifdef Q_OS_SYMBIAN
-bool QApplicationProto::symbianEventFilter(const QSymbianEvent *event)
-{
-  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
-  if (item)
-    return item->symbianEventFilter(event);
-  return false;
-}
-
-int QApplicationProto::symbianProcessEvent(const QSymbianEvent *event)
-{
-  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
-  if (item)
-    return item->symbianProcessEvent(event);
-  return 0;
-}
-#endif
-
-#ifdef Q_WS_X11
-bool QApplicationProto::x11EventFilter(XEvent *event)
-{
-  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
-  if (item)
-    return item->x11EventFilter(event);
-  return false;
-}
-
-int QApplicationProto::x11ProcessEvent(XEvent *event)
-{
-  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
-  if (item)
-    return item->x11ProcessEvent(event);
-  return 0;
-}
-#endif
 
 QWidget *QApplicationProto::activeModalWidget()
 {
@@ -276,16 +182,6 @@ bool QApplicationProto::isRightToLeft()
   return qApp->isRightToLeft();
 }
 
-Qt::LayoutDirection QApplicationProto::keyboardInputDirection()
-{
-  return qApp->keyboardInputDirection();
-}
-
-QLocale QApplicationProto::keyboardInputLocale()
-{
-  return qApp->keyboardInputLocale();
-}
-
 Qt::KeyboardModifiers QApplicationProto::keyboardModifiers()
 {
   return qApp->keyboardModifiers();
@@ -320,23 +216,6 @@ Qt::KeyboardModifiers QApplicationProto::queryKeyboardModifiers()
 {
   return qApp->queryKeyboardModifiers();
 }
-
-#if defined(QT_WS_QWS) && !defined(Q_NO_QWS_MANAGER)
-QDecoration &QApplicationProto::qwsDecoration()
-{
-  return qApp->qwsDecoration();
-}
-
-void QApplicationProto::qwsSetDecoration(QDecoration *decoration)
-{
-  qApp->qwsSetDecoration(decoration);
-}
-
-QDecoration *QApplicationProto::qwsSetDecoration(const QString &decoration)
-{
-  return qApp->qwsSetDecoration(decoration);
-}
-#endif
 
 void QApplicationProto::restoreOverrideCursor()
 {
@@ -373,11 +252,6 @@ void QApplicationProto::setFont(const QFont &font, const char *className)
   qApp->setFont(font, className);
 }
 
-void QApplicationProto::setGraphicsSystem(const QString &system)
-{
-  qApp->setGraphicsSystem(system);
-}
-
 void QApplicationProto::setOverrideCursor(const QCursor &cursor)
 {
   qApp->setOverrideCursor(cursor);
@@ -408,11 +282,6 @@ QStyle *QApplicationProto::style()
   return qApp->style();
 }
 
-void QApplicationProto::syncX()
-{
-  qApp->syncX();
-}
-
 QWidget *QApplicationProto::topLevelAt(const QPoint &point)
 {
   return qApp->topLevelAt(point);
@@ -427,11 +296,6 @@ QWidgetList QApplicationProto::topLevelWidgets()
 {
   return qApp->topLevelWidgets();
   return QWidgetList();
-}
-
-QApplication::Type QApplicationProto::type()
-{
-  return qApp->type();
 }
 
 QWidget *QApplicationProto::widgetAt(const QPoint &point)

--- a/scriptapi/qapplicationproto.cpp
+++ b/scriptapi/qapplicationproto.cpp
@@ -1,0 +1,595 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which (including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#include "qapplicationproto.h"
+
+#include <QInputContext>
+#include <QString>
+#include <QSymbianEvent>
+#include <QStyle>
+#include <QRgb>
+
+QScriptValue QApplicationtoScriptValue(QScriptEngine *engine, QApplication* const &item)
+{ return engine->newQObject(item); }
+
+void QApplicationfromScriptValue(const QScriptValue &obj, QApplication* &item)
+{
+  item = qobject_cast<QApplication*>(obj.toQObject());
+}
+
+void setupQApplicationProto(QScriptEngine *engine)
+{
+ qScriptRegisterMetaType(engine, QApplicationtoScriptValue, QApplicationfromScriptValue);
+
+  QScriptValue proto = engine->newQObject(new QApplicationProto(engine));
+  engine->setDefaultPrototype(qMetaTypeId<QApplication*>(), proto);
+  /*
+  //engine->setDefaultPrototype(qMetaTypeId<QApplication>(),  proto);
+
+  QScriptValue constructor = engine->newFunction(constructQApplication,
+                                                 proto);
+  engine->globalObject().setProperty("QApplication", constructor);
+  */
+  engine->globalObject().setProperty("QApplication", engine->newQObject(qApp));
+}
+
+QScriptValue constructQApplication(QScriptContext  *context,
+                                    QScriptEngine  *engine)
+{
+  Q_UNUSED(engine);
+  context->throwError(QScriptContext::UnknownError,
+                      QString("Cannot construct a QApplication in a script!"));
+  return QScriptValue();
+}
+
+QApplicationProto::QApplicationProto(QObject *parent)
+    : QObject(parent)
+{
+}
+
+void QApplicationProto::commitData(QSessionManager &manager)
+{
+  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
+  if (item)
+    item->commitData(manager);
+}
+
+QInputContext *QApplicationProto::inputContext() const
+{
+  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
+  if (item)
+    return item->inputContext();
+  return 0;
+}
+
+bool QApplicationProto::isSessionRestored() const
+{
+  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
+  if (item)
+    return item->isSessionRestored();
+  return false;
+}
+
+bool QApplicationProto::macEventFilter(EventHandlerCallRef caller, EventRef event)
+{
+  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
+  if (item)
+    return item->macEventFilter(caller, event);
+  return false;
+}
+
+bool QApplicationProto::notify(QObject *receiver, QEvent *e)
+{
+  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
+  if (item)
+    return item->notify(receiver, e);
+  return false;
+}
+
+#ifdef Q_OS_LINUX
+bool QApplicationProto::qwsEventFilter(QWSEvent *event)
+{
+  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
+  if (item)
+    return item->qwsEventFilter(event);
+  return false;
+}
+
+void QApplicationProto::qwsSetCustomColors(QRgb *colorTable, int start, int numColors)
+{
+  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
+  if (item)
+    item->qwsSetCustomColors(colorTable, start, numColors);
+}
+#endif
+
+void QApplicationProto::saveState(QSessionManager &manager)
+{
+  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
+  if (item)
+    item->saveState(manager);
+}
+
+QString QApplicationProto::sessionId() const
+{
+  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
+  if (item)
+    return item->sessionId();
+  return QString();
+}
+
+QString QApplicationProto::sessionKey() const
+{
+  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
+  if (item)
+    return item->sessionKey();
+  return QString();
+}
+
+void QApplicationProto::setInputContext(QInputContext* inputContext)
+{
+  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
+  if (item)
+    item->setInputContext(inputContext);
+}
+
+/*
+QString QApplicationProto::styleSheet() const
+{
+  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
+  if (item)
+    return item->styleSheet();
+  return QString();
+}
+*/
+
+#ifdef Q_OS_SYMBIAN
+bool QApplicationProto::symbianEventFilter(const QSymbianEvent *event)
+{
+  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
+  if (item)
+    return item->symbianEventFilter(event);
+  return false;
+}
+
+int QApplicationProto::symbianProcessEvent(const QSymbianEvent *event)
+{
+  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
+  if (item)
+    return item->symbianProcessEvent(event);
+  return 0;
+}
+#endif
+
+#ifdef Q_WS_X11
+bool QApplicationProto::x11EventFilter(XEvent *event)
+{
+  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
+  if (item)
+    return item->x11EventFilter(event);
+  return false;
+}
+
+int QApplicationProto::x11ProcessEvent(XEvent *event)
+{
+  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
+  if (item)
+    return item->x11ProcessEvent(event);
+  return 0;
+}
+#endif
+
+QWidget *QApplicationProto::activeModalWidget()
+{
+  return qApp->activeModalWidget();
+}
+
+QWidget *QApplicationProto::activePopupWidget()
+{
+  return qApp->activePopupWidget();
+}
+
+QWidget *QApplicationProto::activeWindow()
+{
+  return qApp->activeWindow();
+}
+
+void QApplicationProto::alert(QWidget *widget, int msec)
+{
+  qApp->alert(widget, msec);
+}
+
+QWidgetList QApplicationProto::allWidgets()
+{
+  return qApp->allWidgets();
+}
+
+void QApplicationProto::beep()
+{
+  qApp->beep();
+}
+
+void QApplicationProto::changeOverrideCursor(const QCursor &cursor)
+{
+  qApp->changeOverrideCursor(cursor);
+}
+
+QClipboard *QApplicationProto::clipboard()
+{
+  return qApp->clipboard();
+}
+
+int QApplicationProto::colorSpec()
+{
+  return qApp->colorSpec();
+}
+
+/*
+int QApplicationProto::cursorFlashTime()
+{
+  return qApp->cursorFlashTime();
+}
+*/
+
+QDesktopWidget *QApplicationProto::desktop()
+{
+  return qApp->desktop();
+}
+
+bool QApplicationProto::desktopSettingsAware()
+{
+  return qApp->desktopSettingsAware();
+}
+
+/*
+int QApplicationProto::doubleClickInterval()
+{
+  return qApp->doubleClickInterval();
+}
+*/
+
+int QApplicationProto::exec()
+{
+  return qApp->exec();
+}
+
+QWidget *QApplicationProto::focusWidget()
+{
+  return qApp->focusWidget();
+}
+
+QFont QApplicationProto::font()
+{
+  return qApp->font();
+}
+
+QFont QApplicationProto::font(const QWidget *widget)
+{
+  return qApp->font(widget);
+}
+
+QFont QApplicationProto::font(const char *className)
+{
+  return qApp->font(className);
+}
+
+QFontMetrics QApplicationProto::fontMetrics()
+{
+  return qApp->fontMetrics();
+}
+
+/*
+QSize QApplicationProto::globalStrut()
+{
+  return qApp->globalStrut();
+}
+*/
+
+bool QApplicationProto::isEffectEnabled(Qt::UIEffect effect)
+{
+  return qApp->isEffectEnabled(effect);
+}
+
+bool QApplicationProto::isLeftToRight()
+{
+  return qApp->isLeftToRight();
+}
+
+bool QApplicationProto::isRightToLeft()
+{
+  return qApp->isRightToLeft();
+}
+
+Qt::LayoutDirection QApplicationProto::keyboardInputDirection()
+{
+  return qApp->keyboardInputDirection();
+}
+
+/*
+int QApplicationProto::keyboardInputInterval()
+{
+  return qApp->keyboardInputInterval();
+}
+*/
+
+QLocale QApplicationProto::keyboardInputLocale()
+{
+  return qApp->keyboardInputLocale();
+}
+
+Qt::KeyboardModifiers QApplicationProto::keyboardModifiers()
+{
+  return qApp->keyboardModifiers();
+}
+
+/*
+Qt::LayoutDirection QApplicationProto::layoutDirection()
+{
+  return qApp->layoutDirection();
+}
+*/
+
+Qt::MouseButtons QApplicationProto::mouseButtons()
+{
+  return qApp->mouseButtons();
+}
+
+/*
+#if defined(Q_OS_LINUX) || defined(Q_OS_SYMBIAN) || defined(Q_OS_WINCE)
+Qt::NavigationMode QApplicationProto::navigationMode()
+{
+  return qApp->navigationMode();
+}
+#endif
+*/
+
+QCursor *QApplicationProto::overrideCursor()
+{
+  return qApp->overrideCursor();
+}
+
+QPalette QApplicationProto::palette()
+{
+  return qApp->palette();
+}
+
+QPalette QApplicationProto::palette(const QWidget *widget)
+{
+  return qApp->palette(widget);
+}
+
+QPalette QApplicationProto::palette(const char *className)
+{
+  return qApp->palette(className);
+}
+
+Qt::KeyboardModifiers QApplicationProto::queryKeyboardModifiers()
+{
+  return qApp->queryKeyboardModifiers();
+}
+
+/*
+bool QApplicationProto::quitOnLastWindowClosed()
+{
+  return qApp->quitOnLastWindowClosed();
+}
+*/
+
+#ifdef Q_OS_LINUX
+QDecoration &QApplicationProto::qwsDecoration()
+{
+  return qApp->qwsDecoration();
+}
+
+void QApplicationProto::qwsSetDecoration(QDecoration *decoration)
+{
+  qApp->qwsSetDecoration(decoration);
+}
+
+QDecoration *QApplicationProto::qwsSetDecoration(const QString &decoration)
+{
+  return qApp->qwsSetDecoration(decoration);
+}
+#endif
+
+void QApplicationProto::restoreOverrideCursor()
+{
+  qApp->restoreOverrideCursor();
+}
+
+void QApplicationProto::setActiveWindow(QWidget *active)
+{
+  qApp->setActiveWindow(active);
+}
+
+void QApplicationProto::setColorSpec(int spec)
+{
+  qApp->setColorSpec(spec);
+}
+
+/*
+void QApplicationProto::setCursorFlashTime(int ms)
+{
+  qApp->setCursorFlashTime(ms);
+}
+*/
+
+void QApplicationProto::setDesktopSettingsAware(bool on)
+{
+  qApp->setDesktopSettingsAware(on);
+}
+
+void QApplicationProto::setDoubleClickInterval(int ms)
+{
+  qApp->setDoubleClickInterval(ms);
+}
+
+void QApplicationProto::setEffectEnabled(Qt::UIEffect effect, bool enable)
+{
+  qApp->setEffectEnabled(effect, enable);
+}
+
+void QApplicationProto::setFont(const QFont &font, const char *className)
+{
+  qApp->setFont(font, className);
+}
+
+/*
+void QApplicationProto::setGlobalStrut(const QSize &size)
+{
+  qApp->setGlobalStrut(size);
+}
+*/
+
+void QApplicationProto::setGraphicsSystem(const QString &system)
+{
+  qApp->setGraphicsSystem(system);
+}
+
+/*
+void QApplicationProto::setKeyboardInputInterval(int ms)
+{
+  qApp->setKeyboardInputInterval(ms);
+}
+
+void QApplicationProto::setLayoutDirection(Qt::LayoutDirection direction)
+{
+  qApp->setLayoutDirection(direction);
+}
+
+#if defined(Q_OS_LINUX) || defined(Q_OS_SYMBIAN) || defined(Q_OS_WINCE)
+void QApplicationProto::setNavigationMode(Qt::NavigationMode mode)
+{
+  qApp->setNavigationMode(mode);
+}
+#endif
+*/
+
+void QApplicationProto::setOverrideCursor(const QCursor &cursor)
+{
+  qApp->setOverrideCursor(cursor);
+}
+
+void QApplicationProto::setPalette(const QPalette &palette, const char *className)
+{
+  qApp->setPalette(palette, className);
+}
+
+void QApplicationProto::setQuitOnLastWindowClosed(bool quit)
+{
+  qApp->setQuitOnLastWindowClosed(quit);
+}
+
+/*
+void QApplicationProto::setStartDragDistance(int l)
+{
+  qApp->setStartDragDistance(l);
+}
+
+void QApplicationProto::setStartDragTime(int ms)
+{
+  qApp->setStartDragTime(ms);
+}
+*/
+
+void QApplicationProto::setStyle(QStyle *style)
+{
+  qApp->setStyle(style);
+}
+
+QStyle *QApplicationProto::setStyle(const QString &style)
+{
+  return qApp->setStyle(style);
+}
+
+/*
+void QApplicationProto::setWheelScrollLines(int lines)
+{
+  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
+  if (item)
+    item->setWheelScrollLines(lines);
+}
+
+void QApplicationProto::setWindowIcon(const QIcon &icon)
+{
+  qApp->setWindowIcon(icon);
+}
+
+int QApplicationProto::startDragDistance()
+{
+  return qApp->startDragDistance();
+}
+
+int QApplicationProto::startDragTime()
+{
+  return qApp->startDragTime();
+}
+*/
+
+QStyle *QApplicationProto::style()
+{
+  return qApp->style();
+}
+
+void QApplicationProto::syncX()
+{
+  qApp->syncX();
+}
+
+QWidget *QApplicationProto::topLevelAt(const QPoint &point)
+{
+  return qApp->topLevelAt(point);
+}
+
+QWidget *QApplicationProto::topLevelAt(int x, int y)
+{
+  return qApp->topLevelAt(x, y);
+}
+
+QWidgetList QApplicationProto::topLevelWidgets()
+{
+  return qApp->topLevelWidgets();
+  return QWidgetList();
+}
+
+QApplication::Type QApplicationProto::type()
+{
+  return qApp->type();
+}
+
+/*
+int QApplicationProto::wheelScrollLines()
+{
+  return qApp->wheelScrollLines();
+}
+*/
+
+QWidget *QApplicationProto::widgetAt(const QPoint &point)
+{
+  return qApp->widgetAt(point);
+}
+
+QWidget *QApplicationProto::widgetAt(int x, int y)
+{
+  return qApp->widgetAt(x, y);
+}
+
+/*
+QIcon QApplicationProto::windowIcon()
+{
+  return qApp->windowIcon();
+}
+*/
+
+QString QApplicationProto::toString() const
+{
+  return qApp->arguments().join(" ");
+}
+

--- a/scriptapi/qapplicationproto.cpp
+++ b/scriptapi/qapplicationproto.cpp
@@ -31,8 +31,6 @@ void setupQApplicationProto(QScriptEngine *engine)
   QScriptValue proto = engine->newQObject(new QApplicationProto(engine));
   engine->setDefaultPrototype(qMetaTypeId<QApplication*>(), proto);
   /*
-  //engine->setDefaultPrototype(qMetaTypeId<QApplication>(),  proto);
-
   QScriptValue constructor = engine->newFunction(constructQApplication,
                                                  proto);
   engine->globalObject().setProperty("QApplication", constructor);
@@ -77,6 +75,7 @@ bool QApplicationProto::isSessionRestored() const
   return false;
 }
 
+#ifdef Q_WS_MAC
 bool QApplicationProto::macEventFilter(EventHandlerCallRef caller, EventRef event)
 {
   QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
@@ -84,6 +83,7 @@ bool QApplicationProto::macEventFilter(EventHandlerCallRef caller, EventRef even
     return item->macEventFilter(caller, event);
   return false;
 }
+#endif
 
 bool QApplicationProto::notify(QObject *receiver, QEvent *e)
 {
@@ -93,7 +93,7 @@ bool QApplicationProto::notify(QObject *receiver, QEvent *e)
   return false;
 }
 
-#ifdef Q_OS_LINUX
+#ifdef Q_WS_QWS
 bool QApplicationProto::qwsEventFilter(QWSEvent *event)
 {
   QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
@@ -139,16 +139,6 @@ void QApplicationProto::setInputContext(QInputContext* inputContext)
   if (item)
     item->setInputContext(inputContext);
 }
-
-/*
-QString QApplicationProto::styleSheet() const
-{
-  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
-  if (item)
-    return item->styleSheet();
-  return QString();
-}
-*/
 
 #ifdef Q_OS_SYMBIAN
 bool QApplicationProto::symbianEventFilter(const QSymbianEvent *event)
@@ -231,13 +221,6 @@ int QApplicationProto::colorSpec()
   return qApp->colorSpec();
 }
 
-/*
-int QApplicationProto::cursorFlashTime()
-{
-  return qApp->cursorFlashTime();
-}
-*/
-
 QDesktopWidget *QApplicationProto::desktop()
 {
   return qApp->desktop();
@@ -247,13 +230,6 @@ bool QApplicationProto::desktopSettingsAware()
 {
   return qApp->desktopSettingsAware();
 }
-
-/*
-int QApplicationProto::doubleClickInterval()
-{
-  return qApp->doubleClickInterval();
-}
-*/
 
 int QApplicationProto::exec()
 {
@@ -285,13 +261,6 @@ QFontMetrics QApplicationProto::fontMetrics()
   return qApp->fontMetrics();
 }
 
-/*
-QSize QApplicationProto::globalStrut()
-{
-  return qApp->globalStrut();
-}
-*/
-
 bool QApplicationProto::isEffectEnabled(Qt::UIEffect effect)
 {
   return qApp->isEffectEnabled(effect);
@@ -312,13 +281,6 @@ Qt::LayoutDirection QApplicationProto::keyboardInputDirection()
   return qApp->keyboardInputDirection();
 }
 
-/*
-int QApplicationProto::keyboardInputInterval()
-{
-  return qApp->keyboardInputInterval();
-}
-*/
-
 QLocale QApplicationProto::keyboardInputLocale()
 {
   return qApp->keyboardInputLocale();
@@ -329,26 +291,10 @@ Qt::KeyboardModifiers QApplicationProto::keyboardModifiers()
   return qApp->keyboardModifiers();
 }
 
-/*
-Qt::LayoutDirection QApplicationProto::layoutDirection()
-{
-  return qApp->layoutDirection();
-}
-*/
-
 Qt::MouseButtons QApplicationProto::mouseButtons()
 {
   return qApp->mouseButtons();
 }
-
-/*
-#if defined(Q_OS_LINUX) || defined(Q_OS_SYMBIAN) || defined(Q_OS_WINCE)
-Qt::NavigationMode QApplicationProto::navigationMode()
-{
-  return qApp->navigationMode();
-}
-#endif
-*/
 
 QCursor *QApplicationProto::overrideCursor()
 {
@@ -375,14 +321,7 @@ Qt::KeyboardModifiers QApplicationProto::queryKeyboardModifiers()
   return qApp->queryKeyboardModifiers();
 }
 
-/*
-bool QApplicationProto::quitOnLastWindowClosed()
-{
-  return qApp->quitOnLastWindowClosed();
-}
-*/
-
-#ifdef Q_OS_LINUX
+#if defined(QT_WS_QWS) && !defined(Q_NO_QWS_MANAGER)
 QDecoration &QApplicationProto::qwsDecoration()
 {
   return qApp->qwsDecoration();
@@ -414,13 +353,6 @@ void QApplicationProto::setColorSpec(int spec)
   qApp->setColorSpec(spec);
 }
 
-/*
-void QApplicationProto::setCursorFlashTime(int ms)
-{
-  qApp->setCursorFlashTime(ms);
-}
-*/
-
 void QApplicationProto::setDesktopSettingsAware(bool on)
 {
   qApp->setDesktopSettingsAware(on);
@@ -441,36 +373,10 @@ void QApplicationProto::setFont(const QFont &font, const char *className)
   qApp->setFont(font, className);
 }
 
-/*
-void QApplicationProto::setGlobalStrut(const QSize &size)
-{
-  qApp->setGlobalStrut(size);
-}
-*/
-
 void QApplicationProto::setGraphicsSystem(const QString &system)
 {
   qApp->setGraphicsSystem(system);
 }
-
-/*
-void QApplicationProto::setKeyboardInputInterval(int ms)
-{
-  qApp->setKeyboardInputInterval(ms);
-}
-
-void QApplicationProto::setLayoutDirection(Qt::LayoutDirection direction)
-{
-  qApp->setLayoutDirection(direction);
-}
-
-#if defined(Q_OS_LINUX) || defined(Q_OS_SYMBIAN) || defined(Q_OS_WINCE)
-void QApplicationProto::setNavigationMode(Qt::NavigationMode mode)
-{
-  qApp->setNavigationMode(mode);
-}
-#endif
-*/
 
 void QApplicationProto::setOverrideCursor(const QCursor &cursor)
 {
@@ -487,18 +393,6 @@ void QApplicationProto::setQuitOnLastWindowClosed(bool quit)
   qApp->setQuitOnLastWindowClosed(quit);
 }
 
-/*
-void QApplicationProto::setStartDragDistance(int l)
-{
-  qApp->setStartDragDistance(l);
-}
-
-void QApplicationProto::setStartDragTime(int ms)
-{
-  qApp->setStartDragTime(ms);
-}
-*/
-
 void QApplicationProto::setStyle(QStyle *style)
 {
   qApp->setStyle(style);
@@ -508,30 +402,6 @@ QStyle *QApplicationProto::setStyle(const QString &style)
 {
   return qApp->setStyle(style);
 }
-
-/*
-void QApplicationProto::setWheelScrollLines(int lines)
-{
-  QApplication *item = qscriptvalue_cast<QApplication*>(thisObject());
-  if (item)
-    item->setWheelScrollLines(lines);
-}
-
-void QApplicationProto::setWindowIcon(const QIcon &icon)
-{
-  qApp->setWindowIcon(icon);
-}
-
-int QApplicationProto::startDragDistance()
-{
-  return qApp->startDragDistance();
-}
-
-int QApplicationProto::startDragTime()
-{
-  return qApp->startDragTime();
-}
-*/
 
 QStyle *QApplicationProto::style()
 {
@@ -564,13 +434,6 @@ QApplication::Type QApplicationProto::type()
   return qApp->type();
 }
 
-/*
-int QApplicationProto::wheelScrollLines()
-{
-  return qApp->wheelScrollLines();
-}
-*/
-
 QWidget *QApplicationProto::widgetAt(const QPoint &point)
 {
   return qApp->widgetAt(point);
@@ -580,13 +443,6 @@ QWidget *QApplicationProto::widgetAt(int x, int y)
 {
   return qApp->widgetAt(x, y);
 }
-
-/*
-QIcon QApplicationProto::windowIcon()
-{
-  return qApp->windowIcon();
-}
-*/
 
 QString QApplicationProto::toString() const
 {

--- a/scriptapi/qapplicationproto.h
+++ b/scriptapi/qapplicationproto.h
@@ -1,0 +1,154 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which (including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#ifndef __QAPPLICATIONPROTO_H__
+#define __QAPPLICATIONPROTO_H__
+
+#include <QApplication>
+#include <QDecoration>
+#include <QObject>
+#include <QSessionManager>
+#include <QWSEvent>
+#include <QtScript>
+
+class QInputContext;
+class QString;
+class QSymbianEvent;
+class XEvent;
+
+Q_DECLARE_METATYPE(QApplication*)
+
+void setupQApplicationProto(QScriptEngine *engine);
+QScriptValue constructQApplication(QScriptContext *context, QScriptEngine *engine);
+
+class QApplicationProto : public QObject, public QScriptable
+{
+  Q_OBJECT
+
+//Q_PROPERTY(int     autoMaximizeThreshold        READ autoMaximizeThreshold  WRITE setAutoMaximizeThreshold)
+//Q_PROPERTY(bool    autoSipEnabled               READ autoSipEnabled         WRITE setAutoSipEnabled)
+//Q_PROPERTY(int     cursorFlashTime              READ cursorFlashTime        WRITE setCursorFlashTime)
+//Q_PROPERTY(int     doubleClickInterval          READ doubleClickInterval    WRITE setDoubleClickInterval)
+//Q_PROPERTY(QSize   globalStrut                  READ globalStrut            WRITE setGlobalStrut)
+//Q_PROPERTY(int     keyboardInputInterval        READ keyboardInputInterval  WRITE setKeyboardInputInterval)
+//Q_PROPERTY(Qt::LayoutDirection layoutDirection  READ layoutDirection        WRITE setLayoutDirection)
+//Q_PROPERTY(bool    quitOnLastWindowClosed       READ quitOnLastWindowClosed WRITE setQuitOnLastWindowClosed)
+//Q_PROPERTY(int     startDragDistance            READ startDragDistance      WRITE setStartDragDistance)
+//Q_PROPERTY(int     startDragTime                READ startDragTime          WRITE setStartDragTime)
+//Q_PROPERTY(QString styleSheet                   READ styleSheet             WRITE setStyleSheet)
+//Q_PROPERTY(int     wheelScrollLines             READ wheelScrollLines       WRITE setWheelScrollLines)
+//Q_PROPERTY(QIcon   windowIcon                   READ windowIcon             WRITE setWindowIcon)
+
+  public:
+    QApplicationProto(QObject *parent);
+
+    Q_INVOKABLE void            commitData(QSessionManager &manager);
+    Q_INVOKABLE QInputContext  *inputContext()                   const;
+    Q_INVOKABLE bool            isSessionRestored()              const;
+    Q_INVOKABLE bool            macEventFilter(EventHandlerCallRef caller, EventRef event);
+    Q_INVOKABLE bool            notify(QObject *receiver, QEvent *e);
+#ifdef Q_OS_LINUX
+    Q_INVOKABLE bool            qwsEventFilter(QWSEvent *event);
+    Q_INVOKABLE void            qwsSetCustomColors(QRgb *colorTable, int start, int numColors);
+#endif
+    Q_INVOKABLE void            saveState(QSessionManager &manager);
+    Q_INVOKABLE QString         sessionId()         const;
+    Q_INVOKABLE QString         sessionKey()        const;
+    Q_INVOKABLE void            setInputContext(QInputContext* inputContext);
+//  Q_INVOKABLE QString         styleSheet()        const;
+#ifdef Q_OS_SYMBIAN
+    Q_INVOKABLE bool            symbianEventFilter(const QSymbianEvent *event);
+    Q_INVOKABLE int             symbianProcessEvent(const QSymbianEvent *event);
+#endif
+#ifdef Q_WS_X11
+    Q_INVOKABLE bool            x11EventFilter(XEvent *event);
+    Q_INVOKABLE int             x11ProcessEvent(XEvent *event);
+#endif
+
+    Q_INVOKABLE QWidget        *activeModalWidget();
+    Q_INVOKABLE QWidget        *activePopupWidget();
+    Q_INVOKABLE QWidget        *activeWindow();
+    Q_INVOKABLE void            alert(QWidget * widget, int msec = 0);
+    Q_INVOKABLE QWidgetList     allWidgets();
+    Q_INVOKABLE void            beep();
+    Q_INVOKABLE void            changeOverrideCursor(const QCursor &cursor);
+    Q_INVOKABLE QClipboard     *clipboard();
+    Q_INVOKABLE int             colorSpec();
+//  Q_INVOKABLE int             cursorFlashTime();
+    Q_INVOKABLE QDesktopWidget *desktop();
+    Q_INVOKABLE bool            desktopSettingsAware();
+//  Q_INVOKABLE int             doubleClickInterval();
+    Q_INVOKABLE int             exec();
+    Q_INVOKABLE QWidget        *focusWidget();
+    Q_INVOKABLE QFont           font();
+    Q_INVOKABLE QFont           font(const QWidget * widget);
+    Q_INVOKABLE QFont           font(const char * className);
+    Q_INVOKABLE QFontMetrics    fontMetrics();
+//  Q_INVOKABLE QSize           globalStrut();
+    Q_INVOKABLE bool            isEffectEnabled(Qt::UIEffect effect);
+    Q_INVOKABLE bool            isLeftToRight();
+    Q_INVOKABLE bool            isRightToLeft();
+    Q_INVOKABLE Qt::LayoutDirection     keyboardInputDirection();
+//  Q_INVOKABLE int             keyboardInputInterval();
+    Q_INVOKABLE QLocale         keyboardInputLocale();
+    Q_INVOKABLE Qt::KeyboardModifiers   keyboardModifiers();
+//  Q_INVOKABLE Qt::LayoutDirection     layoutDirection();
+    Q_INVOKABLE Qt::MouseButtons        mouseButtons();
+//  Q_INVOKABLE Qt::NavigationMode      navigationMode();
+    Q_INVOKABLE QCursor        *overrideCursor();
+    Q_INVOKABLE QPalette        palette();
+    Q_INVOKABLE QPalette        palette(const QWidget *widget);
+    Q_INVOKABLE QPalette        palette(const char *className);
+    Q_INVOKABLE Qt::KeyboardModifiers   queryKeyboardModifiers();
+//  Q_INVOKABLE bool            quitOnLastWindowClosed();
+#ifdef Q_OS_LINUX
+    Q_INVOKABLE QDecoration    &qwsDecoration();
+    Q_INVOKABLE void            qwsSetDecoration(QDecoration *decoration);
+    Q_INVOKABLE QDecoration    *qwsSetDecoration(const QString &decoration);
+#endif
+    Q_INVOKABLE void            restoreOverrideCursor();
+    Q_INVOKABLE void            setActiveWindow(QWidget *active);
+    Q_INVOKABLE void            setColorSpec(int spec);
+//  Q_INVOKABLE void            setCursorFlashTime(int ms);
+    Q_INVOKABLE void            setDesktopSettingsAware(bool on);
+    Q_INVOKABLE void            setDoubleClickInterval(int ms);
+    Q_INVOKABLE void            setEffectEnabled(Qt::UIEffect effect, bool enable = true);
+    Q_INVOKABLE void            setFont(const QFont &font, const char *className = 0);
+//  Q_INVOKABLE void            setGlobalStrut(const QSize &size);
+    Q_INVOKABLE void            setGraphicsSystem(const QString &system);
+//  Q_INVOKABLE void            setKeyboardInputInterval(int ms);
+//  Q_INVOKABLE void            setLayoutDirection(Qt::LayoutDirection direction);
+//  Q_INVOKABLE void            setNavigationMode(Qt::NavigationMode mode);
+    Q_INVOKABLE void            setOverrideCursor(const QCursor &cursor);
+    Q_INVOKABLE void            setPalette(const QPalette &palette, const char *className = 0);
+    Q_INVOKABLE void            setQuitOnLastWindowClosed(bool quit);
+//  Q_INVOKABLE void            setStartDragDistance(int l);
+//  Q_INVOKABLE void            setStartDragTime(int ms);
+    Q_INVOKABLE void            setStyle(QStyle *style);
+    Q_INVOKABLE QStyle         *setStyle(const QString &style);
+//  Q_INVOKABLE void            setWheelScrollLines(int);
+//  Q_INVOKABLE void            setWindowIcon(const QIcon &icon);
+//  Q_INVOKABLE int             startDragDistance();
+//  Q_INVOKABLE int             startDragTime();
+    Q_INVOKABLE QStyle         *style();
+    Q_INVOKABLE void            syncX();
+    Q_INVOKABLE QWidget        *topLevelAt(const QPoint &point);
+    Q_INVOKABLE QWidget        *topLevelAt(int x, int y);
+    Q_INVOKABLE QWidgetList     topLevelWidgets();
+    Q_INVOKABLE QApplication::Type      type();
+//  Q_INVOKABLE int             wheelScrollLines();
+    Q_INVOKABLE QWidget        *widgetAt(const QPoint &point);
+    Q_INVOKABLE QWidget        *widgetAt(int x, int y);
+//  Q_INVOKABLE QIcon           windowIcon();
+
+    Q_INVOKABLE QString        toString()          const;
+};
+
+#endif

--- a/scriptapi/qapplicationproto.h
+++ b/scriptapi/qapplicationproto.h
@@ -21,7 +21,6 @@
 class QInputContext;
 class QString;
 class QSymbianEvent;
-class XEvent;
 
 Q_DECLARE_METATYPE(QApplication*)
 
@@ -32,29 +31,17 @@ class QApplicationProto : public QObject, public QScriptable
 {
   Q_OBJECT
 
-//Q_PROPERTY(int     autoMaximizeThreshold        READ autoMaximizeThreshold  WRITE setAutoMaximizeThreshold)
-//Q_PROPERTY(bool    autoSipEnabled               READ autoSipEnabled         WRITE setAutoSipEnabled)
-//Q_PROPERTY(int     cursorFlashTime              READ cursorFlashTime        WRITE setCursorFlashTime)
-//Q_PROPERTY(int     doubleClickInterval          READ doubleClickInterval    WRITE setDoubleClickInterval)
-//Q_PROPERTY(QSize   globalStrut                  READ globalStrut            WRITE setGlobalStrut)
-//Q_PROPERTY(int     keyboardInputInterval        READ keyboardInputInterval  WRITE setKeyboardInputInterval)
-//Q_PROPERTY(Qt::LayoutDirection layoutDirection  READ layoutDirection        WRITE setLayoutDirection)
-//Q_PROPERTY(bool    quitOnLastWindowClosed       READ quitOnLastWindowClosed WRITE setQuitOnLastWindowClosed)
-//Q_PROPERTY(int     startDragDistance            READ startDragDistance      WRITE setStartDragDistance)
-//Q_PROPERTY(int     startDragTime                READ startDragTime          WRITE setStartDragTime)
-//Q_PROPERTY(QString styleSheet                   READ styleSheet             WRITE setStyleSheet)
-//Q_PROPERTY(int     wheelScrollLines             READ wheelScrollLines       WRITE setWheelScrollLines)
-//Q_PROPERTY(QIcon   windowIcon                   READ windowIcon             WRITE setWindowIcon)
-
   public:
     QApplicationProto(QObject *parent);
 
     Q_INVOKABLE void            commitData(QSessionManager &manager);
     Q_INVOKABLE QInputContext  *inputContext()                   const;
     Q_INVOKABLE bool            isSessionRestored()              const;
+#ifdef Q_WS_MAC
     Q_INVOKABLE bool            macEventFilter(EventHandlerCallRef caller, EventRef event);
+#endif
     Q_INVOKABLE bool            notify(QObject *receiver, QEvent *e);
-#ifdef Q_OS_LINUX
+#ifdef Q_WS_QWS
     Q_INVOKABLE bool            qwsEventFilter(QWSEvent *event);
     Q_INVOKABLE void            qwsSetCustomColors(QRgb *colorTable, int start, int numColors);
 #endif
@@ -62,7 +49,6 @@ class QApplicationProto : public QObject, public QScriptable
     Q_INVOKABLE QString         sessionId()         const;
     Q_INVOKABLE QString         sessionKey()        const;
     Q_INVOKABLE void            setInputContext(QInputContext* inputContext);
-//  Q_INVOKABLE QString         styleSheet()        const;
 #ifdef Q_OS_SYMBIAN
     Q_INVOKABLE bool            symbianEventFilter(const QSymbianEvent *event);
     Q_INVOKABLE int             symbianProcessEvent(const QSymbianEvent *event);
@@ -81,34 +67,27 @@ class QApplicationProto : public QObject, public QScriptable
     Q_INVOKABLE void            changeOverrideCursor(const QCursor &cursor);
     Q_INVOKABLE QClipboard     *clipboard();
     Q_INVOKABLE int             colorSpec();
-//  Q_INVOKABLE int             cursorFlashTime();
     Q_INVOKABLE QDesktopWidget *desktop();
     Q_INVOKABLE bool            desktopSettingsAware();
-//  Q_INVOKABLE int             doubleClickInterval();
     Q_INVOKABLE int             exec();
     Q_INVOKABLE QWidget        *focusWidget();
     Q_INVOKABLE QFont           font();
     Q_INVOKABLE QFont           font(const QWidget * widget);
     Q_INVOKABLE QFont           font(const char * className);
     Q_INVOKABLE QFontMetrics    fontMetrics();
-//  Q_INVOKABLE QSize           globalStrut();
     Q_INVOKABLE bool            isEffectEnabled(Qt::UIEffect effect);
     Q_INVOKABLE bool            isLeftToRight();
     Q_INVOKABLE bool            isRightToLeft();
     Q_INVOKABLE Qt::LayoutDirection     keyboardInputDirection();
-//  Q_INVOKABLE int             keyboardInputInterval();
     Q_INVOKABLE QLocale         keyboardInputLocale();
     Q_INVOKABLE Qt::KeyboardModifiers   keyboardModifiers();
-//  Q_INVOKABLE Qt::LayoutDirection     layoutDirection();
     Q_INVOKABLE Qt::MouseButtons        mouseButtons();
-//  Q_INVOKABLE Qt::NavigationMode      navigationMode();
     Q_INVOKABLE QCursor        *overrideCursor();
     Q_INVOKABLE QPalette        palette();
     Q_INVOKABLE QPalette        palette(const QWidget *widget);
     Q_INVOKABLE QPalette        palette(const char *className);
     Q_INVOKABLE Qt::KeyboardModifiers   queryKeyboardModifiers();
-//  Q_INVOKABLE bool            quitOnLastWindowClosed();
-#ifdef Q_OS_LINUX
+#if defined(QT_WS_QWS) && !defined(Q_NO_QWS_MANAGER)
     Q_INVOKABLE QDecoration    &qwsDecoration();
     Q_INVOKABLE void            qwsSetDecoration(QDecoration *decoration);
     Q_INVOKABLE QDecoration    *qwsSetDecoration(const QString &decoration);
@@ -116,37 +95,24 @@ class QApplicationProto : public QObject, public QScriptable
     Q_INVOKABLE void            restoreOverrideCursor();
     Q_INVOKABLE void            setActiveWindow(QWidget *active);
     Q_INVOKABLE void            setColorSpec(int spec);
-//  Q_INVOKABLE void            setCursorFlashTime(int ms);
     Q_INVOKABLE void            setDesktopSettingsAware(bool on);
     Q_INVOKABLE void            setDoubleClickInterval(int ms);
     Q_INVOKABLE void            setEffectEnabled(Qt::UIEffect effect, bool enable = true);
     Q_INVOKABLE void            setFont(const QFont &font, const char *className = 0);
-//  Q_INVOKABLE void            setGlobalStrut(const QSize &size);
     Q_INVOKABLE void            setGraphicsSystem(const QString &system);
-//  Q_INVOKABLE void            setKeyboardInputInterval(int ms);
-//  Q_INVOKABLE void            setLayoutDirection(Qt::LayoutDirection direction);
-//  Q_INVOKABLE void            setNavigationMode(Qt::NavigationMode mode);
     Q_INVOKABLE void            setOverrideCursor(const QCursor &cursor);
     Q_INVOKABLE void            setPalette(const QPalette &palette, const char *className = 0);
     Q_INVOKABLE void            setQuitOnLastWindowClosed(bool quit);
-//  Q_INVOKABLE void            setStartDragDistance(int l);
-//  Q_INVOKABLE void            setStartDragTime(int ms);
     Q_INVOKABLE void            setStyle(QStyle *style);
     Q_INVOKABLE QStyle         *setStyle(const QString &style);
-//  Q_INVOKABLE void            setWheelScrollLines(int);
-//  Q_INVOKABLE void            setWindowIcon(const QIcon &icon);
-//  Q_INVOKABLE int             startDragDistance();
-//  Q_INVOKABLE int             startDragTime();
     Q_INVOKABLE QStyle         *style();
     Q_INVOKABLE void            syncX();
     Q_INVOKABLE QWidget        *topLevelAt(const QPoint &point);
     Q_INVOKABLE QWidget        *topLevelAt(int x, int y);
     Q_INVOKABLE QWidgetList     topLevelWidgets();
     Q_INVOKABLE QApplication::Type      type();
-//  Q_INVOKABLE int             wheelScrollLines();
     Q_INVOKABLE QWidget        *widgetAt(const QPoint &point);
     Q_INVOKABLE QWidget        *widgetAt(int x, int y);
-//  Q_INVOKABLE QIcon           windowIcon();
 
     Q_INVOKABLE QString        toString()          const;
 };

--- a/scriptapi/qapplicationproto.h
+++ b/scriptapi/qapplicationproto.h
@@ -12,15 +12,14 @@
 #define __QAPPLICATIONPROTO_H__
 
 #include <QApplication>
-#include <QDecoration>
+#include <QFont>
+#include <QFontMetrics>
 #include <QObject>
+#include <QPalette>
 #include <QSessionManager>
-#include <QWSEvent>
 #include <QtScript>
 
-class QInputContext;
 class QString;
-class QSymbianEvent;
 
 Q_DECLARE_METATYPE(QApplication*)
 
@@ -34,29 +33,10 @@ class QApplicationProto : public QObject, public QScriptable
   public:
     QApplicationProto(QObject *parent);
 
-    Q_INVOKABLE void            commitData(QSessionManager &manager);
-    Q_INVOKABLE QInputContext  *inputContext()                   const;
     Q_INVOKABLE bool            isSessionRestored()              const;
-#ifdef Q_WS_MAC
-    Q_INVOKABLE bool            macEventFilter(EventHandlerCallRef caller, EventRef event);
-#endif
     Q_INVOKABLE bool            notify(QObject *receiver, QEvent *e);
-#ifdef Q_WS_QWS
-    Q_INVOKABLE bool            qwsEventFilter(QWSEvent *event);
-    Q_INVOKABLE void            qwsSetCustomColors(QRgb *colorTable, int start, int numColors);
-#endif
-    Q_INVOKABLE void            saveState(QSessionManager &manager);
     Q_INVOKABLE QString         sessionId()         const;
     Q_INVOKABLE QString         sessionKey()        const;
-    Q_INVOKABLE void            setInputContext(QInputContext* inputContext);
-#ifdef Q_OS_SYMBIAN
-    Q_INVOKABLE bool            symbianEventFilter(const QSymbianEvent *event);
-    Q_INVOKABLE int             symbianProcessEvent(const QSymbianEvent *event);
-#endif
-#ifdef Q_WS_X11
-    Q_INVOKABLE bool            x11EventFilter(XEvent *event);
-    Q_INVOKABLE int             x11ProcessEvent(XEvent *event);
-#endif
 
     Q_INVOKABLE QWidget        *activeModalWidget();
     Q_INVOKABLE QWidget        *activePopupWidget();
@@ -78,8 +58,6 @@ class QApplicationProto : public QObject, public QScriptable
     Q_INVOKABLE bool            isEffectEnabled(Qt::UIEffect effect);
     Q_INVOKABLE bool            isLeftToRight();
     Q_INVOKABLE bool            isRightToLeft();
-    Q_INVOKABLE Qt::LayoutDirection     keyboardInputDirection();
-    Q_INVOKABLE QLocale         keyboardInputLocale();
     Q_INVOKABLE Qt::KeyboardModifiers   keyboardModifiers();
     Q_INVOKABLE Qt::MouseButtons        mouseButtons();
     Q_INVOKABLE QCursor        *overrideCursor();
@@ -87,11 +65,6 @@ class QApplicationProto : public QObject, public QScriptable
     Q_INVOKABLE QPalette        palette(const QWidget *widget);
     Q_INVOKABLE QPalette        palette(const char *className);
     Q_INVOKABLE Qt::KeyboardModifiers   queryKeyboardModifiers();
-#if defined(QT_WS_QWS) && !defined(Q_NO_QWS_MANAGER)
-    Q_INVOKABLE QDecoration    &qwsDecoration();
-    Q_INVOKABLE void            qwsSetDecoration(QDecoration *decoration);
-    Q_INVOKABLE QDecoration    *qwsSetDecoration(const QString &decoration);
-#endif
     Q_INVOKABLE void            restoreOverrideCursor();
     Q_INVOKABLE void            setActiveWindow(QWidget *active);
     Q_INVOKABLE void            setColorSpec(int spec);
@@ -99,18 +72,15 @@ class QApplicationProto : public QObject, public QScriptable
     Q_INVOKABLE void            setDoubleClickInterval(int ms);
     Q_INVOKABLE void            setEffectEnabled(Qt::UIEffect effect, bool enable = true);
     Q_INVOKABLE void            setFont(const QFont &font, const char *className = 0);
-    Q_INVOKABLE void            setGraphicsSystem(const QString &system);
     Q_INVOKABLE void            setOverrideCursor(const QCursor &cursor);
     Q_INVOKABLE void            setPalette(const QPalette &palette, const char *className = 0);
     Q_INVOKABLE void            setQuitOnLastWindowClosed(bool quit);
     Q_INVOKABLE void            setStyle(QStyle *style);
     Q_INVOKABLE QStyle         *setStyle(const QString &style);
     Q_INVOKABLE QStyle         *style();
-    Q_INVOKABLE void            syncX();
     Q_INVOKABLE QWidget        *topLevelAt(const QPoint &point);
     Q_INVOKABLE QWidget        *topLevelAt(int x, int y);
     Q_INVOKABLE QWidgetList     topLevelWidgets();
-    Q_INVOKABLE QApplication::Type      type();
     Q_INVOKABLE QWidget        *widgetAt(const QPoint &point);
     Q_INVOKABLE QWidget        *widgetAt(int x, int y);
 

--- a/scriptapi/scriptapi.pro
+++ b/scriptapi/scriptapi.pro
@@ -28,6 +28,7 @@ HEADERS += setupscriptapi.h \
     orreportproto.h \
     parameterlistsetup.h \
     qactionproto.h \
+    qapplicationproto.h \
     qboxlayoutproto.h \
     qbytearrayproto.h \
     qdialogbuttonboxproto.h \
@@ -128,6 +129,7 @@ SOURCES += setupscriptapi.cpp \
     orreportproto.cpp \
     parameterlistsetup.cpp \
     qactionproto.cpp \
+    qapplicationproto.cpp \
     qboxlayoutproto.cpp \
     qbytearrayproto.cpp \
     qdialogbuttonboxproto.cpp \

--- a/scriptapi/setupscriptapi.cpp
+++ b/scriptapi/setupscriptapi.cpp
@@ -32,6 +32,7 @@
 #include "parameterwidget.h"
 #include "projectlineeditsetup.h"
 #include "qactionproto.h"
+#include "qapplicationproto.h"
 #include "qboxlayoutproto.h"
 #include "qbytearrayproto.h"
 #include "qdialogsetup.h"
@@ -154,6 +155,7 @@ void setupScriptApi(QScriptEngine *engine)
   setupPeriodListViewItem(engine);
   setupProjectLineEdit(engine);
   setupQActionProto(engine);
+  setupQApplicationProto(engine);
   setupQBoxLayoutProto(engine);
   setupQByteArrayProto(engine);
   setupQDialog(engine);


### PR DESCRIPTION
This change is intended to aid in the current UI/UX push. It should now be possible to script something like
```JavaScript
QApplication.styleSheet = "QPushButton { background-color: red; }";
QApplication.styleSheet += "QComboBox { border-left-style: dotted; border-right-style: dotted; }";
```
and other such silliness.