### PR TITLE
issue #21265 - Column sorting on Bank Reconciliation screen

### DIFF
--- a/guiclient/reconcileBankaccount.cpp
+++ b/guiclient/reconcileBankaccount.cpp
@@ -45,9 +45,9 @@ reconcileBankaccount::reconcileBankaccount(QWidget* parent, const char* name, Qt
     connect(_startDate, SIGNAL(newDate(QDate)), this, SLOT(sDateChanged()));
     connect(_endDate,   SIGNAL(newDate(QDate)), this, SLOT(sDateChanged()));
 
-    _receipts->addColumn(tr("Cleared"),       _ynColumn * 2, Qt::AlignCenter, true, "cleared" );
-    _receipts->addColumn(tr("Date"),            _dateColumn, Qt::AlignCenter, true, "transdate" );
-    _receipts->addColumn(tr("Doc. Type"),     _ynColumn * 2, Qt::AlignCenter, true, "doc_type" );
+    _receipts->addColumn(tr("Cleared"),       _ynColumn * 2, Qt::AlignCenter, true, "cleared");
+    _receipts->addColumn(tr("Date"),            _dateColumn, Qt::AlignCenter, true, "transdate");
+    _receipts->addColumn(tr("Doc. Type"),     _ynColumn * 2, Qt::AlignCenter, true, "doc_type");
     _receipts->addColumn(tr("Doc. Number"),     _itemColumn, Qt::AlignLeft  , true, "doc_number");
     _receipts->addColumn(tr("Notes"),                    -1, Qt::AlignLeft  , true, "notes");
     _receipts->addColumn(tr("Currency"),    _currencyColumn, Qt::AlignCenter, true, "doc_curr");
@@ -339,6 +339,8 @@ void reconcileBankaccount::populate()
   bool cleared = true;
   double amount = 0.0;
   bool amountNull = true;
+  const QString exchangePrecision = "6";
+
   while (rcp.next())
   {
     if(rcp.value("use").toString() == "C/R")
@@ -374,7 +376,7 @@ void reconcileBankaccount::populate()
       lastChild->setText(3, rcp.value("docnumber"));
       lastChild->setText(4, rcp.value("notes"));
       lastChild->setText(5, rcp.value("doc_curr"));
-      lastChild->setText(6, rcp.value("doc_exchrate").isNull() ? tr("?????") : formatNumber(rcp.value("doc_exchrate").toDouble(), 6));
+      lastChild->setNumber(6, rcp.value("doc_exchrate").isNull() ? tr("?????") : rcp.value("doc_exchrate").toDouble(), exchangePrecision);
       lastChild->setNumber(7, rcp.value("base_amount").isNull() ? tr("?????") : rcp.value("base_amount"), "curr");
       lastChild->setNumber(8, rcp.value("amount").isNull() ? tr("?????") : rcp.value("amount"), "curr");
     }
@@ -390,6 +392,7 @@ void reconcileBankaccount::populate()
       amount = 0.0;
       amountNull = true;
       lastChild = 0;
+
       last = new XTreeWidgetItem(_receipts, last, rcp.value("id").toInt(), rcp.value("altid").toInt());
 
       last->setText(0, rcp.value("cleared").toBool() ? tr("Yes") : tr("No"));
@@ -398,7 +401,7 @@ void reconcileBankaccount::populate()
       last->setText(3, rcp.value("docnumber"));
       last->setText(4, rcp.value("notes"));
       last->setText(5, rcp.value("doc_curr"));
-      last->setText(6, rcp.value("doc_exchrate").isNull() ? tr("?????") : formatNumber(rcp.value("doc_exchrate").toDouble(), 6));
+      last->setNumber(6, rcp.value("doc_exchrate").isNull() ? tr("?????") : rcp.value("doc_exchrate").toDouble(), exchangePrecision);
       last->setNumber(7, rcp.value("base_amount").isNull() ? tr("?????") : rcp.value("base_amount"), "curr");
       last->setNumber(8, rcp.value("amount").isNull() ? tr("?????") : rcp.value("amount"), "curr");
     }

