### PR TITLE
Issue #6664: Allow user selection of AR/AP Aging summary vs detailed rpt

### DIFF
--- a/guiclient/displays/dspTimePhasedOpenAPItems.cpp
+++ b/guiclient/displays/dspTimePhasedOpenAPItems.cpp
@@ -32,6 +32,8 @@ dspTimePhasedOpenAPItems::dspTimePhasedOpenAPItems(QWidget* parent, const char*,
   setReportName("APAging");
 
   connect(_custom, SIGNAL(toggled(bool)), this, SLOT(sToggleCustom()));
+  connect(_detailedReport, SIGNAL(clicked()), this, SLOT(sToggleReport()));
+  connect(_summaryReport, SIGNAL(clicked()), this, SLOT(sToggleReport()));
 
   _asOf->setDate(omfgThis->dbDate(), true);
   sToggleCustom();
@@ -248,6 +250,7 @@ void dspTimePhasedOpenAPItems::sToggleCustom()
     _asOf->setDate(omfgThis->dbDate(), true);
     _asOf->setEnabled(FALSE);
     _useGroup->setHidden(TRUE);
+    _reptGroup->setHidden(TRUE);
 
     list()->setColumnCount(0);
     list()->addColumn(tr("Vend. #"), _orderColumn, Qt::AlignLeft, true, "vend_number");
@@ -255,12 +258,13 @@ void dspTimePhasedOpenAPItems::sToggleCustom()
   }
   else
   {
-    setReportName("APAging");
+    sToggleReport();
     _calendarLit->setHidden(TRUE);
     _calendar->setHidden(TRUE);
     _periods->setHidden(TRUE);
     _asOf->setEnabled(TRUE);
     _useGroup->setHidden(FALSE);
+    _reptGroup->setHidden(FALSE);
 
     list()->addColumn(tr("Total Open"), _bigMoneyColumn, Qt::AlignRight, true, "total_val");
     list()->addColumn(tr("0+ Days"),    _bigMoneyColumn, Qt::AlignRight, true, "cur_val");
@@ -278,4 +282,12 @@ void dspTimePhasedOpenAPItems::sToggleCustom()
     list()->addColumn(tr("61-90 Days"), _bigMoneyColumn, Qt::AlignRight, true, "apaging_ninety_val_sum");
     list()->addColumn(tr("90+ Days"),   _bigMoneyColumn, Qt::AlignRight, true, "apaging_plus_val_sum");
   }
+}
+
+void dspTimePhasedOpenAPItems::sToggleReport()
+{
+  if (_detailedReport->isChecked())
+    setReportName("APAging");
+  else
+    setReportName("APAgingSummary");
 }

--- a/guiclient/displays/dspTimePhasedOpenAPItems.h
+++ b/guiclient/displays/dspTimePhasedOpenAPItems.h
@@ -31,6 +31,7 @@ public slots:
     virtual void sFillStd();
     virtual void sFillCustom();
     virtual void sToggleCustom();
+    virtual void sToggleReport();
 
 protected slots:
     virtual bool setParams(ParameterList &);

--- a/guiclient/displays/dspTimePhasedOpenAPItems.ui
+++ b/guiclient/displays/dspTimePhasedOpenAPItems.ui
@@ -108,6 +108,57 @@ to be bound by its terms.</comment>
      </layout>
     </widget>
    </item>
+   <item row="2" column="1">
+    <widget class="QGroupBox" name="_reptGroup">
+     <property name="title">
+      <string>Report</string>
+     </property>
+     <layout class="QHBoxLayout">
+      <property name="leftMargin">
+       <number>3</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>3</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QRadioButton" name="_detailedReport">
+        <property name="text">
+         <string>Detailed Report</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="_summaryReport">
+        <property name="text">
+         <string>Summary Report</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>28</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="3" column="0">
     <layout class="QHBoxLayout">
      <property name="spacing">

