### PR TITLE
issue #27813 Cleaned up bugs in Customer Group feature

### DIFF
--- a/guiclient/cashReceipt.cpp
+++ b/guiclient/cashReceipt.cpp
@@ -687,6 +687,9 @@ void cashReceipt::sAdd()
       return;
   }
 
+  if (_customerSelector->isSelectedGroup())
+    save(true);
+
   ParameterList params = getParams();
   params.append("mode", "new");
 

--- a/guiclient/cashReceiptMiscDistrib.cpp
+++ b/guiclient/cashReceiptMiscDistrib.cpp
@@ -84,7 +84,10 @@ enum SetResponse cashReceiptMiscDistrib::set(const ParameterList &pParams)
   if (valid && param.toString() == "G")
     setGroup(pParams);
   if (valid && param.toString() == "C")
+  {
     _custSelector->setVisible(false);
+    _custSelLit->setVisible(false);
+  }
 
   return NoError;
 }


### PR DESCRIPTION
* Eliminated unnecessary label when adding a miscellaneous distribution using Customer and not Customer Group.
* Fixed changing Customer Group in the dropdown on Cash Receipts screen not properly saving change for calling Miscellaneous Cash Receipt Distribution screen.
* Disabled Add button in Misc. Distribution tab when a Customer Group with no Customers is selected.