--- a/guiclient/reconcileBankaccount.cpp
+++ b/guiclient/reconcileBankaccount.cpp
@@ -52,8 +52,8 @@ reconcileBankaccount::reconcileBankaccount(QWidget* parent, const char* name, Qt
     _receipts->addColumn(tr("Notes"),                    -1, Qt::AlignLeft   );
     _receipts->addColumn(tr("Currency"),    _currencyColumn, Qt::AlignCenter );
     _receipts->addColumn(tr("Exch. Rate"),  _bigMoneyColumn, Qt::AlignRight  );
-    _receipts->addColumn(tr("Base Amount"), _bigMoneyColumn, Qt::AlignRight, true, "base_amount");
-    _receipts->addColumn(tr("Amount"),      _bigMoneyColumn, Qt::AlignRight, true, "amount" );
+    _receipts->addColumn(tr("Base Amount"), _bigMoneyColumn, Qt::AlignRight  );
+    _receipts->addColumn(tr("Amount"),      _bigMoneyColumn, Qt::AlignRight  );
     
     _checks->addColumn(tr("Cleared"),       _ynColumn * 2, Qt::AlignCenter , true, "cleared");
     _checks->addColumn(tr("Date"),            _dateColumn, Qt::AlignCenter , true, "transdate");
@@ -347,13 +347,16 @@ void reconcileBankaccount::populate()
       {
         if(parent != 0)
         {
-          parent->setText(0, (cleared ? tr("Yes") : tr("No")));
-          parent->setText(8, amountNull ? tr("?????") : formatMoney(amount));
-          parent->setNumericRole("curr", "amount");
+          parent->setRawValue(0, (cleared ? tr("Yes") : tr("No")));
+          parent->setRawValue(8, amountNull ? tr("?????") : QVariant(amount));
+          parent->setNumericRole(8, "curr");
         }
         jrnlnum = rcp.value("jrnlnum").toInt();
-        last = new XTreeWidgetItem( _receipts, last,
-          jrnlnum, 9, "", rcp.value("f_jrnldate").toDate(), tr("JS"), rcp.value("jrnlnum"));
+        last = new XTreeWidgetItem( _receipts, last, jrnlnum, 9);
+        last->setRawValue(0, "");
+        last->setRawValue(1, rcp.value("f_jrnldate"));
+        last->setRawValue(2, tr("JS"));
+        last->setRawValue(3, rcp.value("jrnlnum"));
         parent = last;
         cleared = true;
         amount = 0.0;
@@ -364,51 +367,55 @@ void reconcileBankaccount::populate()
       amount += rcp.value("amount").toDouble();
       amountNull = rcp.value("amount").isNull();
       
-      lastChild = new XTreeWidgetItem( parent, lastChild,
-        rcp.value("id").toInt(), rcp.value("altid").toInt(),
-        (rcp.value("cleared").toBool() ? tr("Yes") : tr("No")),
-        rcp.value("f_date").toDate(), rcp.value("doc_type"), rcp.value("docnumber"),
-        rcp.value("notes"),
-        rcp.value("doc_curr"),
-        rcp.value("doc_exchrate").isNull() ? tr("?????") : formatNumber(rcp.value("doc_exchrate").toDouble(), 6), // 6 dp to match bankrec-receipts metasql
-        rcp.value("base_amount").isNull() ? tr("?????") : QVariant(rcp.value("base_amount").toDouble()),
-        rcp.value("amount").isNull() ? tr("?????") : QVariant(rcp.value("amount").toDouble()) );
+      lastChild = new XTreeWidgetItem(parent, lastChild, rcp.value("id").toInt(), rcp.value("altid").toInt());
 
-      lastChild->setNumericRole("curr", "base_amount");
-      lastChild->setNumericRole("curr", "amount");
+      lastChild->setRawValue(0, rcp.value("cleared") ? tr("Yes") : tr("No"));
+      lastChild->setRawValue(1, rcp.value("f_date"));
+      lastChild->setRawValue(2, rcp.value("doc_type"));
+      lastChild->setRawValue(3, rcp.value("docnumber"));
+      lastChild->setRawValue(4, rcp.value("notes"));
+      lastChild->setRawValue(5, rcp.value("doc_curr"));
+      lastChild->setRawValue(6, rcp.value("doc_exchrate").isNull() ? tr("?????") : formatNumber(rcp.value("doc_exchrate").toDouble(), 6));
+      lastChild->setRawValue(7, rcp.value("base_amount").isNull() ? tr("?????") : rcp.value("base_amount"));
+      lastChild->setRawValue(8, rcp.value("amount").isNull() ? tr("?????") : rcp.value("amount"));
+
+      lastChild->setNumericRole(7, "curr");
+      lastChild->setNumericRole(8, "curr");
     }
     else
     {
       if(parent != 0)
       {
-        parent->setText(0, (cleared ? tr("Yes") : tr("No")));
-        parent->setText(8, formatMoney(amount));
-        parent->setNumericRole("curr", "amount");
+        parent->setRawValue(0, (cleared ? tr("Yes") : tr("No")));
+        parent->setRawValue(8, QVariant(amount));
+        parent->setNumericRole(8, "curr");
       }
       parent = 0;
       cleared = true;
       amount = 0.0;
       amountNull = true;
       lastChild = 0;
-      last = new XTreeWidgetItem( _receipts, last,
-        rcp.value("id").toInt(), rcp.value("altid").toInt(),
-        (rcp.value("cleared").toBool() ? tr("Yes") : tr("No")),
-        rcp.value("f_date").toDate(), rcp.value("doc_type"), rcp.value("docnumber"),
-        rcp.value("notes"),
-        rcp.value("doc_curr"),
-        rcp.value("doc_exchrate").isNull() ? tr("?????") : formatNumber(rcp.value("doc_exchrate").toDouble(), 6), // 6 dp to match bankrec-receipts metasql
-        rcp.value("base_amount").isNull() ? tr("?????") : QVariant(rcp.value("base_amount").toDouble()),
-        rcp.value("amount").isNull() ? tr("?????") : QVariant(rcp.value("amount").toDouble()) );
+      last = new XTreeWidgetItem(_receipts, last, rcp.value("id").toInt(), rcp.value("altid").toInt());
 
-      lastChild->setNumericRole("curr", "base_amount");
-      lastChild->setNumericRole("curr", "amount");
+      last->setRawValue(0, rcp.value("cleared") ? tr("Yes") : tr("No"));
+      last->setRawValue(1, rcp.value("f_date"));
+      last->setRawValue(2, rcp.value("doc_type"));
+      last->setRawValue(3, rcp.value("docnumber"));
+      last->setRawValue(4, rcp.value("notes"));
+      last->setRawValue(5, rcp.value("doc_curr"));
+      last->setRawValue(6, rcp.value("doc_exchrate").isNull() ? tr("?????") : formatNumber(rcp.value("doc_exchrate").toDouble(), 6));
+      last->setRawValue(7, rcp.value("base_amount").isNull() ? tr("?????") : rcp.value("base_amount"));
+      last->setRawValue(8, rcp.value("amount").isNull() ? tr("?????") : rcp.value("amount"));
+
+      last->setNumericRole(7, "curr");
+      last->setNumericRole(8, "curr");
     }
   }
   if(parent != 0)
   {
-    parent->setText(0, (cleared ? tr("Yes") : tr("No")));
-    parent->setText(8, amountNull ? tr("?????") : formatMoney(amount));
-    parent->setNumericRole("curr", "amount");
+    parent->setRawValue(0, (cleared ? tr("Yes") : tr("No")));
+    parent->setRawValue(8, amountNull ? tr("?????") : QVariant(amount));
+    parent->setNumericRole(8, "curr");
   }
 
   if(currid != -1)

--- a/guiclient/reconcileBankaccount.cpp
+++ b/guiclient/reconcileBankaccount.cpp
@@ -52,8 +52,8 @@ reconcileBankaccount::reconcileBankaccount(QWidget* parent, const char* name, Qt
     _receipts->addColumn(tr("Notes"),                    -1, Qt::AlignLeft   );
     _receipts->addColumn(tr("Currency"),    _currencyColumn, Qt::AlignCenter );
     _receipts->addColumn(tr("Exch. Rate"),  _bigMoneyColumn, Qt::AlignRight  );
-    _receipts->addColumn(tr("Base Amount"), _bigMoneyColumn, Qt::AlignRight  );
-    _receipts->addColumn(tr("Amount"),      _bigMoneyColumn, Qt::AlignRight  );
+    _receipts->addColumn(tr("Base Amount"), _bigMoneyColumn, Qt::AlignRight, true, "base_amount");
+    _receipts->addColumn(tr("Amount"),      _bigMoneyColumn, Qt::AlignRight, true, "amount" );
     
     _checks->addColumn(tr("Cleared"),       _ynColumn * 2, Qt::AlignCenter , true, "cleared");
     _checks->addColumn(tr("Date"),            _dateColumn, Qt::AlignCenter , true, "transdate");
@@ -349,6 +349,7 @@ void reconcileBankaccount::populate()
         {
           parent->setText(0, (cleared ? tr("Yes") : tr("No")));
           parent->setText(8, amountNull ? tr("?????") : formatMoney(amount));
+          parent->setNumericRole("curr", "amount");
         }
         jrnlnum = rcp.value("jrnlnum").toInt();
         last = new XTreeWidgetItem( _receipts, last,
@@ -372,6 +373,9 @@ void reconcileBankaccount::populate()
         rcp.value("doc_exchrate").isNull() ? tr("?????") : formatNumber(rcp.value("doc_exchrate").toDouble(), 6), // 6 dp to match bankrec-receipts metasql
         rcp.value("base_amount").isNull() ? tr("?????") : QVariant(rcp.value("base_amount").toDouble()),
         rcp.value("amount").isNull() ? tr("?????") : QVariant(rcp.value("amount").toDouble()) );
+
+      lastChild->setNumericRole("curr", "base_amount");
+      lastChild->setNumericRole("curr", "amount");
     }
     else
     {
@@ -379,6 +383,7 @@ void reconcileBankaccount::populate()
       {
         parent->setText(0, (cleared ? tr("Yes") : tr("No")));
         parent->setText(8, formatMoney(amount));
+        parent->setNumericRole("curr", "amount");
       }
       parent = 0;
       cleared = true;
@@ -394,12 +399,16 @@ void reconcileBankaccount::populate()
         rcp.value("doc_exchrate").isNull() ? tr("?????") : formatNumber(rcp.value("doc_exchrate").toDouble(), 6), // 6 dp to match bankrec-receipts metasql
         rcp.value("base_amount").isNull() ? tr("?????") : QVariant(rcp.value("base_amount").toDouble()),
         rcp.value("amount").isNull() ? tr("?????") : QVariant(rcp.value("amount").toDouble()) );
