### PR TITLE
Issue #25927: Close Return Authorisation upon Crediting

### DIFF
--- a/guiclient/configureSO.cpp
+++ b/guiclient/configureSO.cpp
@@ -211,6 +211,7 @@ configureSO::configureSO(QWidget* parent, const char* name, bool /*modal*/, Qt::
 
     _returnAuthChangeLog->setChecked(_metrics->boolean("ReturnAuthorizationChangeLog"));
     _printRA->setChecked(_metrics->boolean("DefaultPrintRAOnSave"));
+    _closeRA->setChecked(_metrics->boolean("CloseRAOnCredit"));
 
     _enableReservations->setChecked(_metrics->boolean("EnableSOReservations"));
     _requireReservations->setChecked(_metrics->boolean("RequireSOReservations"));
@@ -380,6 +381,7 @@ bool configureSO::sSave()
     _metrics->set("DefaultRaCreditMethod", QString(creditMethodTypes[_creditBy->currentIndex()]));
     _metrics->set("ReturnAuthorizationChangeLog", _returnAuthChangeLog->isChecked());
     _metrics->set("DefaultPrintRAOnSave", _printRA->isChecked());
+    _metrics->set("CloseRAOnCredit", _closeRA->isChecked());
     _metrics->set("RANumberGeneration", _returnAuthorizationNumGeneration->methodCode());
 
     configureSave.prepare( "SELECT setNextRaNumber(:ranumber);" );

--- a/guiclient/configureSO.ui
+++ b/guiclient/configureSO.ui
@@ -1395,6 +1395,16 @@ to be bound by its terms.</comment>
               </property>
              </widget>
             </item>
+            <item row="5" column="0" colspan="2">
+             <widget class="QCheckBox" name="_closeRA">
+              <property name="focusPolicy">
+               <enum>Qt::ClickFocus</enum>
+              </property>
+              <property name="text">
+               <string>Close Return Authorization when Crediting</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </widget>
          </item>

--- a/guiclient/openReturnAuthorizations.h
+++ b/guiclient/openReturnAuthorizations.h
@@ -34,6 +34,7 @@ public slots:
     virtual void sNew();
     virtual void sEdit();
     virtual void sView();
+    virtual void sCloseRA();
     virtual void sDelete();
     virtual void sPopulateMenu( QMenu * pMenu );
     virtual void sFillList();

--- a/guiclient/openReturnAuthorizations.ui
+++ b/guiclient/openReturnAuthorizations.ui
@@ -225,6 +225,16 @@ to be bound by its terms.</comment>
                </widget>
               </item>
               <item>
+               <widget class="QPushButton" name="_closeRA">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="text">
+                 <string>Close</string>
+                </property>
+               </widget>
+              </item>
+              <item>
                <widget class="QPushButton" name="_delete">
                 <property name="enabled">
                  <bool>false</bool>
@@ -290,6 +300,7 @@ to be bound by its terms.</comment>
   <tabstop>_new</tabstop>
   <tabstop>_edit</tabstop>
   <tabstop>_view</tabstop>
+  <tabstop>_closeRA</tabstop>
   <tabstop>_delete</tabstop>
   <tabstop>_close</tabstop>
   <tabstop>_print</tabstop>


### PR DESCRIPTION
Based on config setting (metric) automatically close the Return Auth when a credit memo is created.  Prevents partially credited RA's from remaining open indefinitely.  Also adds the capability for a user to manually close an RA via the Open Return Auths screen (as opposed to completely deleting RAs)

Requires xtuple/private-extensions#657

@gilmoskowitz in looking at this issue it seems we post RA information to a rahist table but I cannot find any screen/report/form that references this table so it looks like we lose all visibility of an RA once it is closed/credited.  We probably should add some display/report to show RA history.