--- a/guiclient/displays/dspTimePhasedOpenARItems.cpp
+++ b/guiclient/displays/dspTimePhasedOpenARItems.cpp
@@ -32,6 +32,8 @@ dspTimePhasedOpenARItems::dspTimePhasedOpenARItems(QWidget* parent, const char*,
   setReportName("ARAging");
 
   connect(_custom, SIGNAL(toggled(bool)), this, SLOT(sToggleCustom()));
+  connect(_detailedReport, SIGNAL(clicked()), this, SLOT(sToggleReport()));
+  connect(_summaryReport, SIGNAL(clicked()), this, SLOT(sToggleReport()));
   
   list()->addColumn(tr("Cust. #"),  _orderColumn, Qt::AlignLeft, true, "araging_cust_number" );
   list()->addColumn(tr("Customer"), -1,          Qt::AlignLeft, true, "araging_cust_name" );
@@ -265,6 +267,7 @@ void dspTimePhasedOpenARItems::sToggleCustom()
     _asOf->setDate(omfgThis->dbDate(), true);
     _asOf->setEnabled(FALSE);
     _useGroup->setHidden(TRUE);
+    _reptGroup->setHidden(TRUE);
 
     list()->setColumnCount(0);
     list()->addColumn(tr("Cust. #"), _orderColumn, Qt::AlignLeft, true, "cust_number");
@@ -272,12 +275,13 @@ void dspTimePhasedOpenARItems::sToggleCustom()
   }
   else
   {
-    setReportName("ARAging");
+    sToggleReport();
     _calendarLit->setHidden(TRUE);
     _calendar->setHidden(TRUE);
     _periods->setHidden(TRUE);
     _asOf->setEnabled(TRUE);
     _useGroup->setHidden(FALSE);
+    _reptGroup->setHidden(FALSE);
 
     list()->setColumnCount(0);
     list()->addColumn(tr("Cust. #"),       _orderColumn, Qt::AlignLeft,  true, "araging_cust_number");
@@ -289,4 +293,12 @@ void dspTimePhasedOpenARItems::sToggleCustom()
     list()->addColumn(tr("61-90 Days"), _bigMoneyColumn, Qt::AlignRight, true, "araging_ninety_val_sum");
     list()->addColumn(tr("90+ Days"),   _bigMoneyColumn, Qt::AlignRight, true, "araging_plus_val_sum");
   }
+}
+
+void dspTimePhasedOpenARItems::sToggleReport()
+{
+  if (_detailedReport->isChecked())
+    setReportName("ARAging");
+  else
+    setReportName("ARAgingSummary");
 }

--- a/guiclient/displays/dspTimePhasedOpenARItems.h
+++ b/guiclient/displays/dspTimePhasedOpenARItems.h
@@ -35,6 +35,7 @@ public slots:
     virtual void sFillStd();
     virtual void sFillCustom();
     virtual void sToggleCustom();
+    virtual void sToggleReport();
 
 private:
     int _column;

--- a/guiclient/displays/dspTimePhasedOpenARItems.ui
+++ b/guiclient/displays/dspTimePhasedOpenARItems.ui
@@ -117,6 +117,57 @@ to be bound by its terms.</comment>
      </layout>
     </widget>
    </item>
+   <item row="2" column="1">
+    <widget class="QGroupBox" name="_reptGroup">
+     <property name="title">
+      <string>Report</string>
+     </property>
+     <layout class="QHBoxLayout">
+      <property name="leftMargin">
+       <number>3</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>3</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QRadioButton" name="_detailedReport">
+        <property name="text">
+         <string>Detailed Report</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="_summaryReport">
+        <property name="text">
+         <string>Summary Report</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>28</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="3" column="0">
     <layout class="QHBoxLayout">
      <property name="spacing">


### PR DESCRIPTION
New AP and AR Aging summary reports. User selectable

Requires xtuple/xtuple#2256