+
+      lastChild->setNumericRole("curr", "base_amount");
+      lastChild->setNumericRole("curr", "amount");
     }
   }
   if(parent != 0)
   {
     parent->setText(0, (cleared ? tr("Yes") : tr("No")));
     parent->setText(8, amountNull ? tr("?????") : formatMoney(amount));
+    parent->setNumericRole("curr", "amount");
   }
 
   if(currid != -1)

--- a/guiclient/reconcileBankaccount.cpp
+++ b/guiclient/reconcileBankaccount.cpp
@@ -45,15 +45,15 @@ reconcileBankaccount::reconcileBankaccount(QWidget* parent, const char* name, Qt
     connect(_startDate, SIGNAL(newDate(QDate)), this, SLOT(sDateChanged()));
     connect(_endDate,   SIGNAL(newDate(QDate)), this, SLOT(sDateChanged()));
 
-    _receipts->addColumn(tr("Cleared"),       _ynColumn * 2, Qt::AlignCenter );
-    _receipts->addColumn(tr("Date"),            _dateColumn, Qt::AlignCenter );
-    _receipts->addColumn(tr("Doc. Type"),     _ynColumn * 2, Qt::AlignCenter );
-    _receipts->addColumn(tr("Doc. Number"),     _itemColumn, Qt::AlignLeft   );
-    _receipts->addColumn(tr("Notes"),                    -1, Qt::AlignLeft   );
-    _receipts->addColumn(tr("Currency"),    _currencyColumn, Qt::AlignCenter );
-    _receipts->addColumn(tr("Exch. Rate"),  _bigMoneyColumn, Qt::AlignRight  );
-    _receipts->addColumn(tr("Base Amount"), _bigMoneyColumn, Qt::AlignRight  );
-    _receipts->addColumn(tr("Amount"),      _bigMoneyColumn, Qt::AlignRight  );
+    _receipts->addColumn(tr("Cleared"),       _ynColumn * 2, Qt::AlignCenter, true, "cleared" );
+    _receipts->addColumn(tr("Date"),            _dateColumn, Qt::AlignCenter, true, "transdate" );
+    _receipts->addColumn(tr("Doc. Type"),     _ynColumn * 2, Qt::AlignCenter, true, "doc_type" );
+    _receipts->addColumn(tr("Doc. Number"),     _itemColumn, Qt::AlignLeft  , true, "doc_number");
+    _receipts->addColumn(tr("Notes"),                    -1, Qt::AlignLeft  , true, "notes");
+    _receipts->addColumn(tr("Currency"),    _currencyColumn, Qt::AlignCenter, true, "doc_curr");
+    _receipts->addColumn(tr("Exch. Rate"),  _bigMoneyColumn, Qt::AlignRight , true, "doc_exchrate");
+    _receipts->addColumn(tr("Base Amount"), _bigMoneyColumn, Qt::AlignRight , true, "base_amount");
+    _receipts->addColumn(tr("Amount"),      _bigMoneyColumn, Qt::AlignRight , true, "amount");
     
     _checks->addColumn(tr("Cleared"),       _ynColumn * 2, Qt::AlignCenter , true, "cleared");
     _checks->addColumn(tr("Date"),            _dateColumn, Qt::AlignCenter , true, "transdate");

--- a/guiclient/reconcileBankaccount.cpp
+++ b/guiclient/reconcileBankaccount.cpp
@@ -352,7 +352,7 @@ void reconcileBankaccount::populate()
         }
         jrnlnum = rcp.value("jrnlnum").toInt();
         last = new XTreeWidgetItem( _receipts, last,
-          jrnlnum, 9, "", formatDate(rcp.value("f_jrnldate").toDate()), tr("JS"), rcp.value("jrnlnum"));
+          jrnlnum, 9, "", rcp.value("f_jrnldate").toDate(), tr("JS"), rcp.value("jrnlnum"));
         parent = last;
         cleared = true;
         amount = 0.0;
@@ -366,12 +366,12 @@ void reconcileBankaccount::populate()
       lastChild = new XTreeWidgetItem( parent, lastChild,
         rcp.value("id").toInt(), rcp.value("altid").toInt(),
         (rcp.value("cleared").toBool() ? tr("Yes") : tr("No")),
-        formatDate(rcp.value("f_date").toDate()), rcp.value("doc_type"), rcp.value("docnumber"),
+        rcp.value("f_date").toDate(), rcp.value("doc_type"), rcp.value("docnumber"),
         rcp.value("notes"),
         rcp.value("doc_curr"),
         rcp.value("doc_exchrate").isNull() ? tr("?????") : formatNumber(rcp.value("doc_exchrate").toDouble(), 6), // 6 dp to match bankrec-receipts metasql
-        rcp.value("base_amount").isNull() ? tr("?????") : formatMoney(rcp.value("base_amount").toDouble()),
-        rcp.value("amount").isNull() ? tr("?????") : formatMoney(rcp.value("amount").toDouble()) );
+        rcp.value("base_amount").isNull() ? tr("?????") : rcp.value("base_amount").toDouble(),
+        rcp.value("amount").isNull() ? tr("?????") : rcp.value("amount").toDouble() );
     }
     else
     {
@@ -388,12 +388,12 @@ void reconcileBankaccount::populate()
       last = new XTreeWidgetItem( _receipts, last,
         rcp.value("id").toInt(), rcp.value("altid").toInt(),
         (rcp.value("cleared").toBool() ? tr("Yes") : tr("No")),
-        formatDate(rcp.value("f_date").toDate()), rcp.value("doc_type"), rcp.value("docnumber"),
+        rcp.value("f_date").toDate(), rcp.value("doc_type"), rcp.value("docnumber"),
         rcp.value("notes"),
         rcp.value("doc_curr"),
         rcp.value("doc_exchrate").isNull() ? tr("?????") : formatNumber(rcp.value("doc_exchrate").toDouble(), 6), // 6 dp to match bankrec-receipts metasql
-        rcp.value("base_amount").isNull() ? tr("?????") : formatMoney(rcp.value("base_amount").toDouble()),
-        rcp.value("amount").isNull() ? tr("?????") : formatMoney(rcp.value("amount").toDouble()) );
+        rcp.value("base_amount").isNull() ? tr("?????") : rcp.value("base_amount").toDouble(),
+        rcp.value("amount").isNull() ? tr("?????") : rcp.value("amount").toDouble() );
     }
   }
   if(parent != 0)

