### PR TITLE
Remove ambiguous VendorGroup slot

### DIFF
--- a/widgets/vendorgroup.h
+++ b/widgets/vendorgroup.h
@@ -52,7 +52,6 @@ class XTUPLEWIDGETS_EXPORT VendorGroup : public QWidget, public Ui::VendorGroup
     virtual void setVendId(int p);
     virtual void setVendTypeId(int p);
     virtual void setTypePattern(const QString &p);
-    virtual void setState(int p) { setState((VendorGroupState)p); }
     virtual void setState(enum VendorGroupState p);
 
   signals:


### PR DESCRIPTION
Tested Vendor screen, AP Workbench could find no issues with removing this slot.

Tested scripting and this *has* fixed my original scripting problem