### PR TITLE
issue #27749 Fixed default tab for Financial Report screen

### DIFF
--- a/guiclient/financialLayout.ui
+++ b/guiclient/financialLayout.ui
@@ -205,7 +205,7 @@ to be bound by its terms.</comment>
         </sizepolicy>
        </property>
        <property name="currentIndex">
-        <number>3</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="_rowLayout">
         <attribute name="title">


### PR DESCRIPTION
Straightforward default index fix. Tested and confirmed working.