--- a/guiclient/reconcileBankaccount.cpp
+++ b/guiclient/reconcileBankaccount.cpp
@@ -348,13 +348,12 @@ void reconcileBankaccount::populate()
         if(parent != 0)
         {
           parent->setText(0, (cleared ? tr("Yes") : tr("No")));
-          parent->setRawValue(8, amountNull ? tr("?????") : QVariant(amount));
-          parent->setNumericRole(8, "curr");
+          parent->setNumber(8, amountNull ? tr("?????") : QVariant(amount), "curr");
         }
         jrnlnum = rcp.value("jrnlnum").toInt();
         last = new XTreeWidgetItem( _receipts, last, jrnlnum, 9);
         last->setText(0, "");
-        last->setRawValue(1, rcp.value("f_jrnldate").toDate());
+        last->setDate(1, rcp.value("f_jrnldate").toDate());
         last->setText(2, tr("JS"));
         last->setText(3, rcp.value("jrnlnum"));
         parent = last;
@@ -370,25 +369,21 @@ void reconcileBankaccount::populate()
       lastChild = new XTreeWidgetItem(parent, lastChild, rcp.value("id").toInt(), rcp.value("altid").toInt());
 
       lastChild->setText(0, rcp.value("cleared").toBool() ? tr("Yes") : tr("No"));
-      lastChild->setRawValue(1, rcp.value("f_date").toDate());
+      lastChild->setDate(1, rcp.value("f_date").toDate());
       lastChild->setText(2, rcp.value("doc_type"));
       lastChild->setText(3, rcp.value("docnumber"));
       lastChild->setText(4, rcp.value("notes"));
       lastChild->setText(5, rcp.value("doc_curr"));
-      lastChild->setRawValue(6, rcp.value("doc_exchrate").isNull() ? tr("?????") : formatNumber(rcp.value("doc_exchrate").toDouble(), 6));
-      lastChild->setRawValue(7, rcp.value("base_amount").isNull() ? tr("?????") : rcp.value("base_amount"));
-      lastChild->setRawValue(8, rcp.value("amount").isNull() ? tr("?????") : rcp.value("amount"));
-
-      lastChild->setNumericRole(7, "curr");
-      lastChild->setNumericRole(8, "curr");
+      lastChild->setText(6, rcp.value("doc_exchrate").isNull() ? tr("?????") : formatNumber(rcp.value("doc_exchrate").toDouble(), 6));
+      lastChild->setNumber(7, rcp.value("base_amount").isNull() ? tr("?????") : rcp.value("base_amount"), "curr");
+      lastChild->setNumber(8, rcp.value("amount").isNull() ? tr("?????") : rcp.value("amount"), "curr");
     }
     else
     {
       if(parent != 0)
       {
         parent->setText(0, (cleared ? tr("Yes") : tr("No")));
-        parent->setRawValue(8, QVariant(amount));
-        parent->setNumericRole(8, "curr");
+        parent->setNumber(8, QVariant(amount), "curr");
       }
       parent = 0;
       cleared = true;
@@ -397,25 +392,21 @@ void reconcileBankaccount::populate()
       lastChild = 0;
       last = new XTreeWidgetItem(_receipts, last, rcp.value("id").toInt(), rcp.value("altid").toInt());
 
-      last->setRawValue(0, rcp.value("cleared").toBool() ? tr("Yes") : tr("No"));
-      last->setRawValue(1, rcp.value("f_date").toDate());
+      last->setText(0, rcp.value("cleared").toBool() ? tr("Yes") : tr("No"));
+      last->setDate(1, rcp.value("f_date").toDate());
       last->setText(2, rcp.value("doc_type"));
       last->setText(3, rcp.value("docnumber"));
       last->setText(4, rcp.value("notes"));
       last->setText(5, rcp.value("doc_curr"));
-      last->setRawValue(6, rcp.value("doc_exchrate").isNull() ? tr("?????") : formatNumber(rcp.value("doc_exchrate").toDouble(), 6));
-      last->setRawValue(7, rcp.value("base_amount").isNull() ? tr("?????") : rcp.value("base_amount"));
-      last->setRawValue(8, rcp.value("amount").isNull() ? tr("?????") : rcp.value("amount"));
-
-      last->setNumericRole(7, "curr");
-      last->setNumericRole(8, "curr");
+      last->setText(6, rcp.value("doc_exchrate").isNull() ? tr("?????") : formatNumber(rcp.value("doc_exchrate").toDouble(), 6));
+      last->setNumber(7, rcp.value("base_amount").isNull() ? tr("?????") : rcp.value("base_amount"), "curr");
+      last->setNumber(8, rcp.value("amount").isNull() ? tr("?????") : rcp.value("amount"), "curr");
     }
   }
   if(parent != 0)
   {
     parent->setText(0, (cleared ? tr("Yes") : tr("No")));
-    parent->setRawValue(8, amountNull ? tr("?????") : QVariant(amount));
-    parent->setNumericRole(8, "curr");
+    parent->setNumber(8, amountNull ? tr("?????") : QVariant(amount), "curr");
   }
 
   if(currid != -1)

--- a/guiclient/reconcileBankaccount.cpp
+++ b/guiclient/reconcileBankaccount.cpp
@@ -370,8 +370,8 @@ void reconcileBankaccount::populate()
         rcp.value("notes"),
         rcp.value("doc_curr"),
         rcp.value("doc_exchrate").isNull() ? tr("?????") : formatNumber(rcp.value("doc_exchrate").toDouble(), 6), // 6 dp to match bankrec-receipts metasql
