### PR TITLE
issue #27365: Item images metasql

### DIFF
--- a/guiclient/images.cpp
+++ b/guiclient/images.cpp
@@ -14,6 +14,8 @@
 #include <QSqlError>
 
 #include <parameter.h>
+#include <metasql.h>
+#include "mqlutil.h"
 
 #include "image.h"
 #include "guiclient.h"
@@ -109,6 +111,10 @@ void images::sFillList()
 {
   XSqlQuery imagesFillList;
   // Do not select image_data into the list
+  MetaSQLQuery mql = mqlLoad("images", "list");
+  ParameterList params;
+  imagesFillList = mql.toQuery(params);
+  /*
   imagesFillList.exec("SELECT image_id, image_name, image_descrip, LENGTH(image_data) AS image_size, "
          "       CASE WHEN nspname='public' THEN ''"
          "            ELSE nspname END AS nspname"
@@ -116,6 +122,7 @@ void images::sFillList()
          " WHERE ((image.tableoid=pg_class.oid)"
          "   AND  (relnamespace=pg_namespace.oid))"
          "ORDER BY image_name;" );
+*/
   _image->populate(imagesFillList);
   if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Retrieving Image Information"),
                                 imagesFillList, __FILE__, __LINE__))

--- a/guiclient/images.cpp
+++ b/guiclient/images.cpp
@@ -34,6 +34,7 @@ images::images(QWidget* parent, const char* name, Qt::WindowFlags fl)
   connect(_close, SIGNAL(clicked()), this, SLOT(close()));
   connect(_edit, SIGNAL(clicked()), this, SLOT(sEdit()));
   connect(_image, SIGNAL(valid(bool)), _edit, SLOT(setEnabled(bool)));
+  connect(_showSize, SIGNAL(clicked()), this, SLOT(sFillList()));
 
   _image->addColumn(tr("Name"),  _itemColumn, Qt::AlignLeft, true, "image_name");
   _image->addColumn(tr("Description"),    -1, Qt::AlignLeft, true, "image_descrip");
@@ -109,9 +110,13 @@ void images::sDelete()
 
 void images::sFillList()
 {
+  _image->setColumnHidden(_image->column("image_size"), !_showSize->isChecked());
   XSqlQuery imagesFillList;
   MetaSQLQuery mql = mqlLoad("images", "list");
   ParameterList params;
+  if (_showSize->isChecked())
+    params.append("displayImageSize", true);
+
   imagesFillList = mql.toQuery(params);
   _image->populate(imagesFillList);
   if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Retrieving Image Information"),

--- a/guiclient/images.cpp
+++ b/guiclient/images.cpp
@@ -110,19 +110,9 @@ void images::sDelete()
 void images::sFillList()
 {
   XSqlQuery imagesFillList;
-  // Do not select image_data into the list
   MetaSQLQuery mql = mqlLoad("images", "list");
   ParameterList params;
   imagesFillList = mql.toQuery(params);
-  /*
-  imagesFillList.exec("SELECT image_id, image_name, image_descrip, LENGTH(image_data) AS image_size, "
-         "       CASE WHEN nspname='public' THEN ''"
-         "            ELSE nspname END AS nspname"
-         "  FROM image, pg_class, pg_namespace "
-         " WHERE ((image.tableoid=pg_class.oid)"
-         "   AND  (relnamespace=pg_namespace.oid))"
-         "ORDER BY image_name;" );
-*/
   _image->populate(imagesFillList);
   if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Retrieving Image Information"),
                                 imagesFillList, __FILE__, __LINE__))

--- a/guiclient/images.ui
+++ b/guiclient/images.ui
@@ -13,8 +13,8 @@ to be bound by its terms.</comment>
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>600</width>
-    <height>400</height>
+    <width>369</width>
+    <height>207</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,11 +27,35 @@ to be bound by its terms.</comment>
       <number>0</number>
      </property>
      <item>
-      <widget class="QLabel" name="_imageLit">
-       <property name="text">
-        <string>Images:</string>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QLabel" name="_imageLit">
+         <property name="text">
+          <string>Images:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="XCheckBox" name="_showSize">
+         <property name="text">
+          <string>Display Image Size</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item>
       <widget class="XTreeWidget" name="_image"/>
@@ -122,6 +146,11 @@ to be bound by its terms.</comment>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
+  <customwidget>
+   <class>XCheckBox</class>
+   <extends>QCheckBox</extends>
+   <header>xcheckbox.h</header>
+  </customwidget>
   <customwidget>
    <class>XTreeWidget</class>
    <extends>QTreeWidget</extends>


### PR DESCRIPTION
Convert Images List from embedded SQL to metaSQL.  Allows choosing to calculate image size or not.  Significant performance gain on Db with a lot of images if the size is not calculated.

Requires xtuple/xtuple#2589