### PR TITLE
Issue #25728: prevent missing uom conversion type when cancelling screen

### DIFF
--- a/guiclient/itemUOM.cpp
+++ b/guiclient/itemUOM.cpp
@@ -364,5 +364,12 @@ void itemUOM::reject()
     itemreject.exec();
   }
 
+  if(cEdit == _mode && _selected->count() == 0)
+  {
+    QMessageBox::warning(this, tr("No Types Selected"),
+      tr("<p>You must select at least one UOM Type for this conversion."));
+    return;
+  }
+
   XDialog::reject();
 }


### PR DESCRIPTION
Stop user from cancelling if they have removed conversion type.

There are quite a few holes in the uom area coming out of investigating this issue.