### PR TITLE
Issue #25509: Add privilege descriptions to screens 

### DIFF
--- a/guiclient/group.cpp
+++ b/guiclient/group.cpp
@@ -39,8 +39,9 @@ group::group(QWidget* parent, const char* name, bool modal, Qt::WFlags fl)
   connect(_available, SIGNAL(itemSelected(int)), this, SLOT(sAdd()));
 
 
-  _available->addColumn("Available Privileges", -1, Qt::AlignLeft, true, "priv_name");
-  _granted->addColumn("Granted Privileges", -1, Qt::AlignLeft, true, "priv_name");
+  _available->addColumn(tr("Available Privileges"), -1, Qt::AlignLeft, true, "priv_name");
+  _available->addColumn(tr("Description"), -1, Qt::AlignLeft, true, "priv_descrip");
+  _granted->addColumn(tr("Granted Privileges"), -1, Qt::AlignLeft, true, "priv_name");
 
   groupgroup.exec( "SELECT DISTINCT priv_module "
           "FROM priv "
@@ -234,7 +235,7 @@ void group::sSave()
 void group::sModuleSelected(const QString &pModule)
 {
   XSqlQuery avail;
-  avail.prepare( "SELECT priv_id, priv_name "
+  avail.prepare( "SELECT priv_id, priv_name, priv_descrip "
                  "FROM priv "
                  "WHERE ((priv_module=:priv_module) "
                  "   AND (priv_id NOT IN (SELECT grppriv_priv_id"

--- a/guiclient/user.cpp
+++ b/guiclient/user.cpp
@@ -55,6 +55,7 @@ user::user(QWidget* parent, const char * name, Qt::WindowFlags fl)
   connect(_revokeSite, SIGNAL(clicked()), this, SLOT(sRevokeSite()));
 
   _available->addColumn("Available Privileges", -1, Qt::AlignLeft);
+  _available->addColumn("Description", -1, Qt::AlignLeft);
   _granted->addColumn("Granted Privileges", -1, Qt::AlignLeft);
 
   _availableGroup->addColumn("Available Roles", -1, Qt::AlignLeft);
@@ -371,7 +372,7 @@ void user::sModuleSelected(const QString &pModule)
   _granted->clear();
 
   XSqlQuery privs;
-  privs.prepare( "SELECT priv_id, priv_name "
+  privs.prepare( "SELECT priv_id, priv_name, priv_descrip "
                  "FROM priv "
                  "WHERE (priv_module=:priv_module) "
                  "ORDER BY priv_name;" );
@@ -407,7 +408,7 @@ void user::sModuleSelected(const QString &pModule)
     do
     {
       if (usrpriv.findFirst("priv_id", privs.value("priv_id").toInt()) == -1 && grppriv.findFirst("priv_id", privs.value("priv_id").toInt()) == -1)
-        available = new XTreeWidgetItem(_available, available, privs.value("priv_id").toInt(), privs.value("priv_name"));
+        available = new XTreeWidgetItem(_available, available, privs.value("priv_id").toInt(), privs.value("priv_name"), privs.value("priv_descrip"));
       else
       {
         granted = new XTreeWidgetItem(_granted, granted, privs.value("priv_id").toInt(), privs.value("priv_name"));


### PR DESCRIPTION
Privilege descriptions get loaded and saved but are not displayed anywhere.  Add to Roles and User screens to give users more information about the permissions they are assigning.