### PR TITLE
Issue #25697:Login Screen Database Name Cursor Jumps

### DIFF
--- a/common/login2.cpp
+++ b/common/login2.cpp
@@ -52,8 +52,8 @@ login2::login2(QWidget* parent, const char* name, bool modal, Qt::WindowFlags fl
   connect(_buttonBox, SIGNAL(accepted()), this, SLOT(sLogin()));
   connect(_buttonBox, SIGNAL(helpRequested()), this, SLOT(sOpenHelp()));
   connect(_server, SIGNAL(editingFinished()), this, SLOT(sChangeURL()));
-  connect(_database, SIGNAL(editTextChanged(QString)), this, SLOT(sChangeURL()));
-  connect(_port, SIGNAL(textChanged(QString)), this, SLOT(sChangeURL()));
+  connect(_database->lineEdit(), SIGNAL(editingFinished()), this, SLOT(sChangeURL()));
+  connect(_port, SIGNAL(editingFinished()), this, SLOT(sChangeURL()));
   //connect(_otherOption, SIGNAL(toggled(bool)), _options, SLOT(setEnabled(bool)));
   //connect(_otherOption, SIGNAL(toggled(bool)), _recent, SLOT(setEnabled(bool)));
   //connect(_otherOption, SIGNAL(toggled(bool)), this, SLOT(sHandleButton()));


### PR DESCRIPTION
Also fixes the same issue in the 'port' field on the login screen.