### PR TITLE
Issue #25665: Fix WO Material Return for Lot Items with different qtys

### DIFF
--- a/guiclient/createLotSerial.cpp
+++ b/guiclient/createLotSerial.cpp
@@ -340,14 +340,17 @@ void createLotSerial::sAssign()
   
   if (_preassigned)
   {
-    createAssign.prepare("SELECT lsdetail_qtytoassign "
-              "FROM lsdetail "
-              "WHERE (lsdetail_id=:lsdetail_id);");
+    createAssign.prepare("SELECT SUM(lsd.lsdetail_qtytoassign) AS qtytoassign "
+              "FROM lsdetail lsd "
+              "JOIN lsdetail lsd2 "
+              "  ON (lsd.lsdetail_source_id=lsd2.lsdetail_source_id "
+              "    AND lsd.lsdetail_ls_id = lsd2.lsdetail_ls_id) "
+              " WHERE (lsd2.lsdetail_id=:lsdetail_id);");
     createAssign.bindValue(":lsdetail_id", _lotSerial->id());
     createAssign.exec();
     if (createAssign.first())
     {
-      if ( _qtyToAssign->toDouble() > createAssign.value("lsdetail_qtytoassign").toDouble() )
+      if ( _qtyToAssign->toDouble() > createAssign.value("qtytoassign").toDouble() )
       {
         QMessageBox::critical( this, tr("Invalid Qty"),
                                tr( "<p>The quantity being assigned is greater than the "

--- a/guiclient/createLotSerial.cpp
+++ b/guiclient/createLotSerial.cpp
@@ -344,7 +344,9 @@ void createLotSerial::sAssign()
               "FROM lsdetail lsd "
               "JOIN lsdetail lsd2 "
               "  ON (lsd.lsdetail_source_id=lsd2.lsdetail_source_id "
-              "    AND lsd.lsdetail_ls_id = lsd2.lsdetail_ls_id) "
+              "    AND lsd.lsdetail_ls_id = lsd2.lsdetail_ls_id "
+              "    AND lsd.lsdetail_source_type = lsd2.lsdetail_source_type "
+              "    AND lsd.lsdetail_source_number = lsd2.lsdetail_source_number) "
               " WHERE (lsd2.lsdetail_id=:lsdetail_id);");
     createAssign.bindValue(":lsdetail_id", _lotSerial->id());
     createAssign.exec();


### PR DESCRIPTION
When returning Lot Qty greater than issued Qty an error occurred (when the lot was issued multiple times).  This fix sums the qty issued to check the correct value.  