### PR TITLE
Issue 27643

### DIFF
--- a/guiclient/authorizedotnetprocessor.cpp
+++ b/guiclient/authorizedotnetprocessor.cpp
@@ -581,7 +581,7 @@ int AuthorizeDotNetProcessor::handleResponse(const QString &presponse, const int
   QString r_hash;
 
   QString status;
-  bool    isCP; // looks like an (unsupported) card-present transaction
+  bool    isCP=false; // looks like an (unsupported) card-present transaction
 
   // TODO: explore using encap here and code from CSV Import to properly split
 


### PR DESCRIPTION
Initialize isCP variable to false. Otherwise response from authorize.net is treated improperly as a card-present.