### PR TITLE
issue #25967 - create actions whether menu item is visible or not

### DIFF
--- a/guiclient/menuAccounting.cpp
+++ b/guiclient/menuAccounting.cpp
@@ -461,11 +461,7 @@ void menuAccounting::addActionsToMenu(actionProperties acts[], unsigned int numE
   QAction * m = 0;
   for (unsigned int i = 0; i < numElems; i++)
   {
-    if (! acts[i].visible)
-    {
-      continue;
-    }
-    else if (acts[i].actionName == QString("menu"))
+    if (acts[i].actionName == QString("menu"))
     {
       m = acts[i].menu->addMenu((QMenu*)(acts[i].slot));
       if(m)
@@ -473,11 +469,11 @@ void menuAccounting::addActionsToMenu(actionProperties acts[], unsigned int numE
     }
     else if (acts[i].actionName == QString("separator"))
     {
-      acts[i].menu->addSeparator();
+      m = acts[i].menu->addSeparator();
     }
     else if ((acts[i].toolBar != NULL) && (acts[i].toolBar != NULL))
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -490,7 +486,7 @@ void menuAccounting::addActionsToMenu(actionProperties acts[], unsigned int numE
     }
     else if (acts[i].toolBar != NULL)
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -503,7 +499,7 @@ void menuAccounting::addActionsToMenu(actionProperties acts[], unsigned int numE
     }
     else
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -511,6 +507,7 @@ void menuAccounting::addActionsToMenu(actionProperties acts[], unsigned int numE
                   acts[i].menu,
                   acts[i].priv ) ;
     }
+    if (m) m->setVisible(acts[i].visible);
   }
 }
 

--- a/guiclient/menuCRM.cpp
+++ b/guiclient/menuCRM.cpp
@@ -153,11 +153,7 @@ void menuCRM::addActionsToMenu(actionProperties acts[], unsigned int numElems)
   QAction * m = 0;
   for (unsigned int i = 0; i < numElems; i++)
   {
-    if (! acts[i].visible)
-    {
-      continue;
-    }
-    else if (acts[i].actionName == QString("menu"))
+    if (acts[i].actionName == QString("menu"))
     {
       m = acts[i].menu->addMenu((QMenu*)(acts[i].slot));
       if(m)
@@ -165,11 +161,11 @@ void menuCRM::addActionsToMenu(actionProperties acts[], unsigned int numElems)
     }
     else if (acts[i].actionName == QString("separator"))
     {
-      acts[i].menu->addSeparator();
+      m = acts[i].menu->addSeparator();
     }
     else if ((acts[i].toolBar != NULL) && (!acts[i].toolTip.isEmpty()))
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -182,7 +178,7 @@ void menuCRM::addActionsToMenu(actionProperties acts[], unsigned int numElems)
     }
     else if (acts[i].toolBar != NULL)
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -195,7 +191,7 @@ void menuCRM::addActionsToMenu(actionProperties acts[], unsigned int numElems)
     }
     else
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -203,6 +199,7 @@ void menuCRM::addActionsToMenu(actionProperties acts[], unsigned int numElems)
                   acts[i].menu,
                   acts[i].priv ) ;
     }
+    if (m) m->setVisible(acts[i].visible);
   }
 }
 

--- a/guiclient/menuInventory.cpp
+++ b/guiclient/menuInventory.cpp
@@ -430,11 +430,7 @@ void menuInventory::addActionsToMenu(actionProperties acts[], unsigned int numEl
   QAction * m = 0;
   for (unsigned int i = 0; i < numElems; i++)
   {
-    if (! acts[i].visible)
-    {
-      continue;
-    }
-    else if (acts[i].actionName == QString("menu"))
+    if (acts[i].actionName == QString("menu"))
     {
       m = acts[i].menu->addMenu((QMenu*)(acts[i].slot));
       if(m)
@@ -442,11 +438,11 @@ void menuInventory::addActionsToMenu(actionProperties acts[], unsigned int numEl
     }
     else if (acts[i].actionName == QString("separator"))
     {
-      acts[i].menu->addSeparator();
+      m = acts[i].menu->addSeparator();
     }
     else if ((acts[i].toolBar != NULL) && (!acts[i].toolTip.isEmpty()))
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -459,7 +455,7 @@ void menuInventory::addActionsToMenu(actionProperties acts[], unsigned int numEl
     }
     else if (acts[i].toolBar != NULL)
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -472,7 +468,7 @@ void menuInventory::addActionsToMenu(actionProperties acts[], unsigned int numEl
     }
     else
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -480,6 +476,7 @@ void menuInventory::addActionsToMenu(actionProperties acts[], unsigned int numEl
                   acts[i].menu,
                   acts[i].priv ) ;
     }
+    if (m) m->setVisible(acts[i].visible);
   }
 }
 

