### PR TITLE
Issue #25701: Modify reference to check on Vendor screen

### DIFF
--- a/guiclient/vendor.ui
+++ b/guiclient/vendor.ui
@@ -1152,7 +1152,7 @@ and Purchase Order amounts</string>
          <item>
           <widget class="QRadioButton" name="_checksButton">
            <property name="text">
-            <string>Checks</string>
+            <string>Payments</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Missed in previous PR.

Question though - why do we have a Payments radio on the Vendor ui and then immediately upon selection have a checkbox enabling EFT payments?  Could just be the one option?