### PR TITLE
Issue #27367: Rename Project Notes tab to ensure consistency with list

### DIFF
--- a/guiclient/project.ui
+++ b/guiclient/project.ui
@@ -740,7 +740,7 @@ to be bound by its terms.</comment>
      </widget>
      <widget class="QWidget" name="_notesTab">
       <attribute name="title">
-       <string>Notes</string>
+       <string>Description</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_6">
        <item row="1" column="0">


### PR DESCRIPTION
Project List header and Tab had different names.

Customer feedback