--- a/guiclient/menuManufacture.cpp
+++ b/guiclient/menuManufacture.cpp
@@ -204,11 +204,7 @@ void menuManufacture::addActionsToMenu(actionProperties acts[], unsigned int num
   QAction * m = 0;
   for (unsigned int i = 0; i < numElems; i++)
   {
-    if (! acts[i].visible)
-    {
-      continue;
-    }
-    else if (acts[i].actionName == QString("menu"))
+    if (acts[i].actionName == QString("menu"))
     {
       m = acts[i].menu->addMenu((QMenu*)(acts[i].slot));
       if(m)
@@ -216,11 +212,11 @@ void menuManufacture::addActionsToMenu(actionProperties acts[], unsigned int num
     }
     else if (acts[i].actionName == QString("separator"))
     {
-      acts[i].menu->addSeparator();
+      m = acts[i].menu->addSeparator();
     }
     else if ((acts[i].toolBar != NULL) && (!acts[i].toolTip.isEmpty()))
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -233,7 +229,7 @@ void menuManufacture::addActionsToMenu(actionProperties acts[], unsigned int num
     }
     else if (acts[i].toolBar != NULL)
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -246,7 +242,7 @@ void menuManufacture::addActionsToMenu(actionProperties acts[], unsigned int num
     }
     else
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -254,6 +250,7 @@ void menuManufacture::addActionsToMenu(actionProperties acts[], unsigned int num
                   acts[i].menu,
                   acts[i].priv ) ;
     }
+    if (m) m->setVisible(acts[i].visible);
   }
 }
 

--- a/guiclient/menuProducts.cpp
+++ b/guiclient/menuProducts.cpp
@@ -236,11 +236,7 @@ void menuProducts::addActionsToMenu(actionProperties acts[], unsigned int numEle
   QAction * m = 0;
   for (unsigned int i = 0; i < numElems; i++)
   {
-    if (! acts[i].visible)
-    {
-      continue;
-    }
-    else if (acts[i].actionName == QString("menu"))
+    if (acts[i].actionName == QString("menu"))
     {
       m = acts[i].menu->addMenu((QMenu*)(acts[i].slot));
       if(m)
@@ -252,7 +248,7 @@ void menuProducts::addActionsToMenu(actionProperties acts[], unsigned int numEle
     }
     else if ((acts[i].toolBar != NULL) && (!acts[i].toolTip.isEmpty()))
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -265,7 +261,7 @@ void menuProducts::addActionsToMenu(actionProperties acts[], unsigned int numEle
     }
     else if (acts[i].toolBar != NULL)
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -278,7 +274,7 @@ void menuProducts::addActionsToMenu(actionProperties acts[], unsigned int numEle
     }
     else
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -286,6 +282,7 @@ void menuProducts::addActionsToMenu(actionProperties acts[], unsigned int numEle
                   acts[i].menu,
                   acts[i].priv ) ;
     }
+    if (m) m->setVisible(acts[i].visible);
   }
 }
 

--- a/guiclient/menuPurchase.cpp
+++ b/guiclient/menuPurchase.cpp
@@ -257,11 +257,7 @@ void menuPurchase::addActionsToMenu(actionProperties acts[], unsigned int numEle
   QAction * m = 0;
   for (unsigned int i = 0; i < numElems; i++)
   {
-    if (! acts[i].visible)
-    {
-      continue;
-    }
-    else if (acts[i].actionName == QString("menu"))
+    if (acts[i].actionName == QString("menu"))
     {
       m = acts[i].menu->addMenu((QMenu*)(acts[i].slot));
       if(m)
@@ -269,11 +265,11 @@ void menuPurchase::addActionsToMenu(actionProperties acts[], unsigned int numEle
     }
     else if (acts[i].actionName == QString("separator"))
     {
-      acts[i].menu->addSeparator();
+      m = acts[i].menu->addSeparator();
     }
     else if ((acts[i].toolBar != NULL) && (!acts[i].toolTip.isEmpty()))
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -286,7 +282,7 @@ void menuPurchase::addActionsToMenu(actionProperties acts[], unsigned int numEle
     }
     else if (acts[i].toolBar != NULL)
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -299,7 +295,7 @@ void menuPurchase::addActionsToMenu(actionProperties acts[], unsigned int numEle
     }
     else
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -307,6 +303,7 @@ void menuPurchase::addActionsToMenu(actionProperties acts[], unsigned int numEle
                   acts[i].menu,
                   acts[i].priv ) ;
     }
+    if (m) m->setVisible(acts[i].visible);
   }
 }
 

