### PR TITLE
Issue #27298 - emit a general-purpose signal when a bar code has been scanned

### DIFF
--- a/guiclient/inputManager.cpp
+++ b/guiclient/inputManager.cpp
@@ -134,6 +134,7 @@ void InputManagerPrivate::addToEventList(QString prefix, int type, int length1, 
 InputManager::InputManager()
 {
   _private = new InputManagerPrivate(this);
+  connect(_private, SIGNAL(gotBarCode(int, int)), this, SIGNAL(gotBarCode(int, int)));
 }
 
 // TODO: treat _receivers as a stack, not a queue
@@ -390,7 +391,11 @@ QString InputManagerPrivate::queryFieldName(int barcodeType, int receiverType)
     case cBCTransferOrderLineItem:
     case cBCUser:
     case cBCWorkOrder:
+      result = "id";
+      break;
     case cBCWorkOrderOperation:
+      result = "altid";
+      break;
     case cBCUPCCode:
     case cBCLocationIssue:
     case cBCLocationContents:
@@ -462,6 +467,7 @@ void InputManagerPrivate::dispatchScan(int type)
       if (DEBUG)
         qDebug() << receiver.target() << methodName.toLatin1().data() << q.value(fieldName).toInt();
       (void)QMetaObject::invokeMethod(receiver.target(), methodName.toLatin1().data(), arg1);
+      emit gotBarCode(type, q.value(fieldName).toInt());
     }
     else if (q.lastError().type() != QSqlError::NoError)
       message(tr("Error Scanning %1: %2").arg(descrip, q.lastError().text()), 1000);

--- a/guiclient/inputManager.h
+++ b/guiclient/inputManager.h
@@ -52,6 +52,9 @@ class InputManager : public QObject
   public slots:
     void sRemove(QObject *);
 
+  signals:
+    void gotBarCode(int type, int id);
+
   protected:
     bool eventFilter(QObject *, QEvent *);
 

--- a/guiclient/inputManagerPrivate.h
+++ b/guiclient/inputManagerPrivate.h
@@ -64,6 +64,9 @@ class InputManagerPrivate : public QObject
     void         addToEventList(QString prefix, int type, int length1, int length2, int length3, QString descrip, QString query);
     ReceiverItem findReceiver(int pMask);
     QString      queryFieldName(int barcodeType, int receiverType);
+
+  signals:
+    void gotBarCode(int type, int id);
 };
 
 #endif


### PR DESCRIPTION
The old bar code scanning code emitted distinct signals for different scans. That's really hard to extend. The simplification of the scanning code for 4.10.0-beta overlooked the need for this, though:-(