### PR TITLE
Issue #27807: Clarify Non-Inventory PO items on PO form and Goods Receipt

### DIFF
--- a/guiclient/enterPoitemReceipt.cpp
+++ b/guiclient/enterPoitemReceipt.cpp
@@ -132,6 +132,7 @@ enum SetResponse enterPoitemReceipt::set(const ParameterList &pParams)
       _toReceiveLit->setText(tr("Correct Qty. to:"));
       _freightLit->setText(tr("Correct Freight to:"));
       _item->setEnabled(false);
+      _expcat->setEnabled(false);
       setWindowTitle(tr("Correct Item Receipt"));
     }
   }
@@ -234,9 +235,25 @@ void enterPoitemReceipt::populate()
       _orderType->setText(tr("R/A"));
 
     int itemsiteid = enterpopulate.value("itemsiteid").toInt();
-    if (itemsiteid > 0)
-      _item->setItemsiteid(itemsiteid);
-    _item->setEnabled(false);
+
+    if (enterpopulate.value("inventoryitem").toBool())   
+    {
+      if (itemsiteid > 0)
+        _item->setItemsiteid(itemsiteid);
+      _item->setEnabled(false);
+      _itemLitStack->setCurrentIndex(0);
+      _itemStack->setCurrentIndex(0);
+    }
+    else
+    {
+      int expcatid = enterpopulate.value("expcatid").toInt();
+      if (expcatid > 0)
+        _expcat->setId(expcatid);
+      _expcat->setEnabled(false);
+      _itemLitStack->setCurrentIndex(1);
+      _itemStack->setCurrentIndex(1);
+
+    }
 
     _purchCost->setId(enterpopulate.value("recv_purchcost_curr_id").toInt());
     _purchCost->setLocalValue(enterpopulate.value("recv_purchcost").toDouble());

--- a/guiclient/enterPoitemReceipt.ui
+++ b/guiclient/enterPoitemReceipt.ui
@@ -13,8 +13,8 @@ to be bound by its terms.</comment>
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>663</width>
-    <height>658</height>
+    <width>736</width>
+    <height>699</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -152,47 +152,7 @@ to be bound by its terms.</comment>
       <string/>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
-       <layout class="QVBoxLayout" name="verticalLayout">
-        <item>
-         <widget class="QLabel" name="_ItemLit">
-          <property name="text">
-           <string> Item Number:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-      <item row="0" column="1">
-       <widget class="ItemCluster" name="_item">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="focusPolicy">
-         <enum>Qt::StrongFocus</enum>
-        </property>
-        <property name="label">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="_vendItemNumberLit">
         <property name="text">
          <string>Vend. Item Number:</string>
@@ -202,14 +162,14 @@ to be bound by its terms.</comment>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="3" column="1">
        <widget class="QLabel" name="_vendorItemNumber">
         <property name="alignment">
          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="4" column="0">
        <layout class="QVBoxLayout">
         <item>
          <widget class="QLabel" name="_vendItemDescripLit">
@@ -239,7 +199,7 @@ to be bound by its terms.</comment>
         </item>
        </layout>
       </item>
-      <item row="2" column="1">
+      <item row="4" column="1">
        <widget class="XTextEdit" name="_vendorDescrip">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Ignored">
@@ -258,7 +218,7 @@ to be bound by its terms.</comment>
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
+      <item row="5" column="0" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="_toReceiveInvLit">
@@ -308,6 +268,109 @@ to be bound by its terms.</comment>
          </spacer>
         </item>
        </layout>
+      </item>
+      <item row="0" column="0">
+       <layout class="QVBoxLayout" name="_itemLayout">
+        <item>
+         <widget class="QStackedWidget" name="_itemLitStack">
+          <property name="currentIndex">
+           <number>0</number>
+          </property>
+          <widget class="QWidget" name="page_3">
+           <widget class="QLabel" name="_ItemLit">
+            <property name="geometry">
+             <rect>
+              <x>-40</x>
+              <y>0</y>
+              <width>296</width>
+              <height>17</height>
+             </rect>
+            </property>
+            <property name="text">
+             <string> Item Number:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </widget>
+          <widget class="QWidget" name="page_4">
+           <widget class="XLabel" name="_expcatLit">
+            <property name="geometry">
+             <rect>
+              <x>-10</x>
+              <y>0</y>
+              <width>296</width>
+              <height>17</height>
+             </rect>
+            </property>
+            <property name="text">
+             <string>Expense Category:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </widget>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>0</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item row="0" column="1">
+       <widget class="QStackedWidget" name="_itemStack">
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <widget class="QWidget" name="page">
+         <widget class="ItemCluster" name="_item">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="geometry">
+           <rect>
+            <x>10</x>
+            <y>0</y>
+            <width>423</width>
+            <height>73</height>
+           </rect>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::StrongFocus</enum>
+          </property>
+          <property name="label">
+           <string/>
+          </property>
+         </widget>
+        </widget>
+        <widget class="QWidget" name="page_2">
+         <widget class="ExpenseCluster" name="_expcat">
+          <property name="geometry">
+           <rect>
+            <x>20</x>
+            <y>0</y>
+            <width>423</width>
+            <height>65</height>
+           </rect>
+          </property>
+          <property name="label">
+           <string/>
+          </property>
+         </widget>
+        </widget>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -648,6 +711,11 @@ to be bound by its terms.</comment>
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>ExpenseCluster</class>
+   <extends>QWidget</extends>
+   <header>expensecluster.h</header>
+  </customwidget>
+  <customwidget>
    <class>ItemCluster</class>
    <extends>QWidget</extends>
    <header>itemcluster.h</header>
@@ -676,7 +744,6 @@ to be bound by its terms.</comment>
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>_item</tabstop>
   <tabstop>_vendorDescrip</tabstop>
   <tabstop>_toReceive</tabstop>
   <tabstop>_purchCost</tabstop>


### PR DESCRIPTION
Clarify Goods Receipt screens for non-inventory items so users know what they actually should be receipting/confirming.

requires xtuple/xtuple#2672