-        rcp.value("base_amount").isNull() ? tr("?????") : rcp.value("base_amount").toDouble(),
-        rcp.value("amount").isNull() ? tr("?????") : rcp.value("amount").toDouble() );
+        rcp.value("base_amount").isNull() ? tr("?????") : QVariant(rcp.value("base_amount").toDouble()),
+        rcp.value("amount").isNull() ? tr("?????") : QVariant(rcp.value("amount").toDouble()) );
     }
     else
     {
@@ -392,8 +392,8 @@ void reconcileBankaccount::populate()
         rcp.value("notes"),
         rcp.value("doc_curr"),
         rcp.value("doc_exchrate").isNull() ? tr("?????") : formatNumber(rcp.value("doc_exchrate").toDouble(), 6), // 6 dp to match bankrec-receipts metasql
-        rcp.value("base_amount").isNull() ? tr("?????") : rcp.value("base_amount").toDouble(),
-        rcp.value("amount").isNull() ? tr("?????") : rcp.value("amount").toDouble() );
+        rcp.value("base_amount").isNull() ? tr("?????") : QVariant(rcp.value("base_amount").toDouble()),
+        rcp.value("amount").isNull() ? tr("?????") : QVariant(rcp.value("amount").toDouble()) );
     }
   }
   if(parent != 0)

--- a/guiclient/reconcileBankaccount.cpp
+++ b/guiclient/reconcileBankaccount.cpp
@@ -376,7 +376,7 @@ void reconcileBankaccount::populate()
       lastChild->setText(3, rcp.value("docnumber"));
       lastChild->setText(4, rcp.value("notes"));
       lastChild->setText(5, rcp.value("doc_curr"));
-      lastChild->setNumber(6, rcp.value("doc_exchrate").isNull() ? tr("?????") : rcp.value("doc_exchrate").toDouble(), exchangePrecision);
+      lastChild->setNumber(6, rcp.value("doc_exchrate").isNull() ? tr("?????") : rcp.value("doc_exchrate"), exchangePrecision);
       lastChild->setNumber(7, rcp.value("base_amount").isNull() ? tr("?????") : rcp.value("base_amount"), "curr");
       lastChild->setNumber(8, rcp.value("amount").isNull() ? tr("?????") : rcp.value("amount"), "curr");
     }
@@ -401,7 +401,7 @@ void reconcileBankaccount::populate()
       last->setText(3, rcp.value("docnumber"));
       last->setText(4, rcp.value("notes"));
       last->setText(5, rcp.value("doc_curr"));
-      last->setNumber(6, rcp.value("doc_exchrate").isNull() ? tr("?????") : rcp.value("doc_exchrate").toDouble(), exchangePrecision);
+      last->setNumber(6, rcp.value("doc_exchrate").isNull() ? tr("?????") : rcp.value("doc_exchrate"), exchangePrecision);
       last->setNumber(7, rcp.value("base_amount").isNull() ? tr("?????") : rcp.value("base_amount"), "curr");
       last->setNumber(8, rcp.value("amount").isNull() ? tr("?????") : rcp.value("amount"), "curr");
     }

--- a/guiclient/reconcileBankaccount.cpp
+++ b/guiclient/reconcileBankaccount.cpp
@@ -369,7 +369,7 @@ void reconcileBankaccount::populate()
       
       lastChild = new XTreeWidgetItem(parent, lastChild, rcp.value("id").toInt(), rcp.value("altid").toInt());
 
-      lastChild->setRawValue(0, rcp.value("cleared") ? tr("Yes") : tr("No"));
+      lastChild->setRawValue(0, rcp.value("cleared").toBool() ? tr("Yes") : tr("No"));
       lastChild->setRawValue(1, rcp.value("f_date"));
       lastChild->setRawValue(2, rcp.value("doc_type"));
       lastChild->setRawValue(3, rcp.value("docnumber"));
@@ -397,7 +397,7 @@ void reconcileBankaccount::populate()
       lastChild = 0;
       last = new XTreeWidgetItem(_receipts, last, rcp.value("id").toInt(), rcp.value("altid").toInt());
 
-      last->setRawValue(0, rcp.value("cleared") ? tr("Yes") : tr("No"));
+      last->setRawValue(0, rcp.value("cleared").toBool() ? tr("Yes") : tr("No"));
       last->setRawValue(1, rcp.value("f_date"));
       last->setRawValue(2, rcp.value("doc_type"));
       last->setRawValue(3, rcp.value("docnumber"));

