### PR TITLE
Issue #26802: Rename Credit Memo/Return to Sales Credit consistently

### DIFF
--- a/guiclient/arWorkBench.cpp
+++ b/guiclient/arWorkBench.cpp
@@ -157,7 +157,7 @@ bool arWorkBench::setParams(ParameterList &params)
 {
   _customerSelector->appendValue(params);
   params.append("invoice", tr("Invoice"));
-  params.append("return", tr("Return"));
+  params.append("return", tr("Sales Credit"));
   params.append("creditMemo", tr("Credit Memo"));
   params.append("debitMemo", tr("Debit Memo"));
   params.append("cashdeposit", tr("Customer Deposit"));

--- a/guiclient/configureSO.ui
+++ b/guiclient/configureSO.ui
@@ -1379,7 +1379,7 @@ to be bound by its terms.</comment>
               </item>
               <item>
                <property name="text">
-                <string>Return</string>
+                <string>Sales Credit</string>
                </property>
               </item>
               <item>

--- a/guiclient/creditMemo.cpp
+++ b/guiclient/creditMemo.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -749,7 +749,7 @@ void creditMemo::sDelete()
     if (creditDelete.value("cmhead_posted").toBool())
     {
       QMessageBox::information(this, "Line Item cannot be delete",
-                               tr("<p>This Return has been Posted and "
+                               tr("<p>This Sales Credit has been Posted and "
 				"this cannot be modified.") );
       return;
     }

--- a/guiclient/creditMemo.ui
+++ b/guiclient/creditMemo.ui
@@ -18,7 +18,7 @@ to be bound by its terms.</comment>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Sales Credit Memo (Return)</string>
+   <string>Sales Credit</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">

--- a/guiclient/creditMemoEditList.cpp
+++ b/guiclient/creditMemoEditList.cpp
@@ -92,10 +92,10 @@ void creditMemoEditList::sPopulateMenu(QMenu *pMenu, QTreeWidgetItem *pSelected)
 {
   _orderid = _cmhead->id();
 
-  pMenu->addAction(tr("Edit Return..."), this, SLOT(sEditCreditMemo()));
+  pMenu->addAction(tr("Edit Sales Credit..."), this, SLOT(sEditCreditMemo()));
 
   if (((XTreeWidgetItem *)pSelected)->altId() != -1)
-    pMenu->addAction(tr("Edit Return Item..."), this, SLOT(sEditCreditMemoItem()));
+    pMenu->addAction(tr("Edit Sales Credit Item..."), this, SLOT(sEditCreditMemoItem()));
 }
 
 void creditMemoEditList::sFillList()
@@ -139,7 +139,7 @@ bool creditMemoEditList::checkSitePrivs(int ordid)
       if (!check.value("result").toBool())
       {
         QMessageBox::critical(this, tr("Access Denied"),
-                              tr("You may not view or edit this Return as it references "
+                              tr("You may not view or edit this Sales Credit as it references "
                                  "a Site for which you have not been granted privileges.")) ;
         return false;
       }

--- a/guiclient/creditMemoEditList.ui
+++ b/guiclient/creditMemoEditList.ui
@@ -18,7 +18,7 @@ to be bound by its terms.</comment>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Return Edit List</string>
+   <string>Sales Credit Edit List</string>
   </property>
   <layout class="QVBoxLayout">
    <item>

--- a/guiclient/creditMemoItem.cpp
+++ b/guiclient/creditMemoItem.cpp
@@ -223,7 +223,7 @@ void creditMemoItem::sSave()
   errors << GuiErrorCheck(_qtyToCredit->toDouble() == 0.0, _qtyToCredit,
                           tr("<p>You have not selected a quantity of the "
 			    "selected item to credit. If you wish to return a "
-			    "quantity to stock but not issue a Return "
+			    "quantity to stock but not issue a Sales Credit "
 			    "then you should enter a Return to Stock "
 			    "transaction from the I/M module.  Otherwise, you "
 			    "must enter a quantity to credit."))
@@ -662,7 +662,7 @@ void creditMemoItem::sPopulateUOM()
       params.append("global", tr("-Global"));
     }
     
-    // Also have to factor UOMs previously used on Return now inactive
+    // Also have to factor UOMs previously used on Sales Credit now inactive
     if (_cmitemid != -1)
     {
       XSqlQuery cmuom;
@@ -671,7 +671,7 @@ void creditMemoItem::sPopulateUOM()
                     " WHERE(cmitem_id=:cmitem_id);");
       cmuom.bindValue(":cmitem_id", _cmitemid);
       cmuom.exec();
-      if (ErrorReporter::error(QtCriticalMsg, this, tr("Getting Return UOMs"),
+      if (ErrorReporter::error(QtCriticalMsg, this, tr("Getting Sales Credit UOMs"),
                                cmuom, __FILE__, __LINE__))
         return;
       else if (cmuom.first())

--- a/guiclient/creditMemoItem.ui
+++ b/guiclient/creditMemoItem.ui
@@ -18,7 +18,7 @@ to be bound by its terms.</comment>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Sales Credit Memo (Return) Item</string>
+   <string>Sales Credit Item</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_6">
    <item row="0" column="0">
@@ -83,7 +83,7 @@ to be bound by its terms.</comment>
        <item>
         <widget class="QLabel" name="_orderNumberLit">
          <property name="text">
-          <string>Return #:</string>
+          <string>Sales Credit #:</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/guiclient/menuSales.cpp
+++ b/guiclient/menuSales.cpp
@@ -194,7 +194,7 @@ menuSales::menuSales(GUIClient *pParent) :
     { "so.postInvoices",		     tr("Post &Invoices..."),		SLOT(sPostInvoices()), billingInvoicesMenu, "PostMiscInvoices",	NULL, NULL, true, NULL },
 
     // Sales | Billing | Credit Memos
-    { "menu",	tr("&Return"), (char*)billingCreditMemosMenu,	billingMenu,	"true",	NULL, NULL, true, NULL },
+    { "menu",	tr("&Sales Credit"), (char*)billingCreditMemosMenu,	billingMenu,	"true",	NULL, NULL, true, NULL },
     { "so.newCreditMemo",		     tr("&New..."),		SLOT(sNewCreditMemo()), billingCreditMemosMenu, "MaintainCreditMemos",	NULL, NULL, true, NULL },
     { "so.listUnpostedCreditMemos",	     tr("&List Unposted..."),	SLOT(sUnpostedCreditMemos()), billingCreditMemosMenu, "MaintainCreditMemos ViewCreditMemos",	NULL, NULL, true, NULL },
     { "so.creditMemoEditList",		     tr("&Edit List..."),	SLOT(sCreditMemoEditList()), billingCreditMemosMenu, "MaintainCreditMemos ViewCreditMemos",	NULL, NULL, true, NULL },
@@ -208,8 +208,8 @@ menuSales::menuSales(GUIClient *pParent) :
     { "so.printInvoices",		     tr("&Print Invoices..."),		SLOT(sPrintInvoices()), billingFormsMenu, "PrintInvoices",	NULL, NULL, true, NULL },
     { "so.reprintInvoices",		     tr("&Re-Print Invoices..."),	SLOT(sReprintInvoices()), billingFormsMenu, "PrintInvoices",	NULL, NULL, true, NULL },
     { "separator",	NULL,	NULL,	billingFormsMenu,	"true",		NULL, NULL, true , NULL },
-    { "so.printCreditMemos",		     tr("Print &Returns..."),	SLOT(sPrintCreditMemos()), billingFormsMenu, "PrintCreditMemos",	NULL, NULL, true, NULL },
-    { "so.reprintCreditMemos",		     tr("Re-Print &Returns..."),	SLOT(sReprintCreditMemos()), billingFormsMenu, "PrintCreditMemos",	NULL, NULL, true, NULL },
+    { "so.printCreditMemos",		     tr("Print &Sales Credits..."),	SLOT(sPrintCreditMemos()), billingFormsMenu, "PrintCreditMemos",	NULL, NULL, true, NULL },
+    { "so.reprintCreditMemos",		     tr("Re-Print &Sales Credits..."),	SLOT(sReprintCreditMemos()), billingFormsMenu, "PrintCreditMemos",	NULL, NULL, true, NULL },
 
     // Sales | Return Authorizations
     { "menu",	tr("&Return Auth."),	(char*)returnsMenu,	mainMenu, "true",	NULL, NULL,  _metrics->boolean("EnableReturnAuth"), NULL },
@@ -329,7 +329,7 @@ menuSales::menuSales(GUIClient *pParent) :
     { "so.updateCreditStatusByCustomer", tr("&Update Credit Status by Customer..."),	SLOT(sUpdateCreditStatusByCustomer()), utilitiesMenu, "MaintainCustomerMasters UpdateCustomerCreditStatus",	NULL, NULL, true, NULL },
     { "separator",	NULL,	NULL,	utilitiesMenu,	"true",		NULL, NULL, true, NULL },
     { "so.purgeInvoices",		     tr("Purge &Invoices..."),		SLOT(sPurgeInvoices()), utilitiesMenu, "PurgeInvoices",	NULL, NULL, true, NULL },
-    { "so.purgeCreditMemos",		     tr("Purge &Returns..."),	SLOT(sPurgeCreditMemos()), utilitiesMenu, "PurgeCreditMemos",	NULL, NULL, true, NULL },
+    { "so.purgeCreditMemos",		     tr("Purge &Sales Credits..."),	SLOT(sPurgeCreditMemos()), utilitiesMenu, "PurgeCreditMemos",	NULL, NULL, true, NULL },
     { "separator",	NULL,	NULL,	utilitiesMenu,	"true",		NULL, NULL, _metrics->boolean("EnableSOReservations"), NULL },
     { "so.allocateReservations", tr("Allocate Reser&vations..."), SLOT(sAllocateReservations()), utilitiesMenu, "MaintainReservations", NULL, NULL, _metrics->boolean("EnableSOReservations") , NULL },
     { "separator",	NULL,	NULL,	utilitiesMenu,	"true",		NULL, NULL, true, NULL },

--- a/guiclient/postCreditMemos.cpp
+++ b/guiclient/postCreditMemos.cpp
@@ -62,9 +62,9 @@ void postCreditMemos::sPost()
 
     if ( ( (unprinted) && (!printed) ) && (!_postUnprinted->isChecked()) )
     {
-      QMessageBox::warning( this, tr("No Returns to Post"),
-                            tr( "Although there are unposted Returns, there are no unposted Returns that have been printed.\n"
-                                "You must manually print these Returns or select 'Post Unprinted Returns' before these Returns\n"
+      QMessageBox::warning( this, tr("No Sales Credits to Post"),
+                            tr( "Although there are unposted Sales Credits, there are no unposted Sales Credits that have been printed.\n"
+                                "You must manually print these Sales Credits or select 'Post Unprinted Sales Credits' before these Sales Credits\n"
                                 "may be posted." ) );
       _postUnprinted->setFocus();
       return;
@@ -72,8 +72,8 @@ void postCreditMemos::sPost()
   }
   else
   {
-    QMessageBox::warning( this, tr("No Returns to Post"),
-                          tr("There are no Returns, printed or not, to post.\n" ) );
+    QMessageBox::warning( this, tr("No Sales Credits to Post"),
+                          tr("There are no Sales Credits, printed or not, to post.\n" ) );
     _close->setFocus();
     return;
   }
@@ -103,11 +103,11 @@ void postCreditMemos::sPost()
     if (result == -5)
     {
       rollback.exec();
-      QMessageBox::critical( this, tr("Cannot Post one or more Returns"),
-                             tr( "The Ledger Account Assignments for one or more of the Returns that you are trying to post are not\n"
-                                 "configured correctly.  Because of this, G/L Transactions cannot be posted for these Returns.\n"
+      QMessageBox::critical( this, tr("Cannot Post one or more Sales Credits"),
+                             tr( "The Ledger Account Assignments for one or more of the Sales Credits that you are trying to post are not\n"
+                                 "configured correctly.  Because of this, G/L Transactions cannot be posted for these Sales Credits.\n"
                                  "You must contact your Systems Administrator to have this corrected before you may\n"
-                                 "post these Returns." ) );
+                                 "post these Sales Credits." ) );
       return;
     }
     else if (result < 0)
@@ -120,7 +120,7 @@ void postCreditMemos::sPost()
     else if (distributeInventory::SeriesAdjust(postPost.value("result").toInt(), this) == XDialog::Rejected)
     {
       rollback.exec();
-      QMessageBox::information( this, tr("Post Returns"), tr("Transaction Canceled") );
+      QMessageBox::information( this, tr("Post Sales Credits"), tr("Transaction Canceled") );
       return;
     }
 

--- a/guiclient/postCreditMemos.ui
+++ b/guiclient/postCreditMemos.ui
@@ -2,7 +2,7 @@
 <ui version="4.0">
  <comment>This file is part of the xTuple ERP: PostBooks Edition, a free and
 open source Enterprise Resource Planning software suite,
-Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
 It is licensed to you under the Common Public Attribution License
 version 1.0, the full text of which (including xTuple-specific Exhibits)
 is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -18,7 +18,7 @@ to be bound by its terms.</comment>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Post Returns</string>
+   <string>Post Sales Credits</string>
   </property>
   <layout class="QHBoxLayout">
    <property name="spacing">
@@ -54,7 +54,7 @@ to be bound by its terms.</comment>
          <item>
           <widget class="XCheckBox" name="_postUnprinted">
            <property name="text">
-            <string>Post Unprinted Returns</string>
+            <string>Post Unprinted Sales Credits</string>
            </property>
           </widget>
          </item>
@@ -87,7 +87,7 @@ to be bound by its terms.</comment>
          <item>
           <widget class="XCheckBox" name="_printJournal">
            <property name="text">
-            <string>P&amp;rint Return Journal</string>
+            <string>P&amp;rint Sales Credit Journal</string>
            </property>
           </widget>
          </item>

--- a/guiclient/printMulticopyDocument.cpp
+++ b/guiclient/printMulticopyDocument.cpp
@@ -521,7 +521,7 @@ void printMulticopyDocument::setDoctype(QString doctype)
   if (doctype == "AR")
     _data->_doctypefull = tr("A/R Statement");
   else if (doctype == "CM")
-    _data->_doctypefull = tr("Return");
+    _data->_doctypefull = tr("Sales Credit");
   else if (doctype == "IN")
     _data->_doctypefull = tr("Invoice");
   else if (doctype == "L")

--- a/guiclient/printSinglecopyDocument.cpp
+++ b/guiclient/printSinglecopyDocument.cpp
@@ -377,7 +377,7 @@ void printSinglecopyDocument::setDoctype(QString doctype)
   if (doctype == "AR")
     _data->_doctypefull = tr("A/R Statement");
   else if (doctype == "CM")
-    _data->_doctypefull = tr("Return");
+    _data->_doctypefull = tr("Sales Credit");
   else if (doctype == "IN")
     _data->_doctypefull = tr("Invoice");
   else if (doctype == "L")

--- a/guiclient/printStatementByCustomer.cpp
+++ b/guiclient/printStatementByCustomer.cpp
@@ -82,7 +82,7 @@ ParameterList printStatementByCustomer::getParams()
   params.append("docid",    _cust->id());
   params.append("cust_id",  _cust->id());
   params.append("invoice",  tr("Invoice"));
-  params.append("return",   tr("Return"));
+  params.append("return",   tr("Sales Credit"));
   params.append("debit",    tr("Debit Memo"));
   params.append("credit",   tr("Credit Memo"));
   params.append("deposit",  tr("Deposit"));

--- a/guiclient/printStatementsByCustomerGroup.cpp
+++ b/guiclient/printStatementsByCustomerGroup.cpp
@@ -69,7 +69,7 @@ ParameterList printStatementsByCustomerGroup::getParams()
   params.append("docid",      _custgrp->id());
   params.append("custgrp",    _custgrp->id());
   params.append("invoice",    tr("Invoice"));
-  params.append("return",     tr("Return"));
+  params.append("return",     tr("Sales Credit"));
   params.append("debitMemo",  tr("Debit Memo"));
   params.append("creditMemo", tr("Credit Memo"));
   params.append("deposit",    tr("Deposit"));

--- a/guiclient/printStatementsByCustomerType.cpp
+++ b/guiclient/printStatementsByCustomerType.cpp
@@ -55,7 +55,7 @@ ParameterList printStatementsByCustomerType::getParams(XSqlQuery *docq)
   ParameterList params = printSinglecopyDocument::getParams(docq);
 
   params.append("invoice",  tr("Invoice"));
-  params.append("return",   tr("Return"));
+  params.append("return",   tr("Sales Credit"));
   params.append("debit",    tr("Debit Memo"));
   params.append("credit",   tr("Credit Memo"));
   params.append("deposit",  tr("Deposit"));

--- a/guiclient/purgeCreditMemos.cpp
+++ b/guiclient/purgeCreditMemos.cpp
@@ -44,9 +44,9 @@ void purgeCreditMemos::sPurge()
     return;
   }
 
-  if ( QMessageBox::warning( this, tr("Delete Return Records"),
-                             tr( "You will not be able to re-print a Return if you delete it.\n"
-                                 "Are you sure that you want to delete the selected Returns?" ),
+  if ( QMessageBox::warning( this, tr("Delete Sales Credit Records"),
+                             tr( "You will not be able to re-print a Sales Credit if you delete it.\n"
+                                 "Are you sure that you want to delete the selected Sales Credits?" ),
                              tr("Yes"), tr("No"), QString::null, 0, 1) == 0)
   {
     purgePurge.prepare("SELECT purgeCreditMemos(:cutOffDate) AS result;");

--- a/guiclient/purgeCreditMemos.ui
+++ b/guiclient/purgeCreditMemos.ui
@@ -24,7 +24,7 @@ to be bound by its terms.</comment>
    </sizepolicy>
   </property>
   <property name="windowTitle">
-   <string>Purge Returns</string>
+   <string>Purge Sales Credits</string>
   </property>
   <layout class="QHBoxLayout">
    <property name="spacing">

--- a/guiclient/reprintMulticopyDocument.cpp
+++ b/guiclient/reprintMulticopyDocument.cpp
@@ -277,7 +277,7 @@ void reprintMulticopyDocument::setDoctype(QString doctype)
   if (doctype == "AR")
     _data->_doctypefull = tr("A/R Statement");
   else if (doctype == "CM")
-    _data->_doctypefull = tr("Return");
+    _data->_doctypefull = tr("Sales Credit");
   else if (doctype == "IN")
     _data->_doctypefull = tr("Invoice");
   else if (doctype == "L")

--- a/guiclient/returnAuthCheck.cpp
+++ b/guiclient/returnAuthCheck.cpp
@@ -181,7 +181,7 @@ void returnAuthCheck::populate()
   XSqlQuery returnpopulate;
   returnpopulate.prepare("SELECT cust_id,cust_name,cmhead_number,cmhead_curr_id, "
 	        "'Return Authorization ' || rahead_number::text AS memo, "
-			"'Applied Against Return ' || cmhead_number::text AS note, "
+			"'Applied Against Sales Credit ' || cmhead_number::text AS note, "
 			"aropen_id,aropen_amount "
 			"FROM rahead,cmhead,custinfo,aropen "
 			"WHERE ((cmhead_cust_id=cust_id) "

--- a/guiclient/returnAuthCheck.ui
+++ b/guiclient/returnAuthCheck.ui
@@ -97,7 +97,7 @@ to be bound by its terms.</comment>
    <item row="1" column="0">
     <widget class="QLabel" name="_creditmemoLit">
      <property name="text">
-      <string>Return:</string>
+      <string>Sales Credit:</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/guiclient/returnAuthorization.cpp
+++ b/guiclient/returnAuthorization.cpp
@@ -1796,8 +1796,8 @@ void returnAuthorization::sRefund()
     if (ccq.first())
     {
       int ccpayid = ccq.value("ccpay_id").toInt();
-      QMessageBox::information( this, tr("New Return Created"),
-                                tr("<p>A new Return has been created and "
+      QMessageBox::information( this, tr("New Sales Credit Created"),
+                                tr("<p>A new Sales Credit has been created and "
                                    "assigned #%1")
                                    .arg(ccq.value("cmhead_number").toString()));
       CreditCardProcessor *cardproc = CreditCardProcessor::getProcessor();
@@ -1878,7 +1878,7 @@ void returnAuthorization::sRefund()
   else if (cmq.lastError().type() != QSqlError::NoError)
   {
     XSqlQuery rollback("ROLLBACK;");
-    ErrorReporter::error(QtCriticalMsg, this, tr("Creating R/A Return"),
+    ErrorReporter::error(QtCriticalMsg, this, tr("Creating R/A Sales Credit"),
                          cmq, __FILE__, __LINE__);
     return;
   }

--- a/guiclient/returnAuthorization.ui
+++ b/guiclient/returnAuthorization.ui
@@ -374,7 +374,7 @@ to be bound by its terms.</comment>
            </item>
            <item>
             <property name="text">
-             <string>Return</string>
+             <string>Sales Credit</string>
             </property>
            </item>
            <item>

--- a/guiclient/returnAuthorizationWorkbench.cpp
+++ b/guiclient/returnAuthorizationWorkbench.cpp
@@ -262,8 +262,8 @@ void returnAuthorizationWorkbench::sProcess()
     returnProcess.exec();
     if (returnProcess.first())
     {
-      QMessageBox::information( this, tr("New Return Created"),
-                                tr("<p>A new Return has been created and "
+      QMessageBox::information( this, tr("New Sales Credit Created"),
+                                tr("<p>A new Sales Credit has been created and "
 				                   "assigned #%1")
                                    .arg(returnProcess.value("cmhead_number").toString()));
 	  if (_printmemo->isChecked())
@@ -371,7 +371,7 @@ void returnAuthorizationWorkbench::setParams(ParameterList &params)
   _customerSelector->appendValue(params);
 
   params.append("credit",     tr("Credit"));
-  params.append("return",     tr("Return"));
+  params.append("return",     tr("Sales Credit"));
   params.append("replace",    tr("Replace"));
   params.append("service",    tr("Service"));
   params.append("none",       tr("None"));

--- a/guiclient/returnAuthorizationWorkbench.ui
+++ b/guiclient/returnAuthorizationWorkbench.ui
@@ -2,7 +2,7 @@
 <ui version="4.0">
  <comment>This file is part of the xTuple ERP: PostBooks Edition, a free and
 open source Enterprise Resource Planning software suite,
-Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
 It is licensed to you under the Common Public Attribution License
 version 1.0, the full text of which (including xTuple-specific Exhibits)
 is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -334,7 +334,7 @@ to be bound by its terms.</comment>
            <item>
             <widget class="XCheckBox" name="_creditmemo">
              <property name="text">
-              <string>Return</string>
+              <string>Sales Credit</string>
              </property>
             </widget>
            </item>
@@ -486,14 +486,14 @@ to be bound by its terms.</comment>
            <item>
             <widget class="XCheckBox" name="_postmemos">
              <property name="text">
-              <string>Post Returns Immediately</string>
+              <string>Post Sales Credits Immediately</string>
              </property>
             </widget>
            </item>
            <item>
             <widget class="XCheckBox" name="_printmemo">
              <property name="text">
-              <string>Print Return</string>
+              <string>Print Sales Credit</string>
              </property>
             </widget>
            </item>

--- a/guiclient/salesAccount.cpp
+++ b/guiclient/salesAccount.cpp
@@ -132,7 +132,7 @@ void salesAccount::sSave()
     errors << GuiErrorCheck(!_sales->isValid(), _sales,
                             tr("<p>You must select a Sales Account for this Assignment."))
            << GuiErrorCheck(!_credit->isValid(), _credit,
-                            tr("<p>You must select a Return Account for this Assignment."))
+                            tr("<p>You must select a Sales Credit Account for this Assignment."))
            << GuiErrorCheck(!_cos->isValid(), _cos,
                             tr("<p>You must select a Cost of Sales Account for this Assignment."))
            << GuiErrorCheck(_metrics->boolean("EnableReturnAuth") && !_returns->isValid(), _returns,

--- a/guiclient/salesAccount.ui
+++ b/guiclient/salesAccount.ui
@@ -189,7 +189,7 @@ to be bound by its terms.</comment>
      <item row="1" column="0">
       <widget class="QLabel" name="_creditLit">
        <property name="text">
-        <string>&amp;Return Account:</string>
+        <string>&amp;Sales Credit Account:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/guiclient/salesAccounts.cpp
+++ b/guiclient/salesAccounts.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -39,7 +39,7 @@ salesAccounts::salesAccounts(QWidget* parent, const char* name, Qt::WindowFlags 
   _salesaccnt->addColumn(tr("Sale Type"),                 _itemColumn, Qt::AlignCenter  , true, "saletypecode");
   _salesaccnt->addColumn(tr("Prod. Cat."),                _itemColumn, Qt::AlignCenter  , true, "prodcatcode");
   _salesaccnt->addColumn(tr("Sales Accnt. #"),            _itemColumn, Qt::AlignCenter  , true, "salesaccount");
-  _salesaccnt->addColumn(tr("Return Accnt. #"),           _itemColumn, Qt::AlignCenter  , true, "creditaccount");
+  _salesaccnt->addColumn(tr("Sales Credit Accnt. #"),     _itemColumn, Qt::AlignCenter  , true, "creditaccount");
   _salesaccnt->addColumn(tr("COS Accnt. #"),              _itemColumn, Qt::AlignCenter  , true, "cosaccount");
   _salesaccnt->addColumn(tr("Returns Accnt. #"),          _itemColumn, Qt::AlignCenter  , true, "returnsaccount");
   _salesaccnt->addColumn(tr("Cost of Returns Accnt. #"),  _itemColumn, Qt::AlignCenter  , true, "coraccount" );

--- a/guiclient/taxBreakdown.cpp
+++ b/guiclient/taxBreakdown.cpp
@@ -243,9 +243,9 @@ void taxBreakdown::sPopulate()
   }
   else if (_ordertype == "CM")
   {
-    _currencyLit->setText(tr("Return Currency:"));
-    _header->setText(tr("Tax Breakdown for Return:"));
-    _totalLit->setText(tr("Return Total:"));
+    _currencyLit->setText(tr("Sales Credit Currency:"));
+    _header->setText(tr("Tax Breakdown for Sales Credit:"));
+    _totalLit->setText(tr("Sales Credit Total:"));
 
     params.append("cmhead_id", _orderid);
   }

--- a/guiclient/unpostedCreditMemos.cpp
+++ b/guiclient/unpostedCreditMemos.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -40,7 +40,7 @@ unpostedCreditMemos::unpostedCreditMemos(QWidget* parent, const char* name, Qt::
     connect(_print, SIGNAL(clicked()), this, SLOT(sPrint()));
     connect(_post, SIGNAL(clicked()), this, SLOT(sPost()));
 
-    _cmhead->addColumn(tr("Return #"),      _orderColumn, Qt::AlignLeft,   true,  "cmhead_number"   );
+    _cmhead->addColumn(tr("Sales Credit #"),      _orderColumn, Qt::AlignLeft,   true,  "cmhead_number"   );
     _cmhead->addColumn(tr("Prnt'd"),        _orderColumn, Qt::AlignCenter, true,  "printed" );
     _cmhead->addColumn(tr("Customer"),      -1,           Qt::AlignLeft,   true,  "cmhead_billtoname"   );
     _cmhead->addColumn(tr("Memo Date"),   _dateColumn,  Qt::AlignCenter, true,  "cmhead_docdate" );
@@ -245,7 +245,7 @@ void unpostedCreditMemos::sPost()
             if (distributeInventory::SeriesAdjust(result, this) == XDialog::Rejected)
             {
               rollback.exec();
-              QMessageBox::information( this, tr("Post Return"), tr("Transaction Canceled") );
+              QMessageBox::information( this, tr("Post Sales Credit"), tr("Transaction Canceled") );
               return;
             }
 
@@ -290,9 +290,9 @@ void unpostedCreditMemos::sPost()
 
 void unpostedCreditMemos::sDelete()
 {
-  if (QMessageBox::question(this, tr("Delete Selected Returns?"),
+  if (QMessageBox::question(this, tr("Delete Selected Sales Credits?"),
                             tr("<p>Are you sure that you want to delete the "
-			       "selected Returns?"),
+			       "selected Sales Credits?"),
                             QMessageBox::Yes, QMessageBox::No | QMessageBox::Default) == QMessageBox::Yes)
   {
     XSqlQuery delq;
@@ -357,7 +357,7 @@ bool unpostedCreditMemos::checkSitePrivs(int orderid)
     if (!check.value("result").toBool())
       {
         QMessageBox::critical(this, tr("Access Denied"),
-                                       tr("You may not view or edit this Return as it references "
+                                       tr("You may not view or edit this Sales Credit as it references "
                                        "a Site for which you have not been granted privileges.")) ;
         return false;
       }

--- a/guiclient/unpostedCreditMemos.ui
+++ b/guiclient/unpostedCreditMemos.ui
@@ -18,7 +18,7 @@ to be bound by its terms.</comment>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>List Unposted Sales Credit Memos (Returns)</string>
+   <string>List Unposted Sales Credits</string>
   </property>
   <layout class="QHBoxLayout">
    <item>
@@ -32,7 +32,7 @@ to be bound by its terms.</comment>
      <item>
       <widget class="QLabel" name="_unpostedCreditMemosList">
        <property name="text">
-        <string>Unposted Credit Memos (Returns):</string>
+        <string>Unposted Sales Credits:</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Did a grep for Return and found large list to go through.  Also checked Reports & metaSQL but could not find anything there that needed changing.