### PR TITLE
issue #26546 - show existing windows instead of creating new ones

### DIFF
--- a/guiclient/guiclient.h
+++ b/guiclient/guiclient.h
@@ -113,7 +113,7 @@ extern Metricsenc  *_metricsenc;
 enum SetResponse
 {
   NoError, NoError_Cancel, NoError_Run, NoError_Print, NoError_Submit,
-  Error_NoSetup, UndefinedError
+  Error_NoSetup, Error_AlreadyOpen, UndefinedError
 };
 
 

--- a/guiclient/systemMessage.h
+++ b/guiclient/systemMessage.h
@@ -16,24 +16,31 @@
 #include <parameter.h>
 #include "ui_systemMessage.h"
 
+#include <QHash>
+
 class systemMessage : public XDialog, public Ui::systemMessage
 {
     Q_OBJECT
 
-public:
+  public:
     systemMessage(QWidget* parent = 0, const char* name = 0, bool modal = false, Qt::WindowFlags fl = 0);
     ~systemMessage();
 
-public slots:
+    static systemMessage *windowForId(int id);
+
+  public slots:
     virtual enum SetResponse set( const ParameterList & pParams );
     virtual void sClose();
     virtual void sSave();
     virtual void populate();
 
-protected slots:
+  protected slots:
     virtual void languageChange();
 
-private:
+  protected:
+    static QHash<int, systemMessage*> open;
+
+  private:
     int _mode;
     int _msguserid;
 


### PR DESCRIPTION
for msgs that are already open.

This is an experiment. If it works then we should consider propagating the idea throughout the application. I think this is what https://github.com/xtuple/qt-client/blob/4_10_x/guiclient/salesOrder.cpp#L3647-L3740 is trying to accomplish, for example.