### PR TITLE
fix bad method call to allow compiling for upcoming fedora release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+postbooks (4.9.4-1) experimental; urgency=medium
+
+  * Placeholder
+
+ -- Gil Moskowitz <gmoskowitz@xtuple.com>  Wed, 15 Jul 2015 13:06:00 -0400
+
 postbooks (4.9.3-1) experimental; urgency=medium
 
   * Placeholder

--- a/guiclient/Info.plist
+++ b/guiclient/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
         <key>CFBundleGetInfoString</key>
-	<string>4.9.3</string>
+	<string>4.9.4</string>
 	<key>CFBundleSignature</key>
 	<string>omfg</string>
 	<key>CFBundleExecutable</key>

--- a/guiclient/displays/dspBookings.cpp
+++ b/guiclient/displays/dspBookings.cpp
@@ -160,7 +160,7 @@ void dspBookings::sEditOrder()
 
 void dspBookings::sViewOrder()
 {
-  salesOrder::viewSalesOrder(list()->altId(), false);
+  salesOrder::viewSalesOrder(list()->altId());
 }
 
 void dspBookings::sEditItem()

--- a/guiclient/version.cpp
+++ b/guiclient/version.cpp
@@ -11,7 +11,7 @@
 #include "version.h"
 
 QString _Name        = "xTuple ERP: %1 Edition";
-QString _Version     = "4.9.3";
+QString _Version     = "4.9.4";
 QString _dbVersion   = "4.9.3";
 QString _Copyright   = "Copyright (c) 1999-2016, OpenMFG, LLC.";
 QString _ConnAppName = "xTuple ERP (qt-client)";


### PR DESCRIPTION
Unit tested the one code change and confirmed that the 4.9.4 application will connect to a 4.9.3 database without error or warning.

@dpocock - Could you please review and let me know if anything else is required at this time?