### PR TITLE
Issue #24663: Prevent addition of jobcosted items to BOMs

### DIFF
--- a/guiclient/bomItem.cpp
+++ b/guiclient/bomItem.cpp
@@ -623,7 +623,7 @@ void bomItem::sItemIdChanged()
   }
   else if (qry.lastError().type() != QSqlError::NoError)
       ErrorReporter::error(QtCriticalMsg, this, tr("Item Job cost check"),
-                           _item->id(), __FILE__, __LINE__);
+                           qry, __FILE__, __LINE__);
 
   MetaSQLQuery muom = mqlLoad("uoms", "item");
 

--- a/guiclient/bomItem.cpp
+++ b/guiclient/bomItem.cpp
@@ -611,18 +611,19 @@ void bomItem::sItemIdChanged()
 {
 // Prevent job costed items from being added to the BOM
   XSqlQuery qry;
-  qry.prepare("SELECT EXISTS(SELECT * FROM itemsite WHERE itemsite_item_id = :item_id AND itemsite_costmethod = 'J')");
+  qry.prepare("SELECT EXISTS(SELECT 1 FROM itemsite WHERE itemsite_item_id = :item_id AND itemsite_costmethod = 'J')");
   qry.bindValue(":item_id", _item->id());
   qry.exec();
-  if (qry.first() && qry.value("exists") == TRUE)
+  if (qry.first() && qry.value("exists").toBool())
   {
     QMessageBox::question(this, tr("Job Costed Item"),
-                            tr("You may cannot add a Job Costed item to a Bill of Material"));
+                            tr("You cannot add a Job Costed item to a Bill of Material"));
     _item->setId(-1);
     return;
   }
   else if (qry.lastError().type() != QSqlError::NoError)
-    systemError(this, qry.lastError().databaseText(), __FILE__, __LINE__);
+      ErrorReporter::error(QtCriticalMsg, this, tr("Item Job cost check"),
+                           _item->id(), __FILE__, __LINE__);
 
   MetaSQLQuery muom = mqlLoad("uoms", "item");
 

--- a/guiclient/bomItem.cpp
+++ b/guiclient/bomItem.cpp
@@ -609,6 +609,21 @@ void bomItem::sFillSubstituteList()
 
 void bomItem::sItemIdChanged()
 {
+// Prevent job costed items from being added to the BOM
+  XSqlQuery qry;
+  qry.prepare("SELECT EXISTS(SELECT * FROM itemsite WHERE itemsite_item_id = :item_id AND itemsite_costmethod = 'J')");
+  qry.bindValue(":item_id", _item->id());
+  qry.exec();
+  if (qry.first() && qry.value("exists") == TRUE)
+  {
+    QMessageBox::question(this, tr("Job Costed Item"),
+                            tr("You may cannot add a Job Costed item to a Bill of Material"));
+    _item->setId(-1);
+    return;
+  }
+  else if (qry.lastError().type() != QSqlError::NoError)
+    systemError(this, qry.lastError().databaseText(), __FILE__, __LINE__);
+
   MetaSQLQuery muom = mqlLoad("uoms", "item");
 
   ParameterList params;


### PR DESCRIPTION
Add check to BOM item addition to prevent if the item is job costed.  Apparently causes all sorts of costing issues and orphaned elements.