### PR TITLE
issue #27691 Issuing multiple quantity of same serial number

### DIFF
--- a/guiclient/distributeInventory.cpp
+++ b/guiclient/distributeInventory.cpp
@@ -458,6 +458,8 @@ void distributeInventory::sSelectLocation()
   else if (_itemloc->altId() == cItemloc)
     params.append("itemlocdist_id", _itemloc->id());
 
+  params.append("itemsite_controlmethod", _controlMethod);
+
   distributeToLocation newdlg(this, "", true);
   newdlg.set(params);
 
@@ -708,6 +710,8 @@ void distributeInventory::sBcDistribute()
   params.append("source_itemlocdist_id", _itemlocdistid);
   params.append("qty",                   _bcQty->text());
   params.append("distribute");
+
+  params.append("itemsite_controlmethod", _controlMethod);
 
   distributeToLocation newdlg(this, "", true);
   if (newdlg.set(params) != NoError)

--- a/guiclient/distributeToLocation.cpp
+++ b/guiclient/distributeToLocation.cpp
@@ -86,6 +86,12 @@ enum SetResponse distributeToLocation::set(const ParameterList &pParams)
     _locationQty->setDouble(locQty);
   }
 
+  param = pParams.value("itemsite_controlmethod", &valid);
+  if (valid)
+  {
+    _controlMethod = param.toString();
+  }
+
   param = pParams.value("distribute", &valid);
   if (valid)
   {
@@ -130,11 +136,24 @@ void distributeToLocation::sDistribute()
     return;
   }
 
-
-  if (qty < 0 && _availToDistribute < qAbs(qty))
+  if (qAbs(qty)>1 && _controlMethod=="S")
   {
     QMessageBox::warning( this, tr("Cannot Distribute Quantity"),
-                          tr("You may not distribute more than is available to be distributed.") );
+                          tr("You may not distribute more than one of the same serial controlled item.") );
+    _locationQty->setFocus();
+    return;
+  }
+  
+
+  if (qty < 0 && _availToDistribute < qAbs(qty) &&
+      QMessageBox::question(this, tr("Distribute More Than Available?"),
+			    tr("<p>It appears you are trying to distribute "
+			       "more than is available to be distributed. "
+			       "Are you sure you want to distribute this "
+			       "quantity?"),
+			    QMessageBox::Yes,
+			    QMessageBox::No | QMessageBox::Default) == QMessageBox::No)
+  {
     _locationQty->setFocus();
     return;
   }

--- a/guiclient/distributeToLocation.cpp
+++ b/guiclient/distributeToLocation.cpp
@@ -130,15 +130,11 @@ void distributeToLocation::sDistribute()
     return;
   }
 
-  if (qty < 0 && _availToDistribute < qAbs(qty) &&
-      QMessageBox::question(this, tr("Distribute More Than Available?"),
-			    tr("<p>It appears you are trying to distribute "
-			       "more than is available to be distributed. "
-			       "Are you sure you want to distribute this "
-			       "quantity?"),
-			    QMessageBox::Yes,
-			    QMessageBox::No | QMessageBox::Default) == QMessageBox::No)
+
+  if (qty < 0 && _availToDistribute < qAbs(qty))
   {
+    QMessageBox::warning( this, tr("Cannot Distribute Quantity"),
+                          tr("You may not distribute more than is available to be distributed.") );
     _locationQty->setFocus();
     return;
   }

--- a/guiclient/distributeToLocation.h
+++ b/guiclient/distributeToLocation.h
@@ -41,6 +41,7 @@ private:
     double _balance;
     QString _lotSerial;
     double _availToDistribute;
+    QString _controlMethod;
 };
 
 #endif // DISTRIBUTETOLOCATION_H


### PR DESCRIPTION
Changed prompt to warning when issuing more items than available. Action is disallowed instead of simply discouraged.