### PR TITLE
Issue #26424: Add Misc Items to Credit Memos, Alt Revenue Accnt

### DIFF
--- a/guiclient/creditMemo.ui
+++ b/guiclient/creditMemo.ui
@@ -18,7 +18,7 @@ to be bound by its terms.</comment>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Return</string>
+   <string>Sales Credit Memo</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
@@ -93,7 +93,7 @@ to be bound by its terms.</comment>
                 </size>
                </property>
                <property name="text">
-                <string>Return #:</string>
+                <string>Credit Memo #:</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -184,7 +184,7 @@ to be bound by its terms.</comment>
                 </size>
                </property>
                <property name="text">
-                <string>Return Date:</string>
+                <string>Memo Date:</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/guiclient/creditMemoItem.h
+++ b/guiclient/creditMemoItem.h
@@ -32,6 +32,7 @@ public slots:
     virtual void populate();
     virtual void sCalculateDiscountPrcnt();
     virtual void sCalculateFromDiscount();
+    virtual void sHandleSelection();
     virtual void sListPrices();
     virtual void sCalculateTax();
     virtual void sPriceGroup();

--- a/guiclient/creditMemoItem.ui
+++ b/guiclient/creditMemoItem.ui
@@ -13,12 +13,12 @@ to be bound by its terms.</comment>
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>743</width>
-    <height>593</height>
+    <width>948</width>
+    <height>980</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Return Item</string>
+   <string>Sales Credit Memo Item</string>
   </property>
   <layout class="QGridLayout">
    <item row="0" column="0">
@@ -35,6 +35,49 @@ to be bound by its terms.</comment>
      <property name="spacing">
       <number>12</number>
      </property>
+     <item row="0" column="2" rowspan="5">
+      <layout class="QVBoxLayout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QPushButton" name="_close">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="text">
+          <string>&amp;Cancel</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="_save">
+         <property name="text">
+          <string>&amp;Save</string>
+         </property>
+         <property name="default">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Expanding</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
      <item row="0" column="0" colspan="2">
       <layout class="QHBoxLayout">
        <item>
@@ -101,85 +144,143 @@ to be bound by its terms.</comment>
        </item>
       </layout>
      </item>
-     <item row="0" column="2" rowspan="4">
-      <layout class="QVBoxLayout">
-       <property name="spacing">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QPushButton" name="_close">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="text">
-          <string>&amp;Cancel</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="_save">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string>&amp;Save</string>
-         </property>
-         <property name="default">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Expanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>0</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
      <item row="1" column="0" colspan="2">
-      <widget class="QGroupBox" name="_itemGroup">
+      <widget class="QGroupBox" name="_itemTypeGroup">
        <property name="title">
         <string/>
        </property>
        <layout class="QGridLayout">
-        <item row="0" column="0">
-         <widget class="ItemCluster" name="_item">
-          <property name="focusPolicy">
-           <enum>Qt::StrongFocus</enum>
+        <item row="0" column="1">
+         <widget class="QGroupBox" name="_itemGroup">
+          <property name="title">
+           <string>Item</string>
           </property>
+          <layout class="QGridLayout" name="gridLayout">
+           <item row="0" column="2">
+            <spacer name="horizontalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="0" column="1">
+            <layout class="QGridLayout">
+             <item row="0" column="0">
+              <widget class="QLabel" name="_warehouseLit">
+               <property name="text">
+                <string>Recv. &amp;Site:</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+               <property name="buddy">
+                <cstring>_warehouse</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="WComboBox" name="_warehouse"/>
+             </item>
+             <item row="1" column="1">
+              <spacer>
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </item>
+           <item row="0" column="0">
+            <widget class="ItemCluster" name="_item">
+             <property name="focusPolicy">
+              <enum>Qt::StrongFocus</enum>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </widget>
         </item>
