### PR TITLE
reorder login metrics fetch

### DIFF
--- a/common/metrics.cpp
+++ b/common/metrics.cpp
@@ -33,6 +33,11 @@ void Parameters::load()
   q.exec();
   while (q.next())
     _values[q.value("key").toString()] = q.value("value").toString();
+  if (q.lastError().type() != QSqlError::NoError) {
+    QMessageBox::critical(0, tr("Error loading %1").arg(metaObject()->className()),
+                         q.lastError().text());
+    return;
+  }
 
   _dirty = FALSE;
 


### PR DESCRIPTION
This PR reduces the number of database queries run during login. I made the changes trying to track down a database error that occurred when loading the metrics, hence https://github.com/xtuple/qt-client/commit/4c342032a6a29320d4e3a9781a99ed58494b2425 Restarting Postgres fixed the problem (something about SSL header length) but the code changes still seem worthwhile.