### PR TITLE
Issue #25600: Resolve various Lot/Serial and Transfer order issues

### DIFF
--- a/guiclient/createLotSerial.h
+++ b/guiclient/createLotSerial.h
@@ -28,6 +28,7 @@ public:
 
 public slots:
     virtual enum SetResponse set(const ParameterList & pParams );
+    virtual void clearCharacteristics();
     virtual void sAssign();
     virtual void sHandleLotSerial();
     virtual void sHandleCharacteristics();

--- a/guiclient/displays/dspDetailedInventoryHistoryByLotSerial.cpp
+++ b/guiclient/displays/dspDetailedInventoryHistoryByLotSerial.cpp
@@ -71,6 +71,8 @@ dspDetailedInventoryHistoryByLotSerial::dspDetailedInventoryHistoryByLotSerial(Q
   list()->addColumn(tr("Item Number"),  _itemColumn,         Qt::AlignLeft,   true,  "lshist_item_number"   );
   list()->addColumn(tr("Location"),     _dateColumn,         Qt::AlignLeft,   true,  "lshist_locationname"   );
   list()->addColumn(tr("Lot/Serial #"), -1,                  Qt::AlignLeft,   true,  "lshist_lotserial"   );
+  list()->addColumn(tr("Perishable"), -1,                    Qt::AlignLeft,   true,  "lshist_perishable"   );
+  list()->addColumn(tr("Expiration"),   _dateColumn,         Qt::AlignLeft,   true,  "lshist_expiration"   );
   list()->addColumn(tr("UOM"),          _uomColumn,          Qt::AlignCenter, true,  "lshist_invuom" );
   list()->addColumn(tr("Trans-Qty"),    _qtyColumn,          Qt::AlignRight,  true,  "lshist_transqty"  );
   list()->addColumn(tr("Qty. Before"),  _qtyColumn,          Qt::AlignRight,  true,  "lshist_qty_before"  );

--- a/guiclient/issueLineToShipping.cpp
+++ b/guiclient/issueLineToShipping.cpp
@@ -323,9 +323,11 @@ void issueLineToShipping::sIssue()
         XSqlQuery lsdetail;
         lsdetail.prepare("INSERT INTO lsdetail "
 	                     "            (lsdetail_itemsite_id, lsdetail_created, lsdetail_source_type, "
-	  	  			     "             lsdetail_source_id, lsdetail_source_number, lsdetail_ls_id, lsdetail_qtytoassign) "
+	  	  			     "             lsdetail_source_id, lsdetail_source_number, lsdetail_ls_id, lsdetail_qtytoassign, "
+                                             "             lsdetail_expiration, lsdetail_warrpurc ) "
 					     "SELECT invhist_itemsite_id, NOW(), 'TR', "
-					     "       :orderitemid, invhist_ordnumber, invdetail_ls_id, (invdetail_qty * -1.0) "
+					     "       :orderitemid, invhist_ordnumber, invdetail_ls_id, (invdetail_qty * -1.0), "
+                                             "       invdetail_expiration, invdetail_warrpurc "
 					     "FROM invhist JOIN invdetail ON (invdetail_invhist_id=invhist_id) "
 					     "WHERE (invhist_series=:itemlocseries);");
         lsdetail.bindValue(":orderitemid", _itemid);

--- a/guiclient/issueToShipping.cpp
+++ b/guiclient/issueToShipping.cpp
@@ -539,9 +539,11 @@ bool issueToShipping::sIssueLineBalance(int id, int altId)
       XSqlQuery lsdetail;
       lsdetail.prepare("INSERT INTO lsdetail "
 	                   "            (lsdetail_itemsite_id, lsdetail_created, lsdetail_source_type, "
-	  				   "             lsdetail_source_id, lsdetail_source_number, lsdetail_ls_id, lsdetail_qtytoassign) "
+	  				   "             lsdetail_source_id, lsdetail_source_number, lsdetail_ls_id, lsdetail_qtytoassign, "
+                                           "             lsdetail_expiration, lsdetail_warrpurc ) "
 					   "SELECT invhist_itemsite_id, NOW(), 'TR', "
-					   "       :orderitemid, invhist_ordnumber, invdetail_ls_id, (invdetail_qty * -1.0) "
+					   "       :orderitemid, invhist_ordnumber, invdetail_ls_id, (invdetail_qty * -1.0), "
+                                           "       invdetail_expiration, invdetail_warrpurc "
 					   "FROM invhist JOIN invdetail ON (invdetail_invhist_id=invhist_id) "
 					   "WHERE (invhist_series=:itemlocseries);");
       lsdetail.bindValue(":orderitemid", id);

--- a/guiclient/lotSerialUtils.cpp
+++ b/guiclient/lotSerialUtils.cpp
@@ -198,7 +198,7 @@ void _addCharsToItem(QTreeWidgetItem *item, int column, int numInitialColumns)
     }
     XSqlQuery q;
     bool success = q.exec(QString("SELECT charass.charass_value FROM charass LEFT JOIN ls on "
-                " charass.charass_target_id=ls.ls_id WHERE ls.ls_number='%1'"
+                " charass.charass_target_id=ls.ls_id WHERE charass.charass_target_type = 'LS' AND ls.ls_number='%1'"
                 " ORDER BY charass.charass_id ASC").arg(item->text(column)));
     if (!success)
     {


### PR DESCRIPTION
Modify Inventory History report to display Lot/Serial Expiration on screen and report.

Also resolves issue where expiration and warranty dates were lost from the system when item quantity fully shipped on Transfer Orders.
Fixes incorrect display of Lot characteristics after Lot creation
Handles duplicated lsdetail entries when TO is issued to shipment then returned

Requires schema change on xtuple/private-extensions#582

Covers Issues #24240, #25600, #24443