### PR TITLE
Issue #25612: Add Sale Type default checkbox to set up to fix SO bug

### DIFF
--- a/guiclient/saleType.cpp
+++ b/guiclient/saleType.cpp
@@ -28,6 +28,7 @@ saleType::saleType(QWidget* parent, const char* name, bool modal, Qt::WFlags fl)
   connect(_buttonBox, SIGNAL(accepted()), this, SLOT(sSave()));
   connect(_buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
   connect(_code, SIGNAL(editingFinished()), this, SLOT(sCheck()));
+  connect(_default, SIGNAL(clicked()), this, SLOT(sDefaultChecked()));
 }
 
 saleType::~saleType()
@@ -69,6 +70,7 @@ enum SetResponse saleType::set(const ParameterList &pParams)
       _mode = cView;
       _code->setEnabled(false);
       _active->setEnabled(false);
+      _default->setEnabled(false);
       _description->setEnabled(false);
       _buttonBox->clear();
       _buttonBox->addButton(QDialogButtonBox::Close);
@@ -103,6 +105,7 @@ void saleType::sSave()
   params.append("saletype_code", _code->text());
   params.append("saletype_descr", _description->text());
   params.append("saletype_active", QVariant(_active->isChecked()));
+  params.append("saletype_default", QVariant(_default->isChecked()));
   saleTypeSave = mql.toQuery(params);
   if (saleTypeSave.first() && _mode == cNew)
     _saletypeid = saleTypeSave.value("saletype_id").toInt();
@@ -144,6 +147,18 @@ void saleType::populate()
     _code->setText(saleTypePopulate.value("saletype_code"));
     _description->setText(saleTypePopulate.value("saletype_descr"));
     _active->setChecked(saleTypePopulate.value("saletype_active").toBool());
+    _default->setChecked(saleTypePopulate.value("saletype_default").toBool());
   }
+}
+
+void saleType::sDefaultChecked()
+{
+  XSqlQuery setDefault;
+  setDefault.prepare("UPDATE saletype SET saletype_default = FALSE WHERE saletype_id <> :saletype_id;");
+  setDefault.bindValue(":saletype_id", _saletypeid);
+  setDefault.exec();
+  if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Updating Defaults"),
+                              setDefault, __FILE__, __LINE__))
+    return;
 }
 

--- a/guiclient/saleType.h
+++ b/guiclient/saleType.h
@@ -33,6 +33,7 @@ protected slots:
 
     virtual void sSave();
     virtual void sCheck();
+    virtual void sDefaultChecked();
 
 
 private:

--- a/guiclient/saleType.ui
+++ b/guiclient/saleType.ui
@@ -106,7 +106,7 @@ to be bound by its terms.</comment>
               <string>Default</string>
              </property>
              <property name="checked">
-              <bool>true</bool>
+              <bool>false</bool>
              </property>
             </widget>
            </item>

--- a/guiclient/saleType.ui
+++ b/guiclient/saleType.ui
@@ -101,6 +101,16 @@ to be bound by its terms.</comment>
             </widget>
            </item>
            <item>
+            <widget class="QCheckBox" name="_default">
+             <property name="text">
+              <string>Default</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
             <spacer name="Spacer29">
              <property name="orientation">
               <enum>Qt::Horizontal</enum>

--- a/guiclient/saleTypes.cpp
+++ b/guiclient/saleTypes.cpp
@@ -38,6 +38,7 @@ saleTypes::saleTypes(QWidget* parent, const char* name, Qt::WFlags fl)
 
   _saletype->addColumn(tr("Code"),       _itemColumn, Qt::AlignLeft,   true,  "saletype_code" );
   _saletype->addColumn(tr("Active"),     _ynColumn,   Qt::AlignCenter, true,  "saletype_active" );
+  _saletype->addColumn(tr("Default"),    _ynColumn,   Qt::AlignCenter, true,  "saletype_default" );
   _saletype->addColumn(tr("Description"), -1,         Qt::AlignLeft,   true,  "saletype_descr" );
 
   if (_privileges->check("MaintainSaleTypes"))

--- a/widgets/xcombobox.cpp
+++ b/widgets/xcombobox.cpp
@@ -548,7 +548,7 @@ void XComboBox::setType(XComboBoxTypes pType)
     case SaleTypes:
       query.exec( "SELECT saletype_id, (saletype_code || '-' || saletype_descr), saletype_code "
                   "FROM saletype "
-                  "ORDER BY saletype_code;" );
+                  "ORDER BY saletype_default DESC, saletype_code;" );
       break;
 
     case ShippingCharges:


### PR DESCRIPTION
SO defaulted to first alphabetically listed Sale Type when not manually set. The default could change if Sale Types were updated.  This change allows a default Sale Type to be set and used in SO automatically.

Requires by xtuple/xtuple#2262