### PR TITLE
issue #27633, issue #25878 - characteristic Validators, issue #26893 - lot/serial screen fixes

### DIFF
--- a/guiclient/characteristic.cpp
+++ b/guiclient/characteristic.cpp
@@ -157,6 +157,12 @@ characteristic::characteristic(QWidget* parent, const char* name, bool modal, Qt
   connect(_new, SIGNAL(clicked()), this, SLOT(sNew()));
   connect(_charoptView, SIGNAL(clicked(QModelIndex)), this, SLOT(sCharoptClicked(QModelIndex)));
   connect(_delete, SIGNAL(clicked()), this, SLOT(sDelete()));
+
+  _validator->append(0, "[Y|N]");
+  _validator->append(1, "\\S+");
+  _validator->append(2, "[1-9]\\d{0,3}");
+  _validator->append(3, "[A-Z]\\d{5}[1-9]");
+  _validator->append(4, "(https?:\\/\\/(?:www\\.|(?!www))[^\\s\\.]+\\.[^\\s]{2,}|www\\.[^\\s]+\\.[^\\s]{2,})");
 }
 
 characteristic::~characteristic()

--- a/guiclient/characteristic.ui
+++ b/guiclient/characteristic.ui
@@ -219,26 +219,6 @@ to be bound by its terms.</comment>
                    <property name="nullStr">
                     <string/>
                    </property>
-                   <item>
-                    <property name="text">
-                     <string notr="true">[Y|N]</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string notr="true">\S+</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string notr="true">[1-9]\d{0,3}</string>
-                    </property>
-                   </item>
-                   <item>
-                    <property name="text">
-                     <string notr="true">[A-Z]\d{5}[1-9]</string>
-                    </property>
-                   </item>
                   </widget>
                  </item>
                 </layout>

--- a/guiclient/lotSerial.cpp
+++ b/guiclient/lotSerial.cpp
@@ -25,6 +25,7 @@ lotSerial::lotSerial(QWidget* parent, const char* name, bool modal, Qt::WindowFl
     setupUi(this);
 
     _print = _buttonBox->addButton(tr("Print Label"),QDialogButtonBox::ActionRole);
+    _print->setEnabled(false);
 
     connect(_buttonBox, SIGNAL(accepted()), this, SLOT(sSave()));
     connect(_lotSerial, SIGNAL(valid(bool)), this, SLOT(populate()));
@@ -119,6 +120,7 @@ void lotSerial::populate()
     return;
   }
   _charass->findChild<QPushButton*>("_newCharacteristic")->setEnabled(_lotSerial->isValid());
+  _print->setEnabled(_lotSerial->isValid());
   sFillList();
 }
 

--- a/guiclient/lotSerial.cpp
+++ b/guiclient/lotSerial.cpp
@@ -35,6 +35,7 @@ lotSerial::lotSerial(QWidget* parent, const char* name, bool modal, Qt::WindowFl
     connect(_print, SIGNAL(clicked()), this, SLOT(sPrint()));
     
     _charass->setType("LS");
+    _charass->findChild<QPushButton*>("_newCharacteristic")->setEnabled(false);
     
     _reg->addColumn(tr("Number")      ,        _orderColumn,  Qt::AlignLeft, true, "lsreg_number" );
     _reg->addColumn(tr("Account#"),            _itemColumn,  Qt::AlignLeft, true, "crmacct_number" );
@@ -117,6 +118,7 @@ void lotSerial::populate()
   {
     return;
   }
+  _charass->findChild<QPushButton*>("_newCharacteristic")->setEnabled(_lotSerial->isValid());
   sFillList();
 }
 


### PR DESCRIPTION
This PR resolves the core issue and improves the URL validator regexp.

However I found the reason the [Y/N] validator was missing looked to be the XComboBox AllowNull string was overriding the first item in the dropdown item list.

This may indicate a wider problem with fixed XComboBox lists elsewhere in the system.   Qt5 or Unicode problem ??

Also resolves Issue #25878 Characteristic Input Mask and Validator not working for Lot/Serial input
AND Issue #27323: New button on Lot/Serial characteristics