### PR TITLE
issue #26653 

### DIFF
--- a/common/errorReporter.cpp
+++ b/common/errorReporter.cpp
@@ -773,6 +773,7 @@ const struct {
   { "priv_priv_name_key",                       Upsert,  0, QT_TRANSLATE_NOOP("errorReporter", "A Privilege already exists with this name.") },
   { "prj_prj_number_check",                     Upsert,  0, QT_TRANSLATE_NOOP("errorReporter", "The Project number is required.") },
   { "prj_prj_number_key",                       Upsert,  0, QT_TRANSLATE_NOOP("errorReporter", "A Project already exists with this number.") },
+  { "prj_prj_prjtype_id_fkey",                  Delete,  0, QT_TRANSLATE_NOOP("errorReporter", "Cannot delete the Project Type because Projects of this type exist.") },
 //{ "prj_prj_recurring_prj_id_fkey",            Delete,  0, QT_TRANSLATE_NOOP("errorReporter", "") },
 //{ "prj_prj_recurring_prj_id_fkey",            Upsert,  0, QT_TRANSLATE_NOOP("errorReporter", "") },
 //{ "prj_prj_status_check",                     Upsert,  0, QT_TRANSLATE_NOOP("errorReporter", "") },

--- a/guiclient/projectType.cpp
+++ b/guiclient/projectType.cpp
@@ -89,6 +89,9 @@ void projectType::sClose()
                 "WHERE (prjtype_id=:prjtype_id);" );
     typeClose.bindValue(":prjtype_id", _prjtypeid);
     typeClose.exec();
+
+    ErrorReporter::error(QtCriticalMsg, this tr("Error Deleting Project Type"),
+                              typeClose, __FILE__, __LINE__);
   }
 
   close();

--- a/guiclient/projectType.cpp
+++ b/guiclient/projectType.cpp
@@ -90,7 +90,7 @@ void projectType::sClose()
     typeClose.bindValue(":prjtype_id", _prjtypeid);
     typeClose.exec();
 
-    ErrorReporter::error(QtCriticalMsg, this tr("Error Deleting Project Type"),
+    ErrorReporter::error(QtCriticalMsg, this, tr("Error Deleting Project Type"),
                               typeClose, __FILE__, __LINE__);
   }
 

--- a/guiclient/projectTypes.cpp
+++ b/guiclient/projectTypes.cpp
@@ -12,6 +12,7 @@
 
 #include <parameter.h>
 #include "projectType.h"
+#include "errorReporter.h"
 #include "guiclient.h"
 
 projectTypes::projectTypes(QWidget* parent, const char* name, Qt::WindowFlags fl)
@@ -63,6 +64,9 @@ void projectTypes::sDelete()
              "WHERE (prjtype_id=:prjtype_id);" );
   typeDelete.bindValue(":prjtype_id", _projecttype->id());
   typeDelete.exec();
+
+  ErrorReporter::error(QtCriticalMsg, this, tr("Error Deleting Project Type"),
+                            typeDelete, __FILE__, __LINE__);
 
   sFillList();
 }


### PR DESCRIPTION
Fix involves three files: errorReporter.cpp, projectType.cpp and projectTypes.cpp.

In the first, added a human readable error for prj_prj_prjtype_id_fkey.  In the others, added call to ErrorReporter on delete where there was no call.