### PR TITLE
Issue #25729: Various UOM handling improvements and consistency

### DIFF
--- a/guiclient/invoiceItem.cpp
+++ b/guiclient/invoiceItem.cpp
@@ -16,6 +16,7 @@
 #include <QVariant>
 
 #include <metasql.h>
+#include "mqlutil.h"
 
 #include "xdoublevalidator.h"
 #include "priceList.h"
@@ -334,7 +335,7 @@ void invoiceItem::populate()
     _lineNumber->setText(invcitem.value("invcitem_linenumber").toString());
 
     // TODO: should this check itemsite_controlmethod == N?
-    _trackqoh = (invcitem.value("invcitem_coitem_id").toInt() > 0 &&
+    _trackqoh = (invcitem.value("invcitem_invcitem_id").toInt() > 0 &&
                  invcitem.value("itemsite_costmethod").toString() != "J");
 
     if (invcitem.value("invcitem_item_id").toInt() != -1)
@@ -422,28 +423,36 @@ void invoiceItem::sPopulateItemInfo(int pItemid)
   XSqlQuery invoicePopulateItemInfo;
   if ( (_itemSelected->isChecked()) && (pItemid != -1) )
   {
-    XSqlQuery uom;
-    uom.prepare("SELECT uom_id, uom_name"
-                "  FROM item"
-                "  JOIN uom ON (item_inv_uom_id=uom_id)"
-                " WHERE(item_id=:item_id)"
-                " UNION "
-                "SELECT uom_id, uom_name"
-                "  FROM item"
-                "  JOIN itemuomconv ON (itemuomconv_item_id=item_id)"
-                "  JOIN uom ON (itemuomconv_to_uom_id=uom_id)"
-                " WHERE((itemuomconv_from_uom_id=item_inv_uom_id)"
-                "   AND (item_id=:item_id))"
-                " UNION "
-                "SELECT uom_id, uom_name"
-                "  FROM item"
-                "  JOIN itemuomconv ON (itemuomconv_item_id=item_id)"
-                "  JOIN uom ON (itemuomconv_from_uom_id=uom_id)"
-                " WHERE((itemuomconv_to_uom_id=item_inv_uom_id)"
-                "   AND (item_id=:item_id))"
-                " ORDER BY uom_name;");
-    uom.bindValue(":item_id", _item->id());
-    uom.exec();
+    // Get list of active, valid Selling UOMs
+    MetaSQLQuery muom = mqlLoad("uoms", "item");
+
+    ParameterList params;
+    params.append("uomtype", "Selling");
+    params.append("item_id", pItemid);
+
+    // Also have to factor UOMs previously used on Invoice now inactive
+    if (_invcitemid != -1)
+    {
+      XSqlQuery invuom;
+      invuom.prepare("SELECT invcitem_qty_uom_id, invcitem_price_uom_id "
+                "  FROM invcitem"
+                " WHERE(invcitem_id=:invcitem_id);");
+      invuom.bindValue(":invcitem_id", _invcitemid);
+      invuom.exec();
+      if (ErrorReporter::error(QtCriticalMsg, this, tr("Getting Invoice UOMs"),
+                           invuom, __FILE__, __LINE__))
+        return;
+      else if (invuom.first())
+      {
+        params.append("uom_id", invuom.value("invcitem_qty_uom_id"));
+        params.append("uom_id2", invuom.value("invcitem_price_uom_id"));
+      }
+    }
+    XSqlQuery uom = muom.toQuery(params);
+    if (ErrorReporter::error(QtCriticalMsg, this, tr("Getting UOMs"),
+                           uom, __FILE__, __LINE__))
+      return;
+
     _qtyUOM->populate(uom);
     _pricingUOM->populate(uom);
 

--- a/guiclient/item.cpp
+++ b/guiclient/item.cpp
@@ -37,6 +37,7 @@
 #include "itemUOM.h"
 #include "itemtax.h"
 #include "itemSource.h"
+#include "mqlutil.h"
 #include "storedProcErrorLookup.h"
 
 const char *_itemTypes[] = { "P", "M", "F", "R", "S", "T", "O", "L", "K", "B", "C", "Y" };
@@ -162,6 +163,7 @@ item::item(QWidget* parent, const char* name, Qt::WFlags fl)
   _uomconv->addColumn(tr("Ratio"),      -1, Qt::AlignRight, true, "uomvalue"  );
   _uomconv->addColumn(tr("Global"),     _ynColumn*2,    Qt::AlignCenter, true, "global" );
   _uomconv->addColumn(tr("Fractional"), _ynColumn*2,   Qt::AlignCenter, true, "fractional" );
+  _uomconv->addColumn(tr("Active"),     _ynColumn*2,   Qt::AlignCenter, true, "active" );
   
   _itemsrc->addColumn(tr("Active"),      _dateColumn,   Qt::AlignCenter, true, "itemsrc_active");
   _itemsrc->addColumn(tr("Vendor"),      _itemColumn, Qt::AlignLeft, true, "vend_number" );
@@ -1875,7 +1877,8 @@ void item::sFillUOMList()
             "       (nuom.uom_name||'/'||duom.uom_name) AS uomname,"
             "       (formatUOMRatio(itemuomconv_from_value)||'/'||formatUOMRatio(itemuomconv_to_value)) AS uomvalue,"
             "       (uomconv_id IS NOT NULL) AS global,"
-            "       itemuomconv_fractional AS fractional"
+            "       itemuomconv_fractional AS fractional, "
+            "       itemuomconv_active AS active "
             "  FROM item"
             "  JOIN itemuomconv ON (itemuomconv_item_id=item_id)"
             "  JOIN uom AS nuom ON (itemuomconv_from_uom_id=nuom.uom_id)"
@@ -1889,7 +1892,8 @@ void item::sFillUOMList()
             "        uomtype_name AS uomname,"
             "       '' AS uomvalue,"
             "       NULL AS global,"
-            "       NULL AS fractional"
+            "       NULL AS fractional, "
+            "       NULL AS active "
             "  FROM item"
             "  JOIN itemuomconv ON (itemuomconv_item_id=item_id)"
             "  JOIN uom AS nuom ON (itemuomconv_from_uom_id=nuom.uom_id)"
@@ -1914,39 +1918,18 @@ void item::sFillUOMList()
 
 void item::sPopulatePriceUOMs()
 {
-  XSqlQuery itemPopulatePriceUOMs;
-  int pid = _priceUOM->id();
-  itemPopulatePriceUOMs.prepare("SELECT uom_id, uom_name, uom_name"
-            "  FROM uom"
-            " WHERE(uom_id=:uom_id)"
-            " UNION "
-            "SELECT uom_id, uom_name, uom_name"
-            "  FROM uom"
-            "  JOIN itemuomconv ON (itemuomconv_to_uom_id=uom_id)"
-            "  JOIN item ON (itemuomconv_from_uom_id=item_inv_uom_id)"
-            "  JOIN itemuom ON (itemuom_itemuomconv_id=itemuomconv_id)"
-            "  JOIN uomtype ON (itemuom_uomtype_id=uomtype_id)"
-            " WHERE((itemuomconv_item_id=:item_id)"
-            "   AND (uomtype_name='Selling'))"
-            " UNION "
-            "SELECT uom_id, uom_name, uom_name"
-            "  FROM uom"
-            "  JOIN itemuomconv ON (itemuomconv_from_uom_id=uom_id)"
-            "  JOIN item ON (itemuomconv_to_uom_id=item_inv_uom_id)"
-            "  JOIN itemuom ON (itemuom_itemuomconv_id=itemuomconv_id)"
-            "  JOIN uomtype ON (itemuom_uomtype_id=uomtype_id)"
-            " WHERE((itemuomconv_item_id=:item_id)"
-            "   AND (uomtype_name='Selling'))"
-            " ORDER BY 2;");
-  itemPopulatePriceUOMs.bindValue(":item_id", _itemid);
-  itemPopulatePriceUOMs.bindValue(":uom_id", _inventoryUOM->id());
-  itemPopulatePriceUOMs.exec();
-  _priceUOM->populate(itemPopulatePriceUOMs, pid);
-  if (itemPopulatePriceUOMs.lastError().type() != QSqlError::NoError)
-  {
-    systemError(this, itemPopulatePriceUOMs.lastError().databaseText(), __FILE__, __LINE__);
+  MetaSQLQuery muom = mqlLoad("uoms", "item");
+
+  ParameterList params;
+  params.append("uomtype", "Selling");
+  params.append("item_id", _itemid);
+  params.append("uom_id", _priceUOM->id());
+
+  XSqlQuery puom = muom.toQuery(params);
+  _priceUOM->populate(puom);
+  if (ErrorReporter::error(QtCriticalMsg, this, tr("Getting Price UOMs"),
+                           puom, __FILE__, __LINE__))
     return;
-  }
 }
 
 void item::closeEvent(QCloseEvent *pEvent)

--- a/guiclient/itemPricingScheduleItem.cpp
+++ b/guiclient/itemPricingScheduleItem.cpp
@@ -792,35 +792,36 @@ void itemPricingScheduleItem::populate()
 
 void itemPricingScheduleItem::sUpdateCosts(int pItemid)
 {
-  XSqlQuery itemUpdateCosts;
-  XSqlQuery uom;
-  uom.prepare("SELECT uom_id, uom_name"
-              "  FROM item"
-              "  JOIN uom ON (item_inv_uom_id=uom_id)"
-              " WHERE(item_id=:item_id)"
-              " UNION "
-              "SELECT uom_id, uom_name"
-              "  FROM item"
-              "  JOIN itemuomconv ON (itemuomconv_item_id=item_id)"
-              "  JOIN uom ON (itemuomconv_to_uom_id=uom_id)"
-              " WHERE((itemuomconv_from_uom_id=item_inv_uom_id)"
-              "   AND (item_id=:item_id))"
-              " UNION "
-              "SELECT uom_id, uom_name"
-              "  FROM item"
-              "  JOIN itemuomconv ON (itemuomconv_item_id=item_id)"
-              "  JOIN uom ON (itemuomconv_from_uom_id=uom_id)"
-              " WHERE((itemuomconv_to_uom_id=item_inv_uom_id)"
-              "   AND (item_id=:item_id))"
-              " ORDER BY uom_name;");
-  uom.bindValue(":item_id", _item->id());
-  uom.exec();
-  if (itemUpdateCosts.lastError().type() != QSqlError::NoError)
+  // Get list of active, valid Selling UOMs
+  MetaSQLQuery muom = mqlLoad("uoms", "item");
+
+  ParameterList params;
+  params.append("uomtype", "Selling");
+  params.append("item_id", pItemid);
+
+  // Also have to factor UOMs previously used on Pricing Item now inactive
+  if (_ipsitemid != -1)
   {
-	systemError(this, _rejectedMsg.arg(itemUpdateCosts.lastError().databaseText()),
-                  __FILE__, __LINE__);
-        done(-1);
+    XSqlQuery pruom;
+    pruom.prepare("SELECT ipsitem_qty_uom_id, ipsitem_price_uom_id "
+                "  FROM ipsiteminfo"
+                " WHERE(ipsitem_id=:ipsitem_id);");
+    pruom.bindValue(":ipsitem_id", _ipsitemid);
+    pruom.exec();
+    if (ErrorReporter::error(QtCriticalMsg, this, tr("Getting Sales Pricing UOMs"),
+                         pruom, __FILE__, __LINE__))
+      return;
+    else if (pruom.first())
+    {
+      params.append("uom_id", pruom.value("ipsitem_qty_uom_id"));
+      params.append("uom_id2", pruom.value("ipsitem_price_uom_id"));
+    }
   }
+  XSqlQuery uom = muom.toQuery(params);
+  if (ErrorReporter::error(QtCriticalMsg, this, tr("Getting UOMs"),
+                         uom, __FILE__, __LINE__))
+    return;
+
   _qtyUOM->populate(uom);
   _priceUOM->populate(uom);
 
@@ -847,12 +848,9 @@ void itemPricingScheduleItem::sUpdateCosts(int pItemid)
     _qtyUOM->setId(cost.value("item_inv_uom_id").toInt());
     _priceUOM->setId(cost.value("item_price_uom_id").toInt());
   }
-  else if (itemUpdateCosts.lastError().type() != QSqlError::NoError)
-  {
-	systemError(this, _rejectedMsg.arg(itemUpdateCosts.lastError().databaseText()),
-                  __FILE__, __LINE__);
-        done(-1);
-  }
+  else if (ErrorReporter::error(QtCriticalMsg, this, tr("Getting Item Costs"),
+                         cost, __FILE__, __LINE__))
+    done(-1);
   
   if (_item->isConfigured())
     _tab->setTabEnabled(_tab->indexOf(_configuredPrices),TRUE);

--- a/guiclient/itemUOM.cpp
+++ b/guiclient/itemUOM.cpp
@@ -101,7 +101,10 @@ enum SetResponse itemUOM::set(const ParameterList &pParams)
   if (valid)
   {
     if (param.toString() == "new")
+    {
+      _active->setChecked(TRUE);
       _mode = cNew;
+    }
     else if (param.toString() == "edit")
     {
       _mode = cEdit;
@@ -156,12 +159,14 @@ void itemUOM::sSave()
   itemSave.prepare("UPDATE itemuomconv"
             "   SET itemuomconv_to_value=:tovalue,"
             "       itemuomconv_from_value=:fromvalue,"
-            "       itemuomconv_fractional=:fractional "
+            "       itemuomconv_fractional=:fractional, "
+            "       itemuomconv_active=:active "
             " WHERE(itemuomconv_id=:itemuomconv_id);");
   itemSave.bindValue(":itemuomconv_id", _itemuomconvid);
   itemSave.bindValue(":tovalue", _toValue->toDouble());
   itemSave.bindValue(":fromvalue", _fromValue->toDouble());
   itemSave.bindValue(":fractional", QVariant(_fractional->isChecked()));
+  itemSave.bindValue(":active", QVariant(_active->isChecked()));
   if(itemSave.exec())
     accept();
 }
@@ -172,7 +177,7 @@ void itemUOM::populate()
   itempopulate.prepare("SELECT itemuomconv_item_id, item_inv_uom_id,"
             "       itemuomconv_from_uom_id, itemuomconv_to_uom_id,"
             "       itemuomconv_from_value, itemuomconv_to_value, itemuomconv_fractional,"
-            "       (uomconv_id IS NOT NULL) AS global"
+            "       itemuomconv_active, (uomconv_id IS NOT NULL) AS global"
             "  FROM itemuomconv"
             "  JOIN item ON (itemuomconv_item_id=item_id)"
             "  LEFT OUTER JOIN uomconv"
@@ -190,6 +195,7 @@ void itemUOM::populate()
     _fromValue->setDouble(itempopulate.value("itemuomconv_from_value").toDouble());
     _toValue->setDouble(itempopulate.value("itemuomconv_to_value").toDouble());
     _fractional->setChecked(itempopulate.value("itemuomconv_fractional").toBool());
+    _active->setChecked(itempopulate.value("itemuomconv_active").toBool());
     _toValue->setEnabled(!itempopulate.value("global").toBool());
     _fromValue->setEnabled(!itempopulate.value("global").toBool());
 

--- a/guiclient/itemUOM.ui
+++ b/guiclient/itemUOM.ui
@@ -1,5 +1,5 @@
-<ui version="4.0" >
- <author></author>
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <comment>This file is part of the xTuple ERP: PostBooks Edition, a free and
 open source Enterprise Resource Planning software suite,
 Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
@@ -8,95 +8,100 @@ version 1.0, the full text of which (including xTuple-specific Exhibits)
 is available at www.xtuple.com/CPAL.  By using this software, you agree
 to be bound by its terms.</comment>
  <class>itemUOM</class>
- <widget class="QDialog" name="itemUOM" >
-  <property name="geometry" >
+ <widget class="QDialog" name="itemUOM">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>443</width>
-    <height>255</height>
+    <width>633</width>
+    <height>309</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Unit of Measure</string>
   </property>
-  <layout class="QVBoxLayout" >
-   <property name="margin" >
-    <number>9</number>
-   </property>
-   <property name="spacing" >
+  <layout class="QVBoxLayout">
+   <property name="spacing">
     <number>6</number>
    </property>
+   <property name="margin">
+    <number>9</number>
+   </property>
    <item>
-    <layout class="QHBoxLayout" >
-     <property name="margin" >
-      <number>0</number>
-     </property>
-     <property name="spacing" >
+    <layout class="QHBoxLayout">
+     <property name="spacing">
       <number>6</number>
      </property>
+     <property name="margin">
+      <number>0</number>
+     </property>
      <item>
-      <layout class="QVBoxLayout" >
-       <property name="margin" >
+      <layout class="QVBoxLayout">
+       <property name="spacing">
         <number>0</number>
        </property>
-       <property name="spacing" >
+       <property name="margin">
         <number>0</number>
        </property>
        <item>
-        <layout class="QVBoxLayout" >
-         <property name="margin" >
-          <number>0</number>
-         </property>
-         <property name="spacing" >
+        <layout class="QVBoxLayout">
+         <property name="spacing">
           <number>6</number>
          </property>
+         <property name="margin">
+          <number>0</number>
+         </property>
          <item>
-          <layout class="QGridLayout" >
-           <property name="margin" >
+          <layout class="QGridLayout">
+           <property name="margin">
             <number>0</number>
            </property>
-           <property name="spacing" >
+           <property name="spacing">
             <number>6</number>
            </property>
-           <item rowspan="2" row="0" column="1" >
-            <widget class="QLabel" name="_perLit" >
-             <property name="text" >
+           <item row="0" column="2">
+            <widget class="XComboBox" name="_uomTo"/>
+           </item>
+           <item row="1" column="2">
+            <widget class="XLineEdit" name="_toValue"/>
+           </item>
+           <item row="1" column="0">
+            <widget class="XLineEdit" name="_fromValue"/>
+           </item>
+           <item row="0" column="1" rowspan="2">
+            <widget class="QLabel" name="_perLit">
+             <property name="text">
               <string> Per </string>
              </property>
             </widget>
            </item>
-           <item row="0" column="0" >
-            <widget class="XComboBox" name="_uomFrom" />
+           <item row="0" column="0">
+            <widget class="XComboBox" name="_uomFrom"/>
            </item>
-           <item row="0" column="2" >
-            <widget class="XComboBox" name="_uomTo" />
-           </item>
-           <item row="1" column="2" >
-            <widget class="XLineEdit" name="_toValue" >
+           <item row="2" column="0">
+            <widget class="QCheckBox" name="_fractional">
+             <property name="text">
+              <string>Fractional</string>
+             </property>
             </widget>
            </item>
-           <item row="1" column="0" >
-            <widget class="XLineEdit" name="_fromValue" >
+           <item row="2" column="2">
+            <widget class="QCheckBox" name="_active">
+             <property name="text">
+              <string>Active</string>
+             </property>
             </widget>
            </item>
           </layout>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="_fractional" >
-           <property name="text" >
-            <string>Fractional</string>
-           </property>
-          </widget>
          </item>
         </layout>
        </item>
        <item>
         <spacer>
-         <property name="orientation" >
+         <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
-         <property name="sizeHint" >
+         <property name="sizeHint" stdset="0">
           <size>
            <width>329</width>
            <height>0</height>
@@ -107,37 +112,37 @@ to be bound by its terms.</comment>
       </layout>
      </item>
      <item>
-      <layout class="QVBoxLayout" >
-       <property name="margin" >
+      <layout class="QVBoxLayout">
+       <property name="spacing">
         <number>0</number>
        </property>
-       <property name="spacing" >
+       <property name="margin">
         <number>0</number>
        </property>
        <item>
-        <layout class="QVBoxLayout" >
-         <property name="margin" >
-          <number>0</number>
-         </property>
-         <property name="spacing" >
+        <layout class="QVBoxLayout">
+         <property name="spacing">
           <number>5</number>
          </property>
+         <property name="margin">
+          <number>0</number>
+         </property>
          <item>
-          <widget class="QPushButton" name="_close" >
-           <property name="text" >
+          <widget class="QPushButton" name="_close">
+           <property name="text">
             <string>&amp;Cancel</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="_save" >
-           <property name="text" >
+          <widget class="QPushButton" name="_save">
+           <property name="text">
             <string>&amp;Save</string>
            </property>
-           <property name="autoDefault" >
+           <property name="autoDefault">
             <bool>true</bool>
            </property>
-           <property name="default" >
+           <property name="default">
             <bool>true</bool>
            </property>
           </widget>
@@ -146,13 +151,13 @@ to be bound by its terms.</comment>
        </item>
        <item>
         <spacer>
-         <property name="orientation" >
+         <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
-         <property name="sizeType" >
+         <property name="sizeType">
           <enum>QSizePolicy::Expanding</enum>
          </property>
-         <property name="sizeHint" >
+         <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
            <height>0</height>
@@ -165,82 +170,80 @@ to be bound by its terms.</comment>
     </layout>
    </item>
    <item>
-    <widget class="QFrame" name="_typeFrame" >
-     <property name="enabled" >
+    <widget class="QFrame" name="_typeFrame">
+     <property name="enabled">
       <bool>false</bool>
      </property>
-     <property name="sizePolicy" >
-      <sizepolicy>
-       <hsizetype>5</hsizetype>
-       <vsizetype>7</vsizetype>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
        <horstretch>0</horstretch>
        <verstretch>1</verstretch>
       </sizepolicy>
      </property>
-     <property name="frameShape" >
+     <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
      </property>
-     <property name="frameShadow" >
+     <property name="frameShadow">
       <enum>QFrame::Plain</enum>
      </property>
-     <layout class="QHBoxLayout" >
-      <property name="margin" >
-       <number>0</number>
-      </property>
-      <property name="spacing" >
+     <layout class="QHBoxLayout">
+      <property name="spacing">
        <number>6</number>
       </property>
+      <property name="margin">
+       <number>0</number>
+      </property>
       <item>
-       <layout class="QVBoxLayout" >
-        <property name="margin" >
+       <layout class="QVBoxLayout">
+        <property name="spacing">
          <number>0</number>
         </property>
-        <property name="spacing" >
+        <property name="margin">
          <number>0</number>
         </property>
         <item>
-         <widget class="QLabel" name="label" >
-          <property name="text" >
+         <widget class="QLabel" name="label">
+          <property name="text">
            <string>Available Types</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QListWidget" name="_available" />
+         <widget class="QListWidget" name="_available"/>
         </item>
        </layout>
       </item>
       <item>
-       <layout class="QVBoxLayout" >
-        <property name="margin" >
+       <layout class="QVBoxLayout">
+        <property name="spacing">
          <number>0</number>
         </property>
-        <property name="spacing" >
+        <property name="margin">
          <number>0</number>
         </property>
         <item>
-         <widget class="QLabel" name="_filler" >
-          <property name="text" >
+         <widget class="QLabel" name="_filler">
+          <property name="text">
            <string/>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="_add" >
-          <property name="text" >
-           <string>Add ></string>
+         <widget class="QPushButton" name="_add">
+          <property name="enabled">
+           <bool>false</bool>
           </property>
-         <property name="enabled" >
-          <bool>false</bool>
-         </property>
+          <property name="text">
+           <string>Add &gt;</string>
+          </property>
          </widget>
         </item>
         <item>
          <spacer>
-          <property name="orientation" >
+          <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
-          <property name="sizeHint" >
+          <property name="sizeHint" stdset="0">
            <size>
             <width>20</width>
             <height>40</height>
@@ -249,34 +252,34 @@ to be bound by its terms.</comment>
          </spacer>
         </item>
         <item>
-         <widget class="QPushButton" name="_remove" >
-          <property name="text" >
-           <string>&lt; Remove</string>
-          </property>
-          <property name="enabled" >
+         <widget class="QPushButton" name="_remove">
+          <property name="enabled">
            <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>&lt; Remove</string>
           </property>
          </widget>
         </item>
        </layout>
       </item>
       <item>
-       <layout class="QVBoxLayout" >
-        <property name="margin" >
+       <layout class="QVBoxLayout">
+        <property name="spacing">
          <number>0</number>
         </property>
-        <property name="spacing" >
+        <property name="margin">
          <number>0</number>
         </property>
         <item>
-         <widget class="QLabel" name="label_2" >
-          <property name="text" >
+         <widget class="QLabel" name="label_2">
+          <property name="text">
            <string>Selected Types</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QListWidget" name="_selected" />
+         <widget class="QListWidget" name="_selected"/>
         </item>
        </layout>
       </item>
@@ -285,7 +288,7 @@ to be bound by its terms.</comment>
    </item>
   </layout>
  </widget>
- <layoutdefault spacing="5" margin="5" />
+ <layoutdefault spacing="5" margin="5"/>
  <customwidgets>
   <customwidget>
    <class>XComboBox</class>
@@ -303,7 +306,6 @@ to be bound by its terms.</comment>
   <tabstop>_fromValue</tabstop>
   <tabstop>_uomTo</tabstop>
   <tabstop>_toValue</tabstop>
-  <tabstop>_fractional</tabstop>
   <tabstop>_available</tabstop>
   <tabstop>_add</tabstop>
   <tabstop>_remove</tabstop>
@@ -311,7 +313,6 @@ to be bound by its terms.</comment>
   <tabstop>_save</tabstop>
   <tabstop>_close</tabstop>
  </tabstops>
- <includes/>
  <resources/>
  <connections>
   <connection>
@@ -320,11 +321,11 @@ to be bound by its terms.</comment>
    <receiver>itemUOM</receiver>
    <slot>reject()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>363</x>
      <y>32</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>308</x>
      <y>16</y>
     </hint>
@@ -336,11 +337,11 @@ to be bound by its terms.</comment>
    <receiver>_add</receiver>
    <slot>animateClick()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>101</x>
      <y>115</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>181</x>
      <y>107</y>
     </hint>
@@ -352,11 +353,11 @@ to be bound by its terms.</comment>
    <receiver>_remove</receiver>
    <slot>animateClick()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>316</x>
      <y>186</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>219</x>
      <y>183</y>
     </hint>
@@ -368,11 +369,11 @@ to be bound by its terms.</comment>
    <receiver>_typeFrame</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>218</x>
      <y>21</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>172</x>
      <y>78</y>
     </hint>

--- a/guiclient/returnAuthorizationItem.cpp
+++ b/guiclient/returnAuthorizationItem.cpp
@@ -15,6 +15,10 @@
 #include <QValidator>
 #include <QVariant>
 
+#include <metasql.h>
+#include "mqlutil.h"
+#include "errorReporter.h"
+
 #include "priceList.h"
 #include "taxDetail.h"
 #include "storedProcErrorLookup.h"
@@ -687,28 +691,36 @@ bool returnAuthorizationItem::sSave()
 
 void returnAuthorizationItem::sPopulateItemInfo()
 {
-  XSqlQuery uom;
-  uom.prepare("SELECT uom_id, uom_name"
-              "  FROM item"
-              "  JOIN uom ON (item_inv_uom_id=uom_id)"
-              " WHERE(item_id=:item_id)"
-              " UNION "
-              "SELECT uom_id, uom_name"
-              "  FROM item"
-              "  JOIN itemuomconv ON (itemuomconv_item_id=item_id)"
-              "  JOIN uom ON (itemuomconv_to_uom_id=uom_id)"
-              " WHERE((itemuomconv_from_uom_id=item_inv_uom_id)"
-              "   AND (item_id=:item_id))"
-              " UNION "
-              "SELECT uom_id, uom_name"
-              "  FROM item"
-              "  JOIN itemuomconv ON (itemuomconv_item_id=item_id)"
-              "  JOIN uom ON (itemuomconv_from_uom_id=uom_id)"
-              " WHERE((itemuomconv_to_uom_id=item_inv_uom_id)"
-              "   AND (item_id=:item_id))"
-              " ORDER BY uom_name;");
-  uom.bindValue(":item_id", _item->id());
-  uom.exec();
+  // Get list of active, valid Selling UOMs
+  MetaSQLQuery muom = mqlLoad("uoms", "item");
+
+  ParameterList params;
+  params.append("uomtype", "Selling");
+  params.append("item_id", _item->id());
+
+  // Also have to factor UOMs previously used on Return Auth now inactive
+  if (_raitemid != -1)
+  {
+    XSqlQuery cmuom;
+    cmuom.prepare("SELECT raitem_qty_uom_id, raitem_price_uom_id "
+                "  FROM raitem"
+                " WHERE(raitem_id=:raitem_id);");
+    cmuom.bindValue(":raitem_id", _raitemid);
+    cmuom.exec();
+    if (ErrorReporter::error(QtCriticalMsg, this, tr("Getting Returns UOMs"),
+                         cmuom, __FILE__, __LINE__))
+      return;
+    else if (cmuom.first())
+    {
+      params.append("uom_id", cmuom.value("raitem_qty_uom_id"));
+      params.append("uom_id2", cmuom.value("raitem_price_uom_id"));
+    }
+  }
+  XSqlQuery uom = muom.toQuery(params);
+  if (ErrorReporter::error(QtCriticalMsg, this, tr("Getting UOMs"),
+                         uom, __FILE__, __LINE__))
+    return;
+
   _qtyUOM->populate(uom);
   _pricingUOM->populate(uom);
   _salePricingUOM->populate(uom);


### PR DESCRIPTION
Build in ability to deactivate Item UoM conversions

Screens previously running individual, duplicated SQL now reference single metaSQL and take account of active status of conversion.

Screens also consistently take account of the conversion "type" (e.g Selling) which they were not previously with potentially confusing results.

requires xtuple/xtuple#2299