--- a/guiclient/reconcileBankaccount.cpp
+++ b/guiclient/reconcileBankaccount.cpp
@@ -347,16 +347,16 @@ void reconcileBankaccount::populate()
       {
         if(parent != 0)
         {
-          parent->setRawValue(0, (cleared ? tr("Yes") : tr("No")));
+          parent->setText(0, (cleared ? tr("Yes") : tr("No")));
           parent->setRawValue(8, amountNull ? tr("?????") : QVariant(amount));
           parent->setNumericRole(8, "curr");
         }
         jrnlnum = rcp.value("jrnlnum").toInt();
         last = new XTreeWidgetItem( _receipts, last, jrnlnum, 9);
-        last->setRawValue(0, "");
-        last->setRawValue(1, rcp.value("f_jrnldate"));
-        last->setRawValue(2, tr("JS"));
-        last->setRawValue(3, rcp.value("jrnlnum"));
+        last->setText(0, "");
+        last->setRawValue(1, rcp.value("f_jrnldate").toDate());
+        last->setText(2, tr("JS"));
+        last->setText(3, rcp.value("jrnlnum"));
         parent = last;
         cleared = true;
         amount = 0.0;
@@ -369,12 +369,12 @@ void reconcileBankaccount::populate()
       
       lastChild = new XTreeWidgetItem(parent, lastChild, rcp.value("id").toInt(), rcp.value("altid").toInt());
 
-      lastChild->setRawValue(0, rcp.value("cleared").toBool() ? tr("Yes") : tr("No"));
-      lastChild->setRawValue(1, rcp.value("f_date"));
-      lastChild->setRawValue(2, rcp.value("doc_type"));
-      lastChild->setRawValue(3, rcp.value("docnumber"));
-      lastChild->setRawValue(4, rcp.value("notes"));
-      lastChild->setRawValue(5, rcp.value("doc_curr"));
+      lastChild->setText(0, rcp.value("cleared").toBool() ? tr("Yes") : tr("No"));
+      lastChild->setRawValue(1, rcp.value("f_date").toDate());
+      lastChild->setText(2, rcp.value("doc_type"));
+      lastChild->setText(3, rcp.value("docnumber"));
+      lastChild->setText(4, rcp.value("notes"));
+      lastChild->setText(5, rcp.value("doc_curr"));
       lastChild->setRawValue(6, rcp.value("doc_exchrate").isNull() ? tr("?????") : formatNumber(rcp.value("doc_exchrate").toDouble(), 6));
       lastChild->setRawValue(7, rcp.value("base_amount").isNull() ? tr("?????") : rcp.value("base_amount"));
       lastChild->setRawValue(8, rcp.value("amount").isNull() ? tr("?????") : rcp.value("amount"));
@@ -386,7 +386,7 @@ void reconcileBankaccount::populate()
     {
       if(parent != 0)
       {
-        parent->setRawValue(0, (cleared ? tr("Yes") : tr("No")));
+        parent->setText(0, (cleared ? tr("Yes") : tr("No")));
         parent->setRawValue(8, QVariant(amount));
         parent->setNumericRole(8, "curr");
       }
@@ -398,11 +398,11 @@ void reconcileBankaccount::populate()
       last = new XTreeWidgetItem(_receipts, last, rcp.value("id").toInt(), rcp.value("altid").toInt());
 
       last->setRawValue(0, rcp.value("cleared").toBool() ? tr("Yes") : tr("No"));
-      last->setRawValue(1, rcp.value("f_date"));
-      last->setRawValue(2, rcp.value("doc_type"));
-      last->setRawValue(3, rcp.value("docnumber"));
-      last->setRawValue(4, rcp.value("notes"));
-      last->setRawValue(5, rcp.value("doc_curr"));
+      last->setRawValue(1, rcp.value("f_date").toDate());
+      last->setText(2, rcp.value("doc_type"));
+      last->setText(3, rcp.value("docnumber"));
+      last->setText(4, rcp.value("notes"));
+      last->setText(5, rcp.value("doc_curr"));
       last->setRawValue(6, rcp.value("doc_exchrate").isNull() ? tr("?????") : formatNumber(rcp.value("doc_exchrate").toDouble(), 6));
       last->setRawValue(7, rcp.value("base_amount").isNull() ? tr("?????") : rcp.value("base_amount"));
       last->setRawValue(8, rcp.value("amount").isNull() ? tr("?????") : rcp.value("amount"));
@@ -413,7 +413,7 @@ void reconcileBankaccount::populate()
   }
   if(parent != 0)
   {
-    parent->setRawValue(0, (cleared ? tr("Yes") : tr("No")));
+    parent->setText(0, (cleared ? tr("Yes") : tr("No")));
     parent->setRawValue(8, amountNull ? tr("?????") : QVariant(amount));
     parent->setNumericRole(8, "curr");
   }

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -762,6 +762,7 @@ void XTreeWidget::populateWorker()
     cleanupAfterPopulate();
 
     populateCalculatedColumns();
+qDebug("Checking for sortColumn() >= 0");
     if (sortColumn() >= 0 && header()->isSortIndicatorShown())
       sortItems(sortColumn(), header()->sortIndicatorOrder());
 
@@ -896,6 +897,7 @@ void XTreeWidget::addColumn(const QString &pString, int pWidth, int pAlignment, 
       roles->insert("qtdisplayrole", pDisplayColumn);
 
     _roles.insert(column, roles);
+qDebug("Adding role %s " + qPrintable(column));
   }
 
   _defaultColumnWidths.insert(column, pWidth);
@@ -1664,9 +1666,11 @@ void XTreeWidget::mouseMoveEvent(QMouseEvent *event)
 
 void XTreeWidget::sHeaderClicked(int column)
 {
+qDebug("sHeaderClicked");
   // Qt::SortOrder sortOrder = Qt::DescendingOrder;
   if (!header()->isSortIndicatorShown())
     header()->setSortIndicatorShown(true);
+qDebug("About to sortItems");
   sortItems(column, header()->sortIndicatorOrder());
 }
 

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -1978,7 +1978,11 @@ QVariant XTreeWidgetItem::rawValue(const QString pName)
 void XTreeWidgetItem::setNumber(int pColumn, const QVariant pValue, const QString pNumericRole)
 {
   setData(pColumn, Xt::RawRole, pValue);
-  setNumericRole(pColumn, pNumericRole);
+  if (!setNumericRole(pColumn, pNumericRole))
+  {
+    // pValue is not a valid number
+    setText(pColumn, pValue);
+  }
 }
 
 void XTreeWidgetItem::setDate(int pColumn, const QDate pDate)
@@ -1987,11 +1991,12 @@ void XTreeWidgetItem::setDate(int pColumn, const QDate pDate)
   setData(pColumn, Qt::DisplayRole, formatDate(pDate));
 }
 
-void XTreeWidgetItem::setNumericRole(int pColIdx, const QString pRole)
+bool XTreeWidgetItem::setNumericRole(int pColIdx, const QString pRole)
 {
+  bool canConvert = false;
+
   if (pColIdx >= 0)
   {
-    bool canConvert = false;
     double value = data(pColIdx, Xt::RawRole).toDouble(&canConvert);
 
     if (canConvert)
@@ -1999,6 +2004,7 @@ void XTreeWidgetItem::setNumericRole(int pColIdx, const QString pRole)
       setData(pColIdx, Qt::DisplayRole, QLocale().toString(value, 'f', decimalPlaces(pRole)));
     }
   }
