### PR TITLE
Issue #24953: Display correct Vendor Address in Vendor Search widget

### DIFF
--- a/widgets/crmacctCluster.cpp
+++ b/widgets/crmacctCluster.cpp
@@ -62,7 +62,7 @@ static QString _listAndSearchQueryString(
       "<? elseif exists('vendor') ?>"
       "    SELECT vend_id AS id,         vend_number AS number,"
       "           vend_name AS name,     vend_cntct1_id AS cntct_id,"
-      "           vend_active AS active, cntct_addr_id AS addr_id,"
+      "           vend_active AS active, COALESCE(cntct_addr_id, vend_addr_id) AS addr_id,"
       "           vendtype_code AS type"
       "      FROM vendinfo"
       "      JOIN vendtype ON (vend_vendtype_id=vendtype_id)"


### PR DESCRIPTION
Previous fix addressed the Vendor List screen.  This resolves the issue in the Vendor Search (crmacct) Widget and List.