### PR TITLE
Fixes issue #15457 - textstreams saved as UTF-8 on windows were not written with BOM

### DIFF
--- a/guiclient/scriptEditor.cpp
+++ b/guiclient/scriptEditor.cpp
@@ -392,7 +392,10 @@ bool scriptEditor::saveFile(const QString &source,
 
   QTextStream ts(&file);
   ts.setCodec("UTF-8");
+#ifdef Q_OS_WIN
+  // bug #15457 Exporting script on windows does not write UTF BOM
   ts.setGenerateByteOrderMark(true);
+#endif
   ts << source;
   file.close();
 

--- a/guiclient/scriptEditor.cpp
+++ b/guiclient/scriptEditor.cpp
@@ -392,6 +392,7 @@ bool scriptEditor::saveFile(const QString &source,
 
   QTextStream ts(&file);
   ts.setCodec("UTF-8");
+  ts.setGenerateByteOrderMark(true);
   ts << source;
   file.close();
 


### PR DESCRIPTION
Export function of xtreewidget uses QTextDocument which doesn't have a way to specify to use te byte oder mark, would need refactoring to use QTextStream if it is required there (that data exports in UTF8 fine, but has no byte order mark. Might not be an issue if that data isn't reimported)