### PR TITLE
issue #26956 Query fields not remaining anchored - resolved

### DIFF
--- a/guiclient/display.ui
+++ b/guiclient/display.ui
@@ -31,7 +31,54 @@ to be bound by its terms.</comment>
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="2">
+   <item row="2" column="0" colspan="2">
+    <widget class="XTreeWidget" name="_list">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="populateLinear">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <layout class="QHBoxLayout" name="_optionLayout">
+     <item>
+      <widget class="XCheckBox" name="_autoupdate">
+       <property name="text">
+        <string>Automatically Update</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="XCheckBox" name="_queryonstart">
+       <property name="text">
+        <string>Query on start</string>
+       </property>
+       <property name="forgetful">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
     <layout class="QGridLayout" name="_topLayout">
      <item row="0" column="0">
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -152,52 +199,18 @@ to be bound by its terms.</comment>
      </item>
     </layout>
    </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="XTreeWidget" name="_list">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>1</verstretch>
-      </sizepolicy>
+   <item row="1" column="1">
+    <spacer name="horizontalSpacer_4">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="populateLinear">
-      <bool>false</bool>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
      </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <layout class="QHBoxLayout" name="_optionLayout">
-     <item>
-      <widget class="XCheckBox" name="_autoupdate">
-       <property name="text">
-        <string>Automatically Update</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="XCheckBox" name="_queryonstart">
-       <property name="text">
-        <string>Query on start</string>
-       </property>
-       <property name="forgetful">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>0</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Query fields now remain anchored at the left if you grab the screen and resize it.  If the screen gets TOO big then the query fields float just a tad to the right...but not all the way into the middle like they were doing previously.