### PR TITLE
Issue #18174 Reverse Behavior on Miscellaneous AP Credit Memo

### DIFF
--- a/guiclient/apOpenItem.h
+++ b/guiclient/apOpenItem.h
@@ -36,6 +36,7 @@ public slots:
     virtual void sPopulateDueDate();
     virtual void sTaxDetail();
     virtual void sReleaseNumber();
+    virtual void sToggleAccount();
 
 protected slots:
     virtual void languageChange();

--- a/guiclient/apOpenItem.ui
+++ b/guiclient/apOpenItem.ui
@@ -283,6 +283,27 @@ to be bound by its terms.</comment>
          </widget>
         </item>
         <item row="4" column="1">
+          <widget class="XCheckBox" name="_usePrepaid">
+           <property name="text">
+            <string>Use Prepaid Account</string>
+           </property>
+          </widget>
+        </item>
+        <item row="5" column="0">
+          <widget class="QLabel" name="_accntIdLit">
+            <property name="text">
+              <string>Distribution Account:</string>
+            </property>
+          </widget>
+        </item>
+        <item  row="5" column="1">
+          <widget class="GLCluster" name="_accntId">
+            <property name="enabled">
+               <bool>false</bool>
+            </property>
+          </widget>
+        </item>
+        <item row="6" column="1">
          <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -424,68 +445,6 @@ to be bound by its terms.</comment>
          </item>
         </layout>
        </widget>
-       <widget class="QWidget" name="_accountTab">
-        <attribute name="title">
-         <string>Account</string>
-        </attribute>
-        <layout class="QGridLayout">
-         <item row="1" column="0">
-          <widget class="QGroupBox" name="_altPrepaid">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="title">
-            <string/>
-           </property>
-           <property name="checkable">
-            <bool>false</bool>
-           </property>
-           <property name="checked">
-            <bool>false</bool>
-           </property>
-           <layout class="QHBoxLayout">
-            <item>
-             <widget class="QLabel" name="_altAccntidLit">
-              <property name="text">
-               <string>Alternate Prepaid Account:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="GLCluster" name="_altAccntid">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <spacer>
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>0</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="0" column="0">
-          <widget class="QCheckBox" name="_useAltPrepaid">
-           <property name="text">
-            <string>Use Alternate Prepaid Account</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
        <widget class="QWidget" name="_applicationsTab">
         <attribute name="title">
          <string>Applications</string>
@@ -580,9 +539,9 @@ to be bound by its terms.</comment>
   <tabstop>_docNumber</tabstop>
   <tabstop>_poNumber</tabstop>
   <tabstop>_journalNumber</tabstop>
+  <tabstop>_accntId</tabstop>
   <tabstop>_terms</tabstop>
   <tabstop>_amount</tabstop>
-  <tabstop>_altAccntid</tabstop>
   <tabstop>_notes</tabstop>
   <tabstop>_apapply</tabstop>
   <tabstop>_paid</tabstop>
@@ -666,22 +625,6 @@ to be bound by its terms.</comment>
     <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>_useAltPrepaid</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>_altAccntid</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>290</x>
-     <y>451</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>374</x>
-     <y>493</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
Remove Accounting Tab and move Distribution account to main window to improve visibility.  Reverse behaviour so selecting the checkbox picks the Prepaid account, unchecking expects an Account to be selected.