-        <item row="0" column="1">
-         <layout class="QGridLayout">
-          <item row="0" column="0">
-           <widget class="QLabel" name="_warehouseLit">
+        <item row="1" column="1">
+         <widget class="QGroupBox" name="_miscGroup">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="title">
+           <string>Miscellaneous</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_5">
+           <item row="0" column="1">
+            <widget class="XLineEdit" name="_itemNumber"/>
+           </item>
+           <item row="1" column="0">
+            <widget class="XLabel" name="_descripLit">
+             <property name="text">
+              <string>Description:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="XTextEdit" name="_itemDescrip"/>
+           </item>
+           <item row="2" column="0">
+            <widget class="XLabel" name="_salescatLit">
+             <property name="text">
+              <string>Sales Category:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="XLabel" name="_itemNumberLit">
+             <property name="text">
+              <string>Item:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="XComboBox" name="_salescat">
+             <property name="allowNull">
+              <bool>true</bool>
+             </property>
+             <property name="type">
+              <enum>XComboBox::SalesCategoriesActive</enum>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <widget class="QRadioButton" name="_itemSelected">
             <property name="text">
-             <string>Recv. &amp;Site:</string>
+             <string/>
             </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-            <property name="buddy">
-             <cstring>_warehouse</cstring>
+            <property name="checked">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="WComboBox" name="_warehouse"/>
-          </item>
-          <item row="1" column="1">
-           <spacer>
+          <item>
+           <spacer name="verticalSpacer_4">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -193,24 +294,35 @@ to be bound by its terms.</comment>
           </item>
          </layout>
         </item>
-        <item row="0" column="2">
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>0</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
+        <item row="1" column="0">
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <item>
+           <widget class="QRadioButton" name="_miscSelected">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
         </item>
        </layout>
       </widget>
      </item>
      <item row="2" column="0" colspan="2">
-      <widget class="QGroupBox" name="_miscGroup">
+      <widget class="QGroupBox" name="_rsnGroup">
        <property name="title">
         <string/>
        </property>
@@ -257,7 +369,7 @@ to be bound by its terms.</comment>
        </layout>
       </widget>
      </item>
-     <item row="3" column="0">
+     <item row="4" column="0">
       <widget class="QGroupBox" name="_inventoryGroup">
        <property name="title">
         <string/>
@@ -388,7 +500,7 @@ to be bound by its terms.</comment>
        </layout>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="4" column="1">
       <widget class="QGroupBox" name="_priceGroup">
        <property name="title">
         <string/>
@@ -530,10 +642,10 @@ to be bound by its terms.</comment>
        </layout>
       </widget>
      </item>
-     <item row="4" column="0" colspan="3">
+     <item row="5" column="0" colspan="3">
       <widget class="QTabWidget" name="tabWidget">
        <property name="currentIndex">
-        <number>0</number>
+        <number>1</number>
        </property>
        <widget class="QWidget" name="_detailTab">
         <attribute name="title">
@@ -813,49 +925,34 @@ to be bound by its terms.</comment>
          </item>
         </layout>
        </widget>
-       <widget class="QWidget" name="_accounting">
-        <attribute name="title">
-         <string>Accounting</string>
-        </attribute>
-        <widget class="QSplitter" name="splitter">
-         <property name="geometry">
-          <rect>
-           <x>2</x>
-           <y>10</y>
-           <width>1032</width>
-           <height>213</height>
-          </rect>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <widget class="QWidget" name="layoutWidget">
-          <layout class="QHBoxLayout" name="horizontalLayout">
-           <item alignment="Qt::AlignTop">
-            <widget class="GLCluster" name="_revAccnt">
-             <property name="label">
-              <string>Revenue Account Override:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_3">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>728</width>
-               <height>17</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </widget>
-        </widget>
-       </widget>
       </widget>
+     </item>
+     <item row="3" column="0" colspan="2">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="XLabel" name="_revAccntLit">
+         <property name="text">
+          <string>Alternate Revenue Account:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="GLCluster" name="_revAccnt"/>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>
@@ -867,7 +964,6 @@ to be bound by its terms.</comment>
    <class>CurrCluster</class>
    <extends>CurrDisplay</extends>
    <header>currcluster.h</header>
-   <container>1</container>
   </customwidget>
   <customwidget>
    <class>CurrDisplay</class>
@@ -883,7 +979,6 @@ to be bound by its terms.</comment>
    <class>ItemCluster</class>
    <extends>QWidget</extends>
    <header>itemcluster.h</header>