+  return canConvert;
 }
 
 /* Calculate the total for a particular XTreeWidgetItem, including any children.

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -1983,7 +1983,7 @@ void XTreeWidgetItem::setNumber(int pColumn, const QVariant pValue, const QStrin
 
 void XTreeWidgetItem::setDate(int pColumn, const QDate pDate)
 {
-  setData(pColumn, Xt::RawRole, pValue);
+  setData(pColumn, Xt::RawRole, pDate);
   setData(pColumn, Qt::DisplayRole, formatDate(pDate));
 }
 

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -1975,7 +1975,7 @@ QVariant XTreeWidgetItem::rawValue(const QString pName)
     return data(colIdx, Xt::RawRole);
 }
 
-void XTreeWidgetItem::setRawValue(int pColumn, const QVariant &pValue)
+void XTreeWidgetItem::setRawValue(int pColumn, const QVariant pValue)
 {
   setData(pColumn, Xt::RawRole, pValue);
 }

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -989,6 +989,7 @@ bool XTreeWidgetItem::operator<(const XTreeWidgetItem &other) const
       break;
 
     case QVariant::Date:
+qDebug("Comparing dates.");
       returnVal = (v1.toDate() < v2.toDate());
       break;
 
@@ -997,6 +998,7 @@ bool XTreeWidgetItem::operator<(const XTreeWidgetItem &other) const
       break;
 
     case QVariant::Double:
+qDebug("Comparing doubles.");
       returnVal = (v1.toDouble() < v2.toDouble());
       break;
 
@@ -1009,6 +1011,7 @@ bool XTreeWidgetItem::operator<(const XTreeWidgetItem &other) const
       break;
 
     case QVariant::String:
+qDebug("Comparint strings.");
       bool ok;
       if (v1.toString().toDouble() == 0.0 && v2.toDouble() == 0.0)
         returnVal = (v1.toString() < v2.toString());

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -1975,9 +1975,16 @@ QVariant XTreeWidgetItem::rawValue(const QString pName)
     return data(colIdx, Xt::RawRole);
 }
 
-void XTreeWidgetItem::setRawValue(int pColumn, const QVariant pValue)
+void XTreeWidgetItem::setNumber(int pColumn, const QVariant pValue, const QString pNumericRole)
 {
   setData(pColumn, Xt::RawRole, pValue);
+  setNumericRole(pColumn, pNumericRole);
+}
+
+void XTreeWidgetItem::setDate(int pColumn, const QDate pDate)
+{
+  setData(pColumn, Xt::RawRole, pValue);
+  setData(pColumn, Qt::DisplayRole, formatDate(pDate));
 }
 
 void XTreeWidgetItem::setNumericRole(int pColIdx, const QString pRole)

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -1975,13 +1975,17 @@ QVariant XTreeWidgetItem::rawValue(const QString pName)
     return data(colIdx, Xt::RawRole);
 }
 
-void XTreeWidgetItem::setNumericRole(const QString pRole, const QString pColumn)
+void XTreeWidgetItem::setRawValue(int pColumn, const QVariant &pValue)
 {
-  int colIdx = ((XTreeWidget *)treeWidget())->column(pColumn);
-  if (colIdx >= 0)
+  setData(pColumn, Qt::RawRole, pValue);
+}
+
+void XTreeWidgetItem::setNumericRole(int pColIdx, const QString pRole)
+{
+  if (pColIdx >= 0)
   {
     bool canConvert = false;
-    double value = text(pColumn).toDouble(&canConvert);
+    double value = data(pColIdx, Xt::RawRole).toDouble(&canConvert);
 
     if (canConvert)
     {

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -1977,7 +1977,7 @@ QVariant XTreeWidgetItem::rawValue(const QString pName)
 
 void XTreeWidgetItem::setRawValue(int pColumn, const QVariant &pValue)
 {
-  setData(pColumn, Qt::RawRole, pValue);
+  setData(pColumn, Xt::RawRole, pValue);
 }
 
 void XTreeWidgetItem::setNumericRole(int pColIdx, const QString pRole)

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -1989,7 +1989,7 @@ void XTreeWidgetItem::setNumericRole(int pColIdx, const QString pRole)
 
     if (canConvert)
     {
-      setData(colIdx, Qt::DisplayRole, QLocale().toString(value, 'f', decimalPlaces(pRole)));
+      setData(pColIdx, Qt::DisplayRole, QLocale().toString(value, 'f', decimalPlaces(pRole)));
     }
   }
 }

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -1985,10 +1985,10 @@ void XTreeWidgetItem::setNumber(int pColumn, const QVariant pValue, const QStrin
   }
 }
 
-void XTreeWidgetItem::setDate(int pColumn, const QDate pDate)
+void XTreeWidgetItem::setDate(int pColumn, const QVariant pDate)
 {
   setData(pColumn, Xt::RawRole, pDate);
-  setData(pColumn, Qt::DisplayRole, formatDate(pDate));
+  setData(pColumn, Qt::DisplayRole, formatDate(pDate.toDate()));
 }
 
 bool XTreeWidgetItem::setNumericRole(int pColIdx, const QString pRole)

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -1011,7 +1011,7 @@ qDebug("Comparing doubles.");
       break;
 
     case QVariant::String:
-qDebug("Comparint strings.");
+qDebug("Comparing strings.");
       bool ok;
       if (v1.toString().toDouble() == 0.0 && v2.toDouble() == 0.0)
         returnVal = (v1.toString() < v2.toString());
@@ -1091,10 +1091,12 @@ bool XTreeWidgetItem::operator>(const XTreeWidgetItem &other) const
 void XTreeWidget::sortItems(int column, Qt::SortOrder order)
 {
   int previd = id();
+qDebug("Starting sort...");
 
   // if old style then maintain backwards compatibility
   if (_roles.size() <= 0)
   {
+qDebug("Old style sort.");
     QTreeWidget::sortItems(column, order);
     return;
   }
@@ -1103,6 +1105,7 @@ void XTreeWidget::sortItems(int column, Qt::SortOrder order)
       headerItem()->data(column, Qt::UserRole).toString() == "xtrunningrole")
     return;
 
+qDebug("New style sort.");
   header()->setSortIndicator(column, order);
 
   // simple insertion sort using binary search to find the right insertion pt

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -897,7 +897,7 @@ void XTreeWidget::addColumn(const QString &pString, int pWidth, int pAlignment, 
       roles->insert("qtdisplayrole", pDisplayColumn);
 
     _roles.insert(column, roles);
-qDebug("Adding role %s " + qPrintable(column));
+qDebug("Adding role %s ", qPrintable(column));
   }
 
   _defaultColumnWidths.insert(column, pWidth);

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -762,7 +762,6 @@ void XTreeWidget::populateWorker()
     cleanupAfterPopulate();
 
     populateCalculatedColumns();
-qDebug("Checking for sortColumn() >= 0");
     if (sortColumn() >= 0 && header()->isSortIndicatorShown())
       sortItems(sortColumn(), header()->sortIndicatorOrder());
 
@@ -897,7 +896,6 @@ void XTreeWidget::addColumn(const QString &pString, int pWidth, int pAlignment, 
       roles->insert("qtdisplayrole", pDisplayColumn);
 
     _roles.insert(column, roles);
-qDebug("Adding role %s ", qPrintable(column));
   }
 
   _defaultColumnWidths.insert(column, pWidth);
@@ -991,7 +989,6 @@ bool XTreeWidgetItem::operator<(const XTreeWidgetItem &other) const
       break;
 
     case QVariant::Date:
-qDebug("Comparing dates.");
       returnVal = (v1.toDate() < v2.toDate());
       break;
 
@@ -1000,7 +997,6 @@ qDebug("Comparing dates.");
       break;
 
     case QVariant::Double:
-qDebug("Comparing doubles.");
       returnVal = (v1.toDouble() < v2.toDouble());
       break;
 
@@ -1013,7 +1009,6 @@ qDebug("Comparing doubles.");
       break;
 
     case QVariant::String:
-qDebug("Comparing strings.");
       bool ok;
       if (v1.toString().toDouble() == 0.0 && v2.toDouble() == 0.0)
         returnVal = (v1.toString() < v2.toString());
@@ -1093,12 +1088,10 @@ bool XTreeWidgetItem::operator>(const XTreeWidgetItem &other) const
 void XTreeWidget::sortItems(int column, Qt::SortOrder order)
 {
   int previd = id();
-qDebug("Starting sort...");
 
   // if old style then maintain backwards compatibility
   if (_roles.size() <= 0)
   {
-qDebug("Old style sort.");
     QTreeWidget::sortItems(column, order);
     return;
   }
@@ -1107,7 +1100,6 @@ qDebug("Old style sort.");
       headerItem()->data(column, Qt::UserRole).toString() == "xtrunningrole")
     return;
 
-qDebug("New style sort.");
   header()->setSortIndicator(column, order);
 
   // simple insertion sort using binary search to find the right insertion pt
@@ -1666,11 +1658,9 @@ void XTreeWidget::mouseMoveEvent(QMouseEvent *event)
 
 void XTreeWidget::sHeaderClicked(int column)
 {
-qDebug("sHeaderClicked");
   // Qt::SortOrder sortOrder = Qt::DescendingOrder;
   if (!header()->isSortIndicatorShown())
     header()->setSortIndicatorShown(true);
-qDebug("About to sortItems");
   sortItems(column, header()->sortIndicatorOrder());
 }
 

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -1975,6 +1975,21 @@ QVariant XTreeWidgetItem::rawValue(const QString pName)
     return data(colIdx, Xt::RawRole);
 }
 
+void XTreeWidgetItem::setNumericRole(const QString pRole, const QString pColumn)
+{
+  int colIdx = ((XTreeWidget *)treeWidget())->column(pColumn);
+  if (colIdx >= 0)
+  {
+    bool canConvert = false;
+    double value = text(pColumn).toDouble(&canConvert);
+
+    if (canConvert)
+    {
+      setData(colIdx, Qt::DisplayRole, QLocale().toString(value, 'f', decimalPlaces(pRole)));
+    }
+  }
+}
+
 /* Calculate the total for a particular XTreeWidgetItem, including any children.
    pcol is the column for which we want the total.
    prole is the value of xttotalrole for which we want the total.

--- a/widgets/xtreewidget.h
+++ b/widgets/xtreewidget.h
@@ -135,7 +135,7 @@ class XTUPLEWIDGETS_EXPORT XTreeWidgetItem : public QObject, public QTreeWidgetI
     Q_INVOKABLE virtual int             id(const QString);
 
     Q_INVOKABLE virtual void            setDate(int pColIdx, const QDate pDate);
-    Q_INVOKABLE virtual void            setNumber(int pColIdx, const QVariant pValue);
+    Q_INVOKABLE virtual void            setNumber(int pColIdx, const QVariant pValue, const QString pRole);
     Q_INVOKABLE virtual void            setNumericRole(int pColIdx, const QString pRole);
 
     virtual bool operator               <(const XTreeWidgetItem &other) const;

--- a/widgets/xtreewidget.h
+++ b/widgets/xtreewidget.h
@@ -56,6 +56,7 @@
 class QAction;
 class QMenu;
 class QScriptEngine;
+class QDate;
 class XTreeWidget;
 class XTreeWidgetProgress;
 
@@ -136,7 +137,7 @@ class XTUPLEWIDGETS_EXPORT XTreeWidgetItem : public QObject, public QTreeWidgetI
 
     Q_INVOKABLE virtual void            setDate(int pColIdx, const QDate pDate);
     Q_INVOKABLE virtual void            setNumber(int pColIdx, const QVariant pValue, const QString pRole);
-    Q_INVOKABLE virtual void            setNumericRole(int pColIdx, const QString pRole);
+    Q_INVOKABLE virtual bool            setNumericRole(int pColIdx, const QString pRole);
 
     virtual bool operator               <(const XTreeWidgetItem &other) const;
     virtual bool operator               ==(const XTreeWidgetItem &other) const;

--- a/widgets/xtreewidget.h
+++ b/widgets/xtreewidget.h
@@ -134,7 +134,8 @@ class XTUPLEWIDGETS_EXPORT XTreeWidgetItem : public QObject, public QTreeWidgetI
     Q_INVOKABLE virtual QVariant        rawValue(const QString colname);
     Q_INVOKABLE virtual int             id(const QString);
 
-    Q_INVOKABLE virtual void            setRawValue(int pColIdx, const QVariant pValue);
+    Q_INVOKABLE virtual void            setDate(int pColIdx, const QDate pDate);
+    Q_INVOKABLE virtual void            setNumber(int pColIdx, const QVariant pValue);
     Q_INVOKABLE virtual void            setNumericRole(int pColIdx, const QString pRole);
 
     virtual bool operator               <(const XTreeWidgetItem &other) const;

--- a/widgets/xtreewidget.h
+++ b/widgets/xtreewidget.h
@@ -134,7 +134,8 @@ class XTUPLEWIDGETS_EXPORT XTreeWidgetItem : public QObject, public QTreeWidgetI
     Q_INVOKABLE virtual QVariant        rawValue(const QString colname);
     Q_INVOKABLE virtual int             id(const QString);
 
-    Q_INVOKABLE virtual void            setNumericRole(const QString pRole, const QString pColumn);
+    Q_INVOKABLE virtual void            setRawValue(int pColIdx, const QVariant pValue);
+    Q_INVOKABLE virtual void            setNumericRole(int pColIdx, const QString pRole);
 
     virtual bool operator               <(const XTreeWidgetItem &other) const;
     virtual bool operator               ==(const XTreeWidgetItem &other) const;

--- a/widgets/xtreewidget.h
+++ b/widgets/xtreewidget.h
@@ -134,6 +134,8 @@ class XTUPLEWIDGETS_EXPORT XTreeWidgetItem : public QObject, public QTreeWidgetI
     Q_INVOKABLE virtual QVariant        rawValue(const QString colname);
     Q_INVOKABLE virtual int             id(const QString);
 
+    Q_INVOKABLE virtual void            setNumericRole(const QString pRole, const QString pColumn);
+
     virtual bool operator               <(const XTreeWidgetItem &other) const;
     virtual bool operator               ==(const XTreeWidgetItem &other) const;
 

--- a/widgets/xtreewidget.h
+++ b/widgets/xtreewidget.h
@@ -56,7 +56,6 @@
 class QAction;
 class QMenu;
 class QScriptEngine;
-class QDate;
 class XTreeWidget;
 class XTreeWidgetProgress;
 
@@ -135,7 +134,7 @@ class XTUPLEWIDGETS_EXPORT XTreeWidgetItem : public QObject, public QTreeWidgetI
     Q_INVOKABLE virtual QVariant        rawValue(const QString colname);
     Q_INVOKABLE virtual int             id(const QString);
 
-    Q_INVOKABLE virtual void            setDate(int pColIdx, const QDate pDate);
+    Q_INVOKABLE virtual void            setDate(int pColIdx, const QVariant pDate);
     Q_INVOKABLE virtual void            setNumber(int pColIdx, const QVariant pValue, const QString pRole);
     Q_INVOKABLE virtual bool            setNumericRole(int pColIdx, const QString pRole);
 


### PR DESCRIPTION
Determined that "old style" sorting was being used because no column names were assigned when adding the columns to the _receipts XTreeWidget.  Adding column names fixed that part.  Also determined that the XTreeWidgetItem constructor that had been used always created QString variants for the raw data (which is what is sorted).  While sort code existed to handle numerics as strings, such logic was not present for dates as strings.

My solution was to set each column data individually with either setText or the new functions setDate and setNumber on XTreeWidgetItem.  These latter set the raw data to the correct type variants and apply the appropriate Qt::DisplayRole formatting.