--- a/guiclient/menuSales.cpp
+++ b/guiclient/menuSales.cpp
@@ -348,11 +348,7 @@ void menuSales::addActionsToMenu(actionProperties acts[], unsigned int numElems)
   QAction * m = 0;
   for (unsigned int i = 0; i < numElems; i++)
   {
-    if (! acts[i].visible)
-    {
-      continue;
-    }
-    else if (acts[i].actionName == QString("menu"))
+    if (acts[i].actionName == QString("menu"))
     {
       m = acts[i].menu->addMenu((QMenu*)(acts[i].slot));
       if(m)
@@ -360,11 +356,11 @@ void menuSales::addActionsToMenu(actionProperties acts[], unsigned int numElems)
     }
     else if (acts[i].actionName == QString("separator"))
     {
-      acts[i].menu->addSeparator();
+      m = acts[i].menu->addSeparator();
     }
     else if ((acts[i].toolBar != NULL) && (!acts[i].toolTip.isEmpty()))
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -377,7 +373,7 @@ void menuSales::addActionsToMenu(actionProperties acts[], unsigned int numElems)
     }
     else if (acts[i].toolBar != NULL)
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -390,7 +386,7 @@ void menuSales::addActionsToMenu(actionProperties acts[], unsigned int numElems)
     }
     else
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -398,6 +394,7 @@ void menuSales::addActionsToMenu(actionProperties acts[], unsigned int numElems)
                   acts[i].menu,
                   acts[i].priv ) ;
     }
+    if (m) m->setVisible(acts[i].visible);
   }
 }
 

--- a/guiclient/menuSchedule.cpp
+++ b/guiclient/menuSchedule.cpp
@@ -111,11 +111,7 @@ void menuSchedule::addActionsToMenu(actionProperties acts[], unsigned int numEle
   QAction * m = 0;
   for (unsigned int i = 0; i < numElems; i++)
   {
-    if (! acts[i].visible)
-    {
-      continue;
-    }
-    else if (acts[i].actionName == QString("menu"))
+    if (acts[i].actionName == QString("menu"))
     {
       m = acts[i].menu->addMenu((QMenu*)(acts[i].slot));
       if(m)
@@ -123,11 +119,11 @@ void menuSchedule::addActionsToMenu(actionProperties acts[], unsigned int numEle
     }
     else if (acts[i].actionName == QString("separator"))
     {
-      acts[i].menu->addSeparator();
+      m = acts[i].menu->addSeparator();
     }
     else if ((acts[i].toolBar != NULL) && (!acts[i].toolTip.isEmpty()))
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -140,7 +136,7 @@ void menuSchedule::addActionsToMenu(actionProperties acts[], unsigned int numEle
     }
     else if (acts[i].toolBar != NULL)
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -153,7 +149,7 @@ void menuSchedule::addActionsToMenu(actionProperties acts[], unsigned int numEle
     }
     else
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -161,6 +157,7 @@ void menuSchedule::addActionsToMenu(actionProperties acts[], unsigned int numEle
                   acts[i].menu,
                   acts[i].priv ) ;
     }
+    if (m) m->setVisible(acts[i].visible);
   }
 }
 

--- a/guiclient/menuSystem.cpp
+++ b/guiclient/menuSystem.cpp
@@ -186,11 +186,7 @@ void menuSystem::addActionsToMenu(actionProperties acts[], unsigned int numElems
   QAction * m = 0;
   for (unsigned int i = 0; i < numElems; i++)
   {
-    if (! acts[i].visible)
-    {
-      continue;
-    }
-    else if (acts[i].actionName == QString("menu"))
+    if (acts[i].actionName == QString("menu"))
     {
       m = acts[i].menu->addMenu((QMenu*)(acts[i].slot));
       if(m)
@@ -198,11 +194,11 @@ void menuSystem::addActionsToMenu(actionProperties acts[], unsigned int numElems
     }
     else if (acts[i].actionName == QString("separator"))
     {
-      acts[i].menu->addSeparator();
+      m = acts[i].menu->addSeparator();
     }
     else if (acts[i].toolBar != NULL)
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -214,7 +210,7 @@ void menuSystem::addActionsToMenu(actionProperties acts[], unsigned int numElems
     }
     else
     {
-      new Action( parent,
+      m = new Action( parent,
                   acts[i].actionName,
                   acts[i].actionTitle,
                   this,
@@ -222,6 +218,7 @@ void menuSystem::addActionsToMenu(actionProperties acts[], unsigned int numElems
                   acts[i].menu,
                   acts[i].priv ) ;
     }
+    if (m) m->setVisible(acts[i].visible);
   }
 }
 


### PR DESCRIPTION
Create menu actions even when the menu items are invisible. This allows fixing the xtSetup bug, done by a separate pull request in the [custom](https://github.com/xtuple/custom) repository.