### PR TITLE
Issue #25838: Convert unassigned account widget to Liability default

### DIFF
--- a/guiclient/company.cpp
+++ b/guiclient/company.cpp
@@ -55,7 +55,7 @@ company::company(QWidget* parent, const char* name, bool modal, Qt::WindowFlags 
   _discrepancy->setType(GLCluster::cExpense);
   _discrepancy->setShowExternal(true);
   _discrepancy->setIgnoreCompany(true);
-  _unassigned->setType(GLCluster::cExpense);
+  _unassigned->setType(GLCluster::cLiability);
   _unassigned->setShowExternal(true);
   _unassigned->setIgnoreCompany(true);
 }

--- a/guiclient/configureGL.cpp
+++ b/guiclient/configureGL.cpp
@@ -29,7 +29,7 @@ configureGL::configureGL(QWidget* parent, const char* name, bool /*modal*/, Qt::
   _yearend->setType(GLCluster::cEquity);
   _gainLoss->setType(GLCluster::cExpense);
   _discrepancy->setType(GLCluster::cExpense);
-  _unassigned->setType(GLCluster::cExpense);
+  _unassigned->setType(GLCluster::cLiability);
 
   // AP
   _nextAPMemoNumber->setValidator(omfgThis->orderVal());


### PR DESCRIPTION
Convert default from expense to liability in the configure Accounting and Company screens