-   <container>1</container>
   </customwidget>
   <customwidget>
    <class>WComboBox</class>
@@ -904,7 +999,6 @@ to be bound by its terms.</comment>
    <class>XLineEdit</class>
    <extends>QLineEdit</extends>
    <header>xlineedit.h</header>
-   <container>1</container>
   </customwidget>
   <customwidget>
    <class>XURLLabel</class>
@@ -918,7 +1012,6 @@ to be bound by its terms.</comment>
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>_item</tabstop>
   <tabstop>_warehouse</tabstop>
   <tabstop>_rsnCode</tabstop>
   <tabstop>_qtyReturned</tabstop>
@@ -958,22 +1051,6 @@ to be bound by its terms.</comment>
    <signal>newId(int)</signal>
    <receiver>_warehouse</receiver>
    <slot>findItemsites(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>_item</sender>
-   <signal>valid(bool)</signal>
-   <receiver>_save</receiver>
-   <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>20</x>

--- a/guiclient/customerFormAssignment.ui
+++ b/guiclient/customerFormAssignment.ui
@@ -116,7 +116,7 @@ to be bound by its terms.</comment>
        <item row="2" column="0">
         <widget class="QLabel" name="_creditMemoLit">
          <property name="text">
-          <string>Return Form:</string>
+          <string>Credit Memo Form:</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/guiclient/customerFormAssignments.cpp
+++ b/guiclient/customerFormAssignments.cpp
@@ -30,7 +30,7 @@ customerFormAssignments::customerFormAssignments(QWidget* parent, const char* na
 
   _custform->addColumn(tr("Customer Type"), -1, Qt::AlignCenter, true, "custtypecode");
   _custform->addColumn(tr("Invoice"),      100, Qt::AlignCenter, true, "invoice");
-  _custform->addColumn(tr("Return"),  100, Qt::AlignCenter, true, "creditmemo");
+  _custform->addColumn(tr("Credit Memo"),  100, Qt::AlignCenter, true, "creditmemo");
   _custform->addColumn(tr("Statement"),    100, Qt::AlignCenter, true, "statement");
   _custform->addColumn(tr("Quote"),        100, Qt::AlignCenter, true, "quote");
   _custform->addColumn(tr("Packing List"), 100, Qt::AlignCenter, true, "packinglist");

--- a/guiclient/dspAROpenItems.cpp
+++ b/guiclient/dspAROpenItems.cpp
@@ -116,7 +116,7 @@ dspAROpenItems::dspAROpenItems(QWidget* parent, const char*, Qt::WindowFlags fl)
   menuItem = newMenu->addAction(tr("Misc. Debit Memo"),   this, SLOT(sEnterMiscArDebitMemo()));
   menuItem->setEnabled(_privileges->check("MaintainARMemos"));
   newMenu->addSeparator();
-  menuItem = newMenu->addAction(tr("Return"), this, SLOT(sNewCreditMemo()));
+  menuItem = newMenu->addAction(tr("Sales Credit Memo"), this, SLOT(sNewCreditMemo()));
   menuItem->setEnabled(_privileges->check("MaintainCreditMemos"));
   menuItem = newMenu->addAction(tr("Misc. Credit Memo"),   this, SLOT(sEnterMiscArCreditMemo()));
   menuItem->setEnabled(_privileges->check("MaintainARMemos"));
@@ -195,7 +195,7 @@ void dspAROpenItems::sPopulateMenu(QMenu *pMenu, QTreeWidgetItem *pItem, int)
   else if (((XTreeWidgetItem *)pItem)->altId() == 1 && ((XTreeWidgetItem *)pItem)->id("docnumber") > -1)
   // Credit Memo
   {
-    menuItem = pMenu->addAction(tr("Edit Return..."), this, SLOT(sEdit()));
+    menuItem = pMenu->addAction(tr("Edit Credit Memo..."), this, SLOT(sEdit()));
     menuItem->setEnabled(_privileges->check("MaintainCreditMemos"));
   }
   else if (((XTreeWidgetItem *)pItem)->id() > 0)
@@ -246,7 +246,7 @@ void dspAROpenItems::sPopulateMenu(QMenu *pMenu, QTreeWidgetItem *pItem, int)
       menuItem->setEnabled(_privileges->check("VoidPostedARCreditMemos"));
     }
 
-    menuItem = pMenu->addAction(tr("View Return..."), this, SLOT(sViewCreditMemo()));
+    menuItem = pMenu->addAction(tr("View Credit Memo..."), this, SLOT(sViewCreditMemo()));
     menuItem->setEnabled(_privileges->check("MaintainCreditMemos") || _privileges->check("ViewCreditMemos"));
   }
   else if (((XTreeWidgetItem *)pItem)->altId() == 4)
