### PR TITLE
Issue #27056: PCI Compliance: configurable password update enforcement

### DIFF
--- a/guiclient/databaseInformation.cpp
+++ b/guiclient/databaseInformation.cpp
@@ -53,6 +53,13 @@ databaseInformation::databaseInformation(QWidget* parent, const char* name, bool
   _disallowMismatchClient->setChecked(_metrics->boolean("DisallowMismatchClientVersion"));
   _checkForUpdates->setChecked(_metrics->boolean("CheckForUpdates"));
   _forceLicense->setChecked(_metrics->boolean("ForceLicenseLimit"));
+  _passwdReset->setChecked(_metrics->boolean("EnforcePasswordReset"));
+
+  if(_passwdReset->isChecked())
+  {
+    int days = _metrics->value("PasswordResetDays").toInt();
+    _passwdDays->setValue(days);
+  }
   
   QString access = _metrics->value("AllowedUserLogins");
   if("AdminOnly" == access)
@@ -118,6 +125,10 @@ bool databaseInformation::sSave()
   _metrics->set("DisallowMismatchClientVersion", _disallowMismatchClient->isChecked());
   _metrics->set("CheckForUpdates", _checkForUpdates->isChecked());
   _metrics->set("ForceLicenseLimit", _forceLicense->isChecked());
+  _metrics->set("EnforcePasswordReset", _passwdReset->isChecked());
+
+  if(_passwdReset->isChecked())
+    _metrics->set("PasswordResetDays", _passwdDays->value());
 
   _metrics->set("updateTickInterval", _interval->value());
 

--- a/guiclient/databaseInformation.ui
+++ b/guiclient/databaseInformation.ui
@@ -13,8 +13,8 @@ to be bound by its terms.</comment>
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>620</width>
-    <height>521</height>
+    <width>684</width>
+    <height>569</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -228,7 +228,16 @@ to be bound by its terms.</comment>
       <property name="spacing">
        <number>0</number>
       </property>
-      <property name="margin">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
        <number>0</number>
       </property>
       <item>
@@ -445,7 +454,14 @@ to be bound by its terms.</comment>
      </property>
     </widget>
    </item>
-   <item row="11" column="1">
+   <item row="6" column="1">
+    <widget class="QCheckBox" name="_enableGapless">
+     <property name="text">
+      <string>Enable Gapless Document Numbering</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QComboBox" name="_access">
@@ -481,7 +497,7 @@ to be bound by its terms.</comment>
      </item>
     </layout>
    </item>
-   <item row="11" column="0">
+   <item row="9" column="0">
     <widget class="QLabel" name="_accessLit">
      <property name="text">
       <string>Access Mode:</string>
@@ -494,11 +510,65 @@ to be bound by its terms.</comment>
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
-    <widget class="QCheckBox" name="_enableGapless">
-     <property name="text">
-      <string>Enable Gapless Document Numbering</string>
+   <item row="10" column="1">
+    <widget class="QGroupBox" name="_passwdReset">
+     <property name="title">
+      <string>Enforce User Password Reset</string>
      </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <widget class="XLabel" name="_days1Lit">
+        <property name="text">
+         <string>Password change every</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="XSpinBox" name="_passwdDays">
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>365</number>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>70</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="XLabel" name="_daysLit">
+        <property name="text">
+         <string>Days</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>
@@ -506,10 +576,20 @@ to be bound by its terms.</comment>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>XLabel</class>
+   <extends>QLabel</extends>
+   <header>xlabel.h</header>
+  </customwidget>
+  <customwidget>
    <class>XLineEdit</class>
    <extends>QLineEdit</extends>
    <header>xlineedit.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>XSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>xspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>XTextEdit</class>

--- a/guiclient/user.cpp
+++ b/guiclient/user.cpp
@@ -319,6 +319,13 @@ bool user::save()
     if (ErrorReporter::error(QtCriticalMsg, this, tr("Setting Password"),
                              usrq, __FILE__, __LINE__))
       return false;
+    usrq.prepare("SELECT setUserPreference(:username, 'PasswordResetDate', :passdate);");
+    usrq.bindValue(":username", username);
+    usrq.bindValue(":passdate", QDate::currentDate());
+    usrq.exec();
+    if (ErrorReporter::error(QtCriticalMsg, this, tr("Saving User Account"),
+                             usrq, __FILE__, __LINE__))
+      return false;
   }
 
   usrq.prepare("SELECT setUserPreference(:username, 'DisableExportContents', :export),"

--- a/guiclient/userPreferences.h
+++ b/guiclient/userPreferences.h
@@ -13,6 +13,8 @@
 
 #include "guiclient.h"
 #include "xdialog.h"
+#include <parameter.h>
+
 #include "ui_userPreferences.h"
 
 class userPreferences : public XDialog, public Ui::userPreferences
@@ -28,6 +30,7 @@ public:
     virtual void setBackgroundImage( int pImageid );
 
 public slots:
+    virtual SetResponse set( const ParameterList & pParams );
     virtual void sBackgroundList();
     virtual void sPopulate();
     virtual void sApply();


### PR DESCRIPTION
Configurable setup switch to enforce password age and the number of days.
Save reset date when user edits passwords (user and user pref screens)
Check for switch and age of user password when logging in - if required, prompt/warn user and then open userPreferences screen on the password tab.