### PR TITLE
Issue #25187: Allow user to turn off immediate Order Header refresh

### DIFF
--- a/guiclient/salesOrderItem.cpp
+++ b/guiclient/salesOrderItem.cpp
@@ -1453,7 +1453,7 @@ void salesOrderItem::sSave(bool pPartial)
 
   salesSave.exec("COMMIT;");
 
-  if (!pPartial)
+  if (!pPartial && _orderRefresh->isChecked())
   {
     if (_mode == cNew)
       omfgThis->sSalesOrdersUpdated(_soheadid);
@@ -4361,6 +4361,11 @@ void salesOrderItem::reject()
       return;
     }
   }
+
+  if (_mode == cNew)
+    omfgThis->sSalesOrdersUpdated(_soheadid);
+  else if (_mode == cNewQuote)
+    omfgThis->sQuotesUpdated(_soheadid);
 
   XDialog::reject();
 }

--- a/guiclient/salesOrderItem.ui
+++ b/guiclient/salesOrderItem.ui
@@ -2,7 +2,7 @@
 <ui version="4.0">
  <comment>This file is part of the xTuple ERP: PostBooks Edition, a free and
 open source Enterprise Resource Planning software suite,
-Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
 It is licensed to you under the Common Public Attribution License
 version 1.0, the full text of which (including xTuple-specific Exhibits)
 is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -149,6 +149,19 @@ to be bound by its terms.</comment>
           </size>
          </property>
         </spacer>
+       </item>
+       <item>
+        <widget class="XCheckBox" name="_orderRefresh">
+         <property name="toolTip">
+          <string>Refresh the Order Items list immediately on save</string>
+         </property>
+         <property name="text">
+          <string>Refresh Order</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
       </layout>
      </item>


### PR DESCRIPTION
Add checkbox to SO Item screen.  If checked refresh SO Header on save (status quo).  If unchecked, refresh once when exiting the SO Item screen.

Requested to assist SO performance on large orders.