@@ -463,9 +463,9 @@ void dspAROpenItems::sCCRefundCM()
 
 void dspAROpenItems::sDeleteCreditMemo()
 {
-  if (QMessageBox::question(this, tr("Delete Selected Returns?"),
+  if (QMessageBox::question(this, tr("Delete Selected Credit Memos?"),
                             tr("<p>Are you sure that you want to delete the "
-			       "selected Returns?"),
+			       "selected Credit Memos?"),
                             QMessageBox::Yes, QMessageBox::No | QMessageBox::Default) == QMessageBox::Yes)
   {
     XSqlQuery delq;
@@ -478,12 +478,12 @@ void dspAROpenItems::sDeleteCreditMemo()
       if (delq.first())
       {
             if (! delq.value("result").toBool())
-              systemError(this, tr("Could not delete Return."),
+              systemError(this, tr("Could not delete Credit Memo."),
                           __FILE__, __LINE__);
       }
       else if (delq.lastError().type() != QSqlError::NoError)
             systemError(this,
-                        tr("Error deleting Return %1\n").arg(list()->currentItem()->text("docnumber")) +
+                        tr("Error deleting Credit Memo %1\n").arg(list()->currentItem()->text("docnumber")) +
                         delq.lastError().databaseText(), __FILE__, __LINE__);
     }
 
@@ -634,8 +634,8 @@ void dspAROpenItems::sVoidCreditMemo()
   XSqlQuery dspVoidCreditMemo;
   XTreeWidgetItem *pItem = list()->currentItem();
   if(pItem->rawValue("posted") != 0 &&
-      QMessageBox::question(this, tr("Void Posted Return?"),
-                            tr("<p>This Return has already been posted. "
+      QMessageBox::question(this, tr("Void Posted Credit Memo?"),
+                            tr("<p>This Credit Memo has already been posted. "
                                "Are you sure you want to void it?"),
                             QMessageBox::Yes,
                             QMessageBox::No | QMessageBox::Default) == QMessageBox::No)
@@ -665,7 +665,7 @@ void dspAROpenItems::sVoidCreditMemo()
     else if (distributeInventory::SeriesAdjust(result, this) == XDialog::Rejected)
     {
       rollback.exec();
-      QMessageBox::information( this, tr("Void Return"), tr("Transaction Canceled") );
+      QMessageBox::information( this, tr("Void Memo"), tr("Transaction Canceled") );
       return;
     }
 
@@ -675,7 +675,7 @@ void dspAROpenItems::sVoidCreditMemo()
   else if (post.lastError().type() != QSqlError::NoError)
   {
     rollback.exec();
-    systemError(this, tr("A System Error occurred voiding Return.\n%1")
+    systemError(this, tr("A System Error occurred voiding Credit Memo.\n%1")
                 .arg(post.lastError().databaseText()),
                 __FILE__, __LINE__);
   }
@@ -892,7 +892,7 @@ bool dspAROpenItems::setParams(ParameterList &params)
     params.append("endDueDate", _dates->endDate());
   }
   params.append("invoice", tr("Invoice"));
-  params.append("return", tr("Return"));
+  params.append("return", tr("Sales Credit Memo"));
   params.append("creditMemo", tr("Credit Memo"));
   params.append("debitMemo", tr("Debit Memo"));
   params.append("cashdeposit", tr("Customer Deposit"));
@@ -922,7 +922,7 @@ void dspAROpenItems::sPreview()
     ParameterList params;
     params.append("cust_id", _customerSelector->custId());
     params.append("invoice",  tr("Invoice"));
-    params.append("return",   tr("Return"));
+    params.append("return",   tr("Sales Credit Memo"));
     params.append("debit",    tr("Debit Memo"));
     params.append("credit",   tr("Credit Memo"));
     params.append("deposit",  tr("Deposit"));
@@ -1053,7 +1053,7 @@ void dspAROpenItems::sPostCreditMemo()
   if (_privileges->check("ChangeSOMemoPostDate"))
   {
     getGLDistDate newdlg(this, "", true);
-    newdlg.sSetDefaultLit(tr("Return Date"));
+    newdlg.sSetDefaultLit(tr("Credit Memo Date"));
     if (newdlg.exec() == XDialog::Accepted)
     {
       newDate = newdlg.date();
@@ -1104,7 +1104,7 @@ void dspAROpenItems::sPostCreditMemo()
       if (distributeInventory::SeriesAdjust(result, this) == XDialog::Rejected)
       {
         rollback.exec();
-        QMessageBox::information( this, tr("Post Return"), tr("Transaction Canceled") );
+        QMessageBox::information( this, tr("Post Credit Memo"), tr("Transaction Canceled") );
         return;
       }
 
@@ -1115,14 +1115,14 @@ void dspAROpenItems::sPostCreditMemo()
   else if (postq.lastError().databaseText().contains("post to closed period"))
   {
     rollback.exec();
-    systemError(this, tr("Could not post Return #%1 because of a missing exchange rate.")
+    systemError(this, tr("Could not post Credit Memo #%1 because of a missing exchange rate.")
                                       .arg(list()->currentItem()->text("docnumber")));
     return;
   }
   else if (postq.lastError().type() != QSqlError::NoError)
   {
     rollback.exec();
-    systemError(this, tr("A System Error occurred posting Return#%1.\n%2")
+    systemError(this, tr("A System Error occurred posting Credit Memo#%1.\n%2")
             .arg(list()->currentItem()->text("docnumber"))
             .arg(postq.lastError().databaseText()),
           __FILE__, __LINE__);
@@ -1343,7 +1343,7 @@ bool dspAROpenItems::checkCreditMemoSitePrivs(int cmid)
     if (!check.value("result").toBool())
       {
         QMessageBox::critical(this, tr("Access Denied"),
-                                       tr("You may not view or edit this Return as it references "
+                                       tr("You may not view or edit this Credit Memo as it references "
                                        "a Site for which you have not been granted privileges.")) ;
         return false;
       }

--- a/guiclient/invoice.cpp
+++ b/guiclient/invoice.cpp
@@ -15,9 +15,12 @@
 #include <QMessageBox>
 #include <QSqlError>
 #include <QVariant>
-
 #include <QDebug>
 
+#include <metasql.h>
+
+#include "mqlutil.h"
+#include "errorReporter.h"
 #include "distributeInventory.h"
 #include "invoiceItem.h"
 #include "storedProcErrorLookup.h"
@@ -1022,47 +1025,17 @@ void invoice::populate()
 
 void invoice::sFillItemList()
 {
-  XSqlQuery invoiceFillItemList;
-  invoiceFillItemList.prepare( "SELECT invcitem_id, invcitem_linenumber,"
-             "       formatSoItemNumber(invcitem_coitem_id) AS soitemnumber, "
-             "       CASE WHEN (item_id IS NULL) THEN invcitem_number"
-             "            ELSE item_number"
-             "       END AS itemnumber,"
-             "       CASE WHEN (item_id IS NULL) THEN invcitem_descrip"
-             "            ELSE (item_descrip1 || ' ' || item_descrip2)"
-             "       END AS itemdescription,"
-             "       quom.uom_name AS qtyuom,"
-             "       invcitem_ordered, invcitem_billed,"
-             "       puom.uom_name AS priceuom,"
-             "       invcitem_price,"
-             "       round((invcitem_billed * invcitem_qty_invuomratio) * (invcitem_price / "
-	           "            (CASE WHEN(item_id IS NULL) THEN 1 "
-	           "			            ELSE invcitem_price_invuomratio END)), 2) AS extprice,"
-             "       COALESCE(coitem_unitcost, itemCost(itemsite_id), 0.0) AS unitcost,"
-             "       ROUND((invcitem_billed * invcitem_qty_invuomratio) *"
-             "             ((invcitem_price / COALESCE(invcitem_price_invuomratio,1.0)) - "
-             "              currtolocal(:curr_id, COALESCE(coitem_unitcost, itemCost(itemsite_id), 0.0), :date)),2) AS margin,"
-             "       CASE WHEN (invcitem_price = 0.0) THEN 100.0"
-             "            ELSE (((invcitem_price - currtolocal(:curr_id, COALESCE(coitem_unitcost, itemCost(itemsite_id), 0.0), :date)) / invcitem_price) * 100.0)"
-             "       END AS marginpercent,"
-             "       'qty' AS invcitem_ordered_xtnumericrole,"
-             "       'qty' AS invcitem_billed_xtnumericrole,"
-             "       'salesprice' AS invcitem_price_xtnumericrole,"
-             "       'curr' AS extprice_xtnumericrole,"
-             "       'cost' AS unitcost_xtnumericrole "
-             "FROM invcitem LEFT OUTER JOIN item on (invcitem_item_id=item_id) "
-             "  LEFT OUTER JOIN uom AS quom ON (invcitem_qty_uom_id=quom.uom_id)"
-             "  LEFT OUTER JOIN uom AS puom ON (invcitem_price_uom_id=puom.uom_id)"
-             "  LEFT OUTER JOIN coitem ON (coitem_id=invcitem_coitem_id)"
-             "  LEFT OUTER JOIN itemsite ON (itemsite_item_id=invcitem_item_id AND itemsite_warehous_id=invcitem_warehous_id)"
-             "WHERE (invcitem_invchead_id=:invchead_id) "
-             "ORDER BY invcitem_linenumber;" );
-  invoiceFillItemList.bindValue(":invchead_id", _invcheadid);
-  invoiceFillItemList.bindValue(":curr_id", _custCurrency->id());
-  invoiceFillItemList.bindValue(":date", _orderDate->date());
-  invoiceFillItemList.exec();
-  if (invoiceFillItemList.lastError().type() != QSqlError::NoError)
-      systemError(this, invoiceFillItemList.lastError().databaseText(), __FILE__, __LINE__);
+  MetaSQLQuery mql = mqlLoad("invoiceItems", "list");
+
+  ParameterList params;
+  params.append("invchead_id", _invcheadid);
+  params.append("curr_id", _custCurrency->id());
+  params.append("date", _orderDate->date());
+  XSqlQuery invoiceFillItemList = mql.toQuery(params);
+
+  if (ErrorReporter::error(QtCriticalMsg, this, tr("Invoice Items"),
+                             invoiceFillItemList, __FILE__, __LINE__))
+    return;
 
   _invcitem->clear();
   _invcitem->populate(invoiceFillItemList);

--- a/guiclient/menuSales.cpp
+++ b/guiclient/menuSales.cpp
@@ -186,8 +186,8 @@ menuSales::menuSales(GUIClient *pParent) :
     { "so.listUnpostedInvoices",	     tr("&List Unposted Invoices..."),	SLOT(sUnpostedInvoices()), billingInvoicesMenu, "SelectBilling",	NULL, NULL,  true, NULL },
     { "so.postInvoices",		     tr("Post &Invoices..."),		SLOT(sPostInvoices()), billingInvoicesMenu, "PostMiscInvoices",	NULL, NULL, true, NULL },
 
-    // Sales | Billing | Return
-    { "menu",	tr("&Return"), (char*)billingCreditMemosMenu,	billingMenu,	"true",	NULL, NULL, true, NULL },
+    // Sales | Billing | Credit Memos
+    { "menu",	tr("&Credit Memo"), (char*)billingCreditMemosMenu,	billingMenu,	"true",	NULL, NULL, true, NULL },
     { "so.newCreditMemo",		     tr("&New..."),		SLOT(sNewCreditMemo()), billingCreditMemosMenu, "MaintainCreditMemos",	NULL, NULL, true, NULL },
     { "so.listUnpostedCreditMemos",	     tr("&List Unposted..."),	SLOT(sUnpostedCreditMemos()), billingCreditMemosMenu, "MaintainCreditMemos ViewCreditMemos",	NULL, NULL, true, NULL },
     { "so.creditMemoEditList",		     tr("&Edit List..."),	SLOT(sCreditMemoEditList()), billingCreditMemosMenu, "MaintainCreditMemos ViewCreditMemos",	NULL, NULL, true, NULL },

--- a/guiclient/printCreditMemo.ui
+++ b/guiclient/printCreditMemo.ui
@@ -18,7 +18,7 @@ to be bound by its terms.</comment>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Print Return</string>
+   <string>Print Credit Memo</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
@@ -32,7 +32,7 @@ to be bound by its terms.</comment>
      <item>
       <widget class="QLabel" name="_numberLit">
        <property name="text">
-        <string>Return #:</string>
+        <string>Memo #:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/guiclient/printCreditMemos.ui
+++ b/guiclient/printCreditMemos.ui
@@ -18,7 +18,7 @@ to be bound by its terms.</comment>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Print Returns</string>
+   <string>Print Credit Memos</string>
   </property>
   <layout class="QHBoxLayout" name="_printCreditMemosLyt"/>
  </widget>

--- a/guiclient/reprintCreditMemos.ui
+++ b/guiclient/reprintCreditMemos.ui
@@ -18,7 +18,7 @@ to be bound by its terms.</comment>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Re-Print Returns</string>
+   <string>Re-Print Credit Memos</string>
   </property>
   <layout class="QGridLayout" name="gridLayout"/>
  </widget>

--- a/guiclient/unpostedCreditMemos.cpp
+++ b/guiclient/unpostedCreditMemos.cpp
@@ -42,7 +42,7 @@ unpostedCreditMemos::unpostedCreditMemos(QWidget* parent, const char* name, Qt::
     _cmhead->addColumn(tr("Return #"),      _orderColumn, Qt::AlignLeft,   true,  "cmhead_number"   );
     _cmhead->addColumn(tr("Prnt'd"),        _orderColumn, Qt::AlignCenter, true,  "printed" );
     _cmhead->addColumn(tr("Customer"),      -1,           Qt::AlignLeft,   true,  "cmhead_billtoname"   );
-    _cmhead->addColumn(tr("Return Date"),   _dateColumn,  Qt::AlignCenter, true,  "cmhead_docdate" );
+    _cmhead->addColumn(tr("Memo Date"),   _dateColumn,  Qt::AlignCenter, true,  "cmhead_docdate" );
     _cmhead->addColumn(tr("Hold"),          _whsColumn,   Qt::AlignCenter, true,  "cmhead_hold" );
     _cmhead->addColumn(tr("G/L Dist Date"), _dateColumn,  Qt::AlignCenter, true,  "distdate" );
 
@@ -172,7 +172,7 @@ void unpostedCreditMemos::sPost()
   if (_privileges->check("ChangeSOMemoPostDate"))
   {
     getGLDistDate newdlg(this, "", true);
-    newdlg.sSetDefaultLit(tr("Return Date"));
+    newdlg.sSetDefaultLit(tr("Credit Memo Date"));
     if (newdlg.exec() == XDialog::Accepted)
     {
       newDate = newdlg.date();

--- a/guiclient/unpostedCreditMemos.ui
+++ b/guiclient/unpostedCreditMemos.ui
@@ -18,7 +18,7 @@ to be bound by its terms.</comment>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>List Unposted Returns</string>
+   <string>List Unposted Sales Credit Memos</string>
   </property>
   <layout class="QHBoxLayout">
    <item>
@@ -32,7 +32,7 @@ to be bound by its terms.</comment>
      <item>
       <widget class="QLabel" name="_unpostedCreditMemosList">
        <property name="text">
-        <string>Unposted Returns:</string>
+        <string>Unposted Credit Memos:</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Add Misc. (non-inventory) items to Credit Memos thus making them proper Credit Memos (reverse Invoices).  Also complete work on alternate revenue account per item (same as Invoice item logic).

Revert naming back from Return to Credit Memo as the functionality is now much more than just returning items.  Also converted Invoice and Credit Memo item list to metaSQL

requires xtuple/xtuple#2480