### PR TITLE
Issue #25719: Invalid lock error in Customer Workbench

### DIFF
--- a/guiclient/customer.cpp
+++ b/guiclient/customer.cpp
@@ -336,11 +336,13 @@ enum SetResponse customer::set(const ParameterList &pParams)
     _captive=true;
   }
 
-  if (_mode == cEdit && !_lock.acquire("custinfo", _custid, AppLock::Interactive))
+  if (_mode == cEdit && _custid > 0)
   {
-    setViewMode();
+    if (!_lock.acquire("custinfo", _custid, AppLock::Interactive))
+    {
+      setViewMode();
+    }
   }
-
 
   return NoError;
 }
@@ -1691,6 +1693,13 @@ void customer::setId(int p)
 {
   if (_custid==p)
     return;
+
+  if (! _lock.release())
+    ErrorReporter::error(QtCriticalMsg, this, tr("Locking Error"),
+                         _lock.lastError(), __FILE__, __LINE__);
+
+  if (_mode == cEdit && !_lock.acquire("custinfo", p, AppLock::Interactive))
+    setViewMode();
 
   _charfilled = false;
   _custid=p;


### PR DESCRIPTION
Fix invalid lock when opening Customer Workbench.  Also found missing lock check in unit testing so resolved that as well.  Checked Vendor Workbench for same problem, but this screen works completely differently.