### PR TITLE
issue #26705, issue #22850 - fix distribution of t/o receipt serial items

### DIFF
--- a/guiclient/xdialog.cpp
+++ b/guiclient/xdialog.cpp
@@ -196,6 +196,6 @@ int XDialog::exec()
 		omfgThis->updateMacDockMenu(this);
 	#endif
 
-	QDialog::exec();
+	return QDialog::exec();
 }
 


### PR DESCRIPTION
Receipts of serial items got really messed up. The distribution windows were not updating themselves properly in response to child dialog success. Therefore, the serial numbers were not being selected, distributed, or otherwise properly recognized.