### PR TITLE
Set minimum width of Bank Rec History combobox

### DIFF
--- a/guiclient/dspBankrecHistory.ui
+++ b/guiclient/dspBankrecHistory.ui
@@ -80,7 +80,14 @@ to be bound by its terms.</comment>
           <item row="1" column="1">
            <layout class="QHBoxLayout" name="horizontalLayout_2">
             <item>
-             <widget class="XComboBox" name="_bankrec"/>
+             <widget class="XComboBox" name="_bankrec">
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>0</height>
+               </size>
+              </property>
+             </widget>
             </item>
             <item>
              <spacer name="horizontalSpacer_2">


### PR DESCRIPTION
Was unreadable under some circumstances at customer site.