### PR TITLE
Issue #26796: Fix Setup menu text (on Mac)

### DIFF
--- a/guiclient/menuProducts.cpp
+++ b/guiclient/menuProducts.cpp
@@ -219,7 +219,7 @@ menuProducts::menuProducts(GUIClient *Pparent) :
   { "pd.reassignProductCategoryByProductCategory", tr("&Reassign Product Categories..."), SLOT(sReassignProductCategoryByProductCategory()), utilitiesMenu, "MaintainItemMasters", NULL, NULL, true , NULL },
 
   // Setup
-  { "pd.setup",	    tr(SETUPMENUITEM),	  SLOT(sSetup()),     mainMenu,	"true",	NULL, NULL,  true, NULL}
+  { "pd.setup",	    tr("&Setup..."),	  SLOT(sSetup()),     mainMenu,	"true",	NULL, NULL,  true, NULL}
 
   };
 

--- a/guiclient/menuSystem.cpp
+++ b/guiclient/menuSystem.cpp
@@ -146,7 +146,7 @@ menuSystem::menuSystem(GUIClient *Pparent) :
     { "sys.printAlignmentPage",	tr("Print &Alignment Page..."),	SLOT(sPrintAlignment()),	sysUtilsMenu,	"true",	NULL,	NULL,	true	},
 
     // Setup
-    { "sys.setup",	tr(SETUPMENUITEM),	SLOT(sSetup()),	systemMenu,	"true",	NULL,	NULL,	true	},
+    { "sys.setup",	tr("&Setup..."),	SLOT(sSetup()),	systemMenu,	"true",	NULL,	NULL,	true	},
     { "separator",		NULL,				NULL,				systemMenu,	"true",	NULL,	NULL,	true	},
     { "sys.exit",	tr("E&xit xTuple ERP..."), SLOT(sExit()),				systemMenu,	"true",	NULL,	NULL,	true	},
 


### PR DESCRIPTION
Reverted to same approach as the other menus.  Cannot test on Mac, but have tested on my build and changes are working.