### PR TITLE
issue #26428 - expose qcoreapplication to scripting

### DIFF
--- a/scriptapi/qapplicationproto.cpp
+++ b/scriptapi/qapplicationproto.cpp
@@ -46,7 +46,7 @@ QScriptValue constructQApplication(QScriptContext  *context,
 }
 
 QApplicationProto::QApplicationProto(QObject *parent)
-    : QObject(parent)
+    : QCoreApplicationProto(parent)
 {
 }
 

--- a/scriptapi/qapplicationproto.h
+++ b/scriptapi/qapplicationproto.h
@@ -19,6 +19,8 @@
 #include <QSessionManager>
 #include <QtScript>
 
+#include "qcoreapplicationproto.h"
+
 class QString;
 
 Q_DECLARE_METATYPE(QApplication*)
@@ -26,7 +28,7 @@ Q_DECLARE_METATYPE(QApplication*)
 void setupQApplicationProto(QScriptEngine *engine);
 QScriptValue constructQApplication(QScriptContext *context, QScriptEngine *engine);
 
-class QApplicationProto : public QObject, public QScriptable
+class QApplicationProto : public QCoreApplicationProto
 {
   Q_OBJECT
 

--- a/scriptapi/qcoreapplicationproto.cpp
+++ b/scriptapi/qcoreapplicationproto.cpp
@@ -1,0 +1,221 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which (including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#include "qcoreapplicationproto.h"
+
+QScriptValue QCoreApplicationToScriptValue(QScriptEngine *engine,
+                                           QCoreApplication *const &item)
+{
+  return engine->newQObject(item);
+}
+
+void QCoreApplicationFromScriptValue(const QScriptValue &obj, QCoreApplication *&item)
+{
+  item = qobject_cast<QCoreApplication*>(obj.toQObject());
+}
+
+void setupQCoreApplicationProto(QScriptEngine *engine)
+{
+  qScriptRegisterMetaType(engine, QCoreApplicationToScriptValue, QCoreApplicationFromScriptValue);
+
+  QScriptValue proto = engine->newQObject(new QCoreApplicationProto(engine));
+  engine->setDefaultPrototype(qMetaTypeId<QCoreApplication*>(), proto);
+  engine->globalObject().setProperty("QCoreApplication",
+                                     engine->newQObject(QCoreApplication::instance()));
+}
+
+QCoreApplicationProto::QCoreApplicationProto(QObject *parent)
+  : QObject(parent)
+{
+}
+
+void QCoreApplicationProto::quit()
+{
+  QCoreApplication *item = qscriptvalue_cast<QCoreApplication*>(thisObject());
+  if (item)
+    item->quit();
+}
+
+void QCoreApplicationProto::addLibraryPath(const QString &path)
+{
+  QCoreApplication::addLibraryPath(path);
+}
+
+QString QCoreApplicationProto::applicationDirPath()
+{
+  return QCoreApplication::applicationDirPath();
+}
+
+
+QString QCoreApplicationProto::applicationFilePath()
+{
+  return QCoreApplication::applicationFilePath();
+}
+
+qint64 QCoreApplicationProto::applicationPid()
+{
+  return QCoreApplication::applicationPid();
+}
+
+QStringList QCoreApplicationProto::arguments()
+{
+  return QCoreApplication::arguments();
+}
+
+bool QCoreApplicationProto::closingDown()
+{
+  return QCoreApplication::closingDown();
+}
+
+int QCoreApplicationProto::exec()
+{
+  return QCoreApplication::exec();
+}
+
+void QCoreApplicationProto::exit(int returnCode)
+{
+  QCoreApplication::exit(returnCode);
+}
+
+void QCoreApplicationProto::flush()
+{
+  QCoreApplication::flush();
+}
+
+bool QCoreApplicationProto::hasPendingEvents()
+{
+  return QCoreApplication::hasPendingEvents();
+}
+
+void QCoreApplicationProto::installTranslator(QTranslator *translationFile)
+{
+  QCoreApplication::installTranslator(translationFile);
+}
+
+QCoreApplication *QCoreApplicationProto::instance()
+{
+  return QCoreApplication::instance();
+}
+
+QStringList QCoreApplicationProto::libraryPaths()
+{
+  return QCoreApplication::libraryPaths();
+}
+
+void QCoreApplicationProto::postEvent(QObject *receiver, QEvent *event)
+{
+  QCoreApplication::postEvent(receiver, event);
+}
+
+void QCoreApplicationProto::postEvent(QObject *receiver, QEvent *event, int priority)
+{
+  QCoreApplication::postEvent(receiver, event, priority);
+}
+
+void QCoreApplicationProto::processEvents(QEventLoop::ProcessEventsFlags flags)
+{
+  QCoreApplication::processEvents(flags);
+}
+
+void QCoreApplicationProto::processEvents(QEventLoop::ProcessEventsFlags flags, int maxtime)
+{
+  QCoreApplication::processEvents(flags, maxtime);
+}
+
+void QCoreApplicationProto::removeLibraryPath(const QString &path)
+{
+  QCoreApplication::removeLibraryPath(path);
+}
+
+void QCoreApplicationProto::removePostedEvents(QObject *receiver)
+{
+  QCoreApplication::removePostedEvents(receiver);
+}
+
+void QCoreApplicationProto::removePostedEvents(QObject *receiver, int eventType)
+{
+  QCoreApplication::removePostedEvents(receiver, eventType);
+}
+
+void QCoreApplicationProto::removeTranslator(QTranslator *translationFile)
+{
+  QCoreApplication::removeTranslator(translationFile);
+}
+
+bool QCoreApplicationProto::sendEvent(QObject *receiver, QEvent *event)
+{
+  return QCoreApplication::sendEvent(receiver, event);
+}
+
+void QCoreApplicationProto::sendPostedEvents(QObject *receiver, int event_type)
+{
+  QCoreApplication::sendPostedEvents(receiver, event_type);
+}
+
+void QCoreApplicationProto::sendPostedEvents()
+{
+  QCoreApplication::sendPostedEvents();
+}
+
+void QCoreApplicationProto::setApplicationName(const QString &application)
+{
+  QCoreApplication::setApplicationName(application);
+}
+
+void QCoreApplicationProto::setApplicationVersion(const QString &version)
+{
+  QCoreApplication::setApplicationVersion(version);
+}
+
+void QCoreApplicationProto::setAttribute(Qt::ApplicationAttribute attribute, bool on)
+{
+  QCoreApplication::setAttribute(attribute, on);
+}
+
+void QCoreApplicationProto::setLibraryPaths(const QStringList &paths)
+{
+  QCoreApplication::setLibraryPaths(paths);
+}
+
+void QCoreApplicationProto::setOrganizationDomain(const QString &orgDomain)
+{
+  QCoreApplication::setOrganizationDomain(orgDomain);
+}
+
+void QCoreApplicationProto::setOrganizationName(const QString &orgName)
+{
+  QCoreApplication::setOrganizationName(orgName);
+}
+
+bool QCoreApplicationProto::startingUp()
+{
+  return QCoreApplication::startingUp();
+}
+
+bool QCoreApplicationProto::testAttribute(Qt::ApplicationAttribute attribute)
+{
+  return QCoreApplication::testAttribute(attribute);
+}
+
+QString QCoreApplicationProto::translate(const char *context, const char *sourceText, const char *disambiguation, QCoreApplication::Encoding encoding, int n)
+{
+  return QCoreApplication::translate(context, sourceText, disambiguation, encoding, n);
+}
+
+QString QCoreApplicationProto::translate(const char *context, const char *sourceText, const char *disambiguation, QCoreApplication::Encoding encoding)
+{
+  return QCoreApplication::translate(context, sourceText, disambiguation, encoding);
+}
+
+QString QCoreApplicationProto::toString()
+{
+  return QCoreApplication::applicationName() + " "
+       + QCoreApplication::arguments().join(" ");
+}

--- a/scriptapi/qcoreapplicationproto.h
+++ b/scriptapi/qcoreapplicationproto.h
@@ -1,0 +1,71 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which (including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#ifndef __QCOREAPPLICATIONPROTO_H__
+#define __QCOREAPPLICATIONPROTO_H__
+
+#include <QCoreApplication>
+#include <QObject>
+#include <QtScript>
+
+class QString;
+class QEvent;
+
+Q_DECLARE_METATYPE(QCoreApplication*)
+
+void setupQCoreApplicationProto(QScriptEngine *engine);
+
+class QCoreApplicationProto : public QObject, public QScriptable
+{
+  Q_OBJECT
+
+  public:
+    QCoreApplicationProto(QObject *parent = 0);
+
+    Q_INVOKABLE void quit();
+    Q_INVOKABLE void addLibraryPath(const QString &path);
+    Q_INVOKABLE QString applicationDirPath();
+    Q_INVOKABLE QString applicationFilePath();
+    Q_INVOKABLE qint64 applicationPid();
+    Q_INVOKABLE QStringList arguments();
+    Q_INVOKABLE bool closingDown();
+    Q_INVOKABLE int exec();
+    Q_INVOKABLE void exit(int returnCode);
+    Q_INVOKABLE void flush();
+    Q_INVOKABLE bool hasPendingEvents();
+    Q_INVOKABLE void installTranslator(QTranslator *translationFile);
+    Q_INVOKABLE QCoreApplication *instance();
+    Q_INVOKABLE QStringList libraryPaths();
+    Q_INVOKABLE void postEvent(QObject *receiver, QEvent *event);
+    Q_INVOKABLE void postEvent(QObject *receiver, QEvent *event, int priority);
+    Q_INVOKABLE void processEvents(QEventLoop::ProcessEventsFlags flags);
+    Q_INVOKABLE void processEvents(QEventLoop::ProcessEventsFlags flags, int maxtime);
+    Q_INVOKABLE void removeLibraryPath(const QString &path);
+    Q_INVOKABLE void removePostedEvents(QObject *receiver);
+    Q_INVOKABLE void removePostedEvents(QObject *receiver, int eventType);
+    Q_INVOKABLE void removeTranslator(QTranslator *translationFile);
+    Q_INVOKABLE bool sendEvent(QObject *receiver, QEvent *event);
+    Q_INVOKABLE void sendPostedEvents(QObject *receiver, int event_type);
+    Q_INVOKABLE void sendPostedEvents();
+    Q_INVOKABLE void setApplicationName(const QString &application);
+    Q_INVOKABLE void setApplicationVersion(const QString &version);
+    Q_INVOKABLE void setAttribute(Qt::ApplicationAttribute attribute, bool on);
+    Q_INVOKABLE void setLibraryPaths(const QStringList &paths);
+    Q_INVOKABLE void setOrganizationDomain(const QString &orgDomain);
+    Q_INVOKABLE void setOrganizationName(const QString &orgName);
+    Q_INVOKABLE bool startingUp();
+    Q_INVOKABLE bool testAttribute(Qt::ApplicationAttribute attribute);
+    Q_INVOKABLE QString translate(const char *context, const char *sourceText, const char *disambiguation, QCoreApplication::Encoding encoding, int n);
+    Q_INVOKABLE QString translate(const char *context, const char *sourceText, const char *disambiguation, QCoreApplication::Encoding encoding);
+    Q_INVOKABLE QString toString();
+
+};
+
+#endif

--- a/scriptapi/scriptapi.pro
+++ b/scriptapi/scriptapi.pro
@@ -36,6 +36,7 @@ HEADERS += setupscriptapi.h \
     qapplicationproto.h \
     qboxlayoutproto.h \
     qbytearrayproto.h \
+    qcoreapplicationproto.h     \
     qdialogbuttonboxproto.h \
     qdialogsetup.h \
     qdirproto.h \
@@ -149,6 +150,7 @@ SOURCES += setupscriptapi.cpp \
     qapplicationproto.cpp \
     qboxlayoutproto.cpp \
     qbytearrayproto.cpp \
+    qcoreapplicationproto.cpp   \
     qdialogbuttonboxproto.cpp \
     qdialogsetup.cpp \
     qdirproto.cpp \

--- a/scriptapi/setupscriptapi.cpp
+++ b/scriptapi/setupscriptapi.cpp
@@ -35,6 +35,7 @@
 #include "qapplicationproto.h"
 #include "qboxlayoutproto.h"
 #include "qbytearrayproto.h"
+#include "qcoreapplicationproto.h"
 #include "qdialogsetup.h"
 #include "qdialogbuttonboxproto.h"
 #include "qdirproto.h"
@@ -168,6 +169,7 @@ void setupScriptApi(QScriptEngine *engine)
   setupQApplicationProto(engine);
   setupQBoxLayoutProto(engine);
   setupQByteArrayProto(engine);
+  setupQCoreApplicationProto(engine);
   setupQDialog(engine);
   setupQDialogButtonBoxProto(engine);
   setupQDirProto(engine);


### PR DESCRIPTION
This allows the script that launches the Trojita clients to search starting at the _application_'s directory instead of some arbitrary place (perhaps the user's home directory or current working directory). The fix for the bug itself is in the [connect](https://github.com/xtuple/connect) repository.