### PR TITLE
issue #25676 - make applock optionally interactive

### DIFF
--- a/common/applock.h
+++ b/common/applock.h
@@ -25,12 +25,14 @@ class AppLock : public QObject
   Q_OBJECT
 
   public:
+    enum AcquireMode { Silent, Interactive };
+
     AppLock(QObject *parent = 0);
     AppLock(QString table, int id, QObject *parent = 0);
     ~AppLock();
 
-    Q_INVOKABLE bool    acquire();
-    Q_INVOKABLE bool    acquire(QString table, int id);
+    Q_INVOKABLE bool    acquire(AcquireMode mode = Silent);
+    Q_INVOKABLE bool    acquire(QString table, int id, AcquireMode mode = Silent);
     Q_INVOKABLE bool    holdsLock()   const;
     Q_INVOKABLE bool    isLockedOut() const;
     Q_INVOKABLE QString lastError()   const;
@@ -42,6 +44,7 @@ class AppLock : public QObject
 };
 
 Q_DECLARE_METATYPE(AppLock *)
+Q_DECLARE_METATYPE(enum AppLock::AcquireMode)
 
 void setupAppLockProto(QScriptEngine *engine);
 QScriptValue constructAppLock(QScriptContext *context, QScriptEngine *engine);
@@ -52,8 +55,8 @@ class AppLockProto : public QObject, public QScriptable
   public:
     AppLockProto(QObject *parent);
 
-    Q_INVOKABLE bool    acquire();
-    Q_INVOKABLE bool    acquire(QString table, int id);
+    Q_INVOKABLE bool    acquire(AppLock::AcquireMode mode);
+    Q_INVOKABLE bool    acquire(QString table, int id, AppLock::AcquireMode mode);
     Q_INVOKABLE bool    holdsLock()   const;
     Q_INVOKABLE bool    isLockedOut() const;
     Q_INVOKABLE QString lastError()   const;

--- a/guiclient/purchaseOrder.cpp
+++ b/guiclient/purchaseOrder.cpp
@@ -647,31 +647,16 @@ void purchaseOrder::createHeader()
   // Populate Ship To contact and addresses for the Receiving Site
   sHandleShipTo();
 
-  if (! _lock.acquire("pohead", _poheadid)
-      && ErrorReporter::error(QtCriticalMsg, this, tr("Locking Error"),
-                              _lock.lastError(), __FILE__, __LINE__))
-  {
-    return;
-  }
+  (void)_lock.acquire("pohead", _poheadid, AppLock::Interactive);
 }
 
 void purchaseOrder::populate()
 {
   XSqlQuery po;
 
-  if (_mode == cEdit && ! _lock.acquire("pohead", _poheadid))
+  if (_mode == cEdit && ! _lock.acquire("pohead", _poheadid, AppLock::Interactive))
   {
-    if (_lock.isLockedOut())
-    {
-      QMessageBox::critical(this, tr("Record Currently Being Edited"),
-                            tr("<p>The record you are trying to edit is "
-                               "currently being edited by another user. "
-                               "Continue in View Mode."));
-      setViewMode();
-    }
-    else if (ErrorReporter::error(QtCriticalMsg, this, tr("Locking Error"),
-                                  _lock.lastError(), __FILE__, __LINE__))
-      setViewMode();
+    setViewMode();
   }
   
   po.prepare( "SELECT pohead.*, COALESCE(pohead_warehous_id, -1) AS warehous_id,"

--- a/guiclient/salesOrder.cpp
+++ b/guiclient/salesOrder.cpp
@@ -1257,10 +1257,9 @@ bool salesOrder::save(bool partial)
 
   // TODO: should this be done before saveSales.exec()?
   if ((cNew == _mode) && (!_saved)
-      && ! _lock.acquire(ISORDER(_mode) ? "cohead" : "quhead", _soheadid))
+      && ! _lock.acquire(ISORDER(_mode) ? "cohead" : "quhead", _soheadid,
+                         AppLock::Interactive))
   {
-    ErrorReporter::error(QtCriticalMsg, this, tr("Locking Error"),
-                         _lock.lastError(), __FILE__, __LINE__);
     return false;
   }
 
@@ -2388,21 +2387,10 @@ void salesOrder::populate()
   {
     XSqlQuery so;
     if (_mode == cEdit
-        && !_lock.acquire(ISORDER(_mode) ? "cohead" : "quhead", _soheadid))
+        && !_lock.acquire(ISORDER(_mode) ? "cohead" : "quhead", _soheadid,
+                          AppLock::Interactive))
     {
-      if (_lock.isLockedOut())
-      {
-        QMessageBox::critical(this, tr("Record Currently Being Edited"),
-                              tr("<p>The record you are trying to edit is "
-                                 "currently being edited by another user. "
-                                 "Continue in View Mode.") );
-        setViewMode();
-      }
-      else if (ErrorReporter::error(QtCriticalMsg, this, tr("Locking Error"),
-                                    _lock.lastError(), __FILE__, __LINE__))
-      {
-        setViewMode();
-      }
+      setViewMode();
     }
     so.prepare( "SELECT cohead.*,"
                 "       COALESCE(cohead_shipto_id,-1) AS cohead_shipto_id,"

--- a/guiclient/transferOrder.cpp
+++ b/guiclient/transferOrder.cpp
@@ -131,21 +131,9 @@ void transferOrder::setToheadid(const int pId)
   _documents->setId(_toheadid);
        
   if (_mode == cEdit
-      && ! _lock.acquire("tohead", _toheadid))
+      && ! _lock.acquire("tohead", _toheadid, AppLock::Interactive))
   {
-    if (_lock.isLockedOut())
-    {
-      QMessageBox::critical(this, tr("Record Currently Being Edited"),
-                            tr("<p>The record you are trying to edit is "
-                               "currently being edited by another user. "
-                               "Continue in View Mode."));
-      setViewMode();
-    }
-    else if (ErrorReporter::error(QtCriticalMsg, this, tr("Locking Error"),
-                                  _lock.lastError(), __FILE__, __LINE__))
-    {
-      setViewMode();
-    }
+    setViewMode();
   }
 }
 
@@ -671,7 +659,7 @@ bool transferOrder::save(bool partial)
 
   // TODO: should this be done before saving the t/o?
   if ((cNew == _mode) && (!_saved)
-      && ! _lock.acquire("tohead", _toheadid))
+      && ! _lock.acquire("tohead", _toheadid, AppLock::Silent))
   {
     rollback.exec();
     (void)ErrorReporter::error(QtCriticalMsg, this, tr("Locking Error"),


### PR DESCRIPTION
issue #25676 - extend the API for AppLock so it can either report its own errors or let the caller do it, then change existing callers to use the revised version