### PR TITLE
issue #25125: Refactored copyItem into two steps

### DIFF
--- a/guiclient/copyItem.cpp
+++ b/guiclient/copyItem.cpp
@@ -102,7 +102,7 @@ void copyItem::sNext()
 
     if (saveItem())
     {
-      _pages->setSelectedIndex(1);
+      _pages->setCurrentIndex(1);
     }
   }
 }
@@ -683,7 +683,7 @@ void copyItem::cancelCopy()
   { 
     XSqlQuery query;
     query.prepare("SELECT deleteItem(:itemid)");
-    query.bind(":itemid", _newitemid);
+    query.bindValue(":itemid", _newitemid);
     query.exec();
   }
 }

--- a/guiclient/copyItem.cpp
+++ b/guiclient/copyItem.cpp
@@ -156,8 +156,8 @@ bool copyItem::saveItem()
 
     // Set item inactive until copy is committed.
 
-    itemsave.prepare("UPDATE item SET item_active=false,"
-                     "                item_descrip1=:item_descrip1"
+    itemsave.prepare("UPDATE item SET item_active=false, "
+                     "                item_descrip1=:item_descrip1 "
                      "WHERE (item_id=:item_id);");
     itemsave.bindValue(":item_id", _newitemid);
     itemsave.bindValue(":item_descrip1", _targetItemDescrip->text());
@@ -563,8 +563,8 @@ void copyItem::sCopy()
   if (! okToSave())
     return;
 
-  copyCopy.prepare("UPDATE item SET item_active=:item_active,"
-                   "                item_listprice=:item_listprice,"
+  copyCopy.prepare("UPDATE item SET item_active=:item_active, "
+                   "                item_listprice=:item_listprice, "
                    "                item_listcost=:item_listcost "
                    "WHERE (item_id=:item_id);");
   copyCopy.bindValue(":item_id", _newitemid);

--- a/guiclient/copyItem.cpp
+++ b/guiclient/copyItem.cpp
@@ -183,6 +183,9 @@ bool copyItem::saveItem()
 
 void copyItem::sCopyBom()
 {
+  if (_newitemid < 0)
+    return;
+
   if (_copyBOM->isChecked())
   {
     XSqlQuery bomitemq;
@@ -388,6 +391,9 @@ void copyItem::sFillBomitem()
 
 void copyItem::sCopyItemsite()
 {
+  if (_newitemid < 0)
+    return;
+
   if (_copyItemsite->isChecked())
   {
     XSqlQuery itemsiteq;

--- a/guiclient/copyItem.cpp
+++ b/guiclient/copyItem.cpp
@@ -560,8 +560,6 @@ bool copyItem::okToSave()
 void copyItem::sCopy()
 {
   XSqlQuery copyCopy;
-  if (! okToSave())
-    return;
 
   copyCopy.prepare("UPDATE item SET item_active=:item_active, "
                    "                item_listprice=:item_listprice, "

--- a/guiclient/copyItem.cpp
+++ b/guiclient/copyItem.cpp
@@ -168,7 +168,7 @@ bool copyItem::saveItem()
     itemupdate.bindValue(":item_descrip1", _targetItemDescrip->text());
     itemupdate.exec();
 
-    if (ErrorReporter::error(QtCriticalMsg, this tr("Error Copying Item"),
+    if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Copying Item"),
                                itemupdate, __FILE__, __LINE__))
     {
       // Remove the copied item since the Update failed.

--- a/guiclient/copyItem.cpp
+++ b/guiclient/copyItem.cpp
@@ -182,12 +182,12 @@ bool copyItem::saveItem()
 
     if (itemupdate.lastError().type() != QSqlError::NoError)
     {
-      // Remove the copied item since the Update failed.
+      // Remove the copied item since the update failed.
       cancelCopy();
 
       // Then report the error to the user.
       ErrorReporter::error(QtCriticalMsg, this, tr("Error Copying Item"),
-                               itemupdate, __FILE__, __LINE__));
+                               itemupdate, __FILE__, __LINE__);
     }
     else
     {

--- a/guiclient/copyItem.cpp
+++ b/guiclient/copyItem.cpp
@@ -115,6 +115,7 @@ void copyItem::sUpdateItem()
                 "WHERE (item_id=:sourceitemid);");
 
   query.bindValue(":sourceitemid", _source->id());
+  query.exec();
 
   if (query.first())
   {
@@ -122,6 +123,11 @@ void copyItem::sUpdateItem()
     _listPrice->setDouble(query.value("item_listprice").toDouble());
     _listCost->setDouble(query.value("item_listcost").toDouble());
     _isActive = query.value("item_active").toBool();
+    _next->setEnabled(true);
+  }
+  else
+  {
+    _next->setEnabled(false);
   }
 }
 

--- a/guiclient/copyItem.cpp
+++ b/guiclient/copyItem.cpp
@@ -187,7 +187,7 @@ bool copyItem::saveItem()
 
       // Then report the error to the user.
       ErrorReporter::error(QtCriticalMsg, this, tr("Error Copying Item"),
-                               itemupdate, __FILE__, __LINE__))
+                               itemupdate, __FILE__, __LINE__));
     }
     else
     {

--- a/guiclient/copyItem.cpp
+++ b/guiclient/copyItem.cpp
@@ -142,7 +142,7 @@ bool copyItem::saveItem()
   XSqlQuery itemsave;
 
   itemsave.prepare("SELECT copyItem(item_id, :targetitemnumber) AS result,"
-                   "       item_id"
+                   "       item_id "
                    "FROM item "
                    "WHERE (item_id=:sourceitemid);");
 

--- a/guiclient/copyItem.h
+++ b/guiclient/copyItem.h
@@ -61,6 +61,7 @@ private:
     bool _captive;
     bool _inTransaction;
     bool _isActive;
+    bool _committed;
     int _newitemid;
 
 };

--- a/guiclient/copyItem.h
+++ b/guiclient/copyItem.h
@@ -51,9 +51,6 @@ public slots:
 
 protected slots:
     virtual void languageChange();
-    virtual void begin();
-    virtual void rollback();
-    virtual void commit();
     virtual void cancelCopy();
     virtual bool saveItem();
 

--- a/guiclient/copyItem.h
+++ b/guiclient/copyItem.h
@@ -28,7 +28,6 @@ public:
     Q_INVOKABLE inline  bool    captive() const { return _captive; }
     Q_INVOKABLE virtual bool    okToSave();
     Q_INVOKABLE virtual int     id()   const;
-    Q_INVOKABLE virtual void    cancelCopy();
 
 public slots:
     virtual enum SetResponse set(const ParameterList & pParams);
@@ -55,10 +54,13 @@ protected slots:
     virtual void begin();
     virtual void rollback();
     virtual void commit();
+    virtual void cancelCopy();
+    virtual bool saveItem();
 
 private:
     bool _captive;
     bool _inTransaction;
+    bool _isActive;
     int _newitemid;
 
 };

--- a/guiclient/copyItem.h
+++ b/guiclient/copyItem.h
@@ -28,11 +28,12 @@ public:
     Q_INVOKABLE inline  bool    captive() const { return _captive; }
     Q_INVOKABLE virtual bool    okToSave();
     Q_INVOKABLE virtual int     id()   const;
+    Q_INVOKABLE virtual void    cancelCopy();
 
 public slots:
     virtual enum SetResponse set(const ParameterList & pParams);
     virtual void clear();
-    virtual void sSaveItem();
+    virtual void sUpdateItem();
     virtual void sCopyBom();
     virtual void sAddBomitem();
     virtual void sEditBomitem();
@@ -44,11 +45,16 @@ public slots:
     virtual void sEditItemsite();
     virtual void sRevokeItemsite();
     virtual void sFillItemsite();
+    virtual void sNext();
+    virtual void sCancel();
     virtual void sCopy();
     virtual void closeEvent( QCloseEvent * pEvent );
 
 protected slots:
     virtual void languageChange();
+    virtual void begin();
+    virtual void rollback();
+    virtual void commit();
 
 private:
     bool _captive;

--- a/guiclient/copyItem.ui
+++ b/guiclient/copyItem.ui
@@ -340,13 +340,7 @@ to be bound by its terms.</comment>
               </layout>
              </item>
              <item>
-              <widget class="XTreeWidget" name="_availablebomitems">
-               <column>
-                <property name="text">
-                 <string notr="true">1</string>
-                </property>
-               </column>
-              </widget>
+              <widget class="XTreeWidget" name="_availablebomitems" />
              </item>
             </layout>
            </item>
@@ -414,13 +408,7 @@ to be bound by its terms.</comment>
               </widget>
              </item>
              <item>
-              <widget class="XTreeWidget" name="_addedbomitems">
-               <column>
-                <property name="text">
-                 <string notr="true">1</string>
-                </property>
-               </column>
-              </widget>
+              <widget class="XTreeWidget" name="_addedbomitems" />
              </item>
             </layout>
            </item>
@@ -441,13 +429,7 @@ to be bound by its terms.</comment>
               </widget>
              </item>
              <item>
-              <widget class="XTreeWidget" name="_addeditemsites">
-               <column>
-                <property name="text">
-                 <string notr="true">1</string>
-                </property>
-               </column>
-              </widget>
+              <widget class="XTreeWidget" name="_addeditemsites" />
              </item>
             </layout>
            </item>
@@ -560,38 +542,6 @@ to be bound by its terms.</comment>
     <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>_close</sender>
-   <signal>clicked()</signal>
-   <receiver>copyItem</receiver>
-   <slot>close()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>_cancel</sender>
-   <signal>clicked()</signal>
-   <receiver>copyItem</receiver>
-   <slot>close()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>546</x>
-     <y>39</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>305</x>
-     <y>248</y>
     </hint>
    </hints>
   </connection>

--- a/guiclient/copyItem.ui
+++ b/guiclient/copyItem.ui
@@ -13,19 +13,95 @@ to be bound by its terms.</comment>
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>718</width>
-    <height>600</height>
+    <width>611</width>
+    <height>497</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Copy Item</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_6">
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
+  <layout class="QGridLayout" name="gridLayout_3">
+   <item row="0" column="0">
+    <widget class="QStackedWidget" name="_pages">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="page">
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="2" rowspan="3">
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <widget class="QPushButton" name="_cancel">
+           <property name="text">
+            <string>&amp;Cancel</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="_next">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Next</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="_targetItemNumberLit">
+         <property name="text">
+          <string>&amp;Target Item Number:</string>
+         </property>
+         <property name="buddy">
+          <cstring>_targetItemNumber</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="XLineEdit" name="_targetItemNumber"/>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="_targetItemDescripLit">
+         <property name="text">
+          <string>Target Item Description:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="XLineEdit" name="_targetItemDescrip"/>
+       </item>
+       <item row="3" column="0">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>323</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="0" column="0" colspan="2">
         <layout class="QVBoxLayout">
          <property name="spacing">
           <number>0</number>
@@ -38,7 +114,7 @@ to be bound by its terms.</comment>
           </widget>
          </item>
          <item>
-          <widget class="ItemCluster" name="_source">
+          <widget class="ItemCluster" name="_source" native="true">
            <property name="focusPolicy">
             <enum>Qt::StrongFocus</enum>
            </property>
@@ -46,62 +122,72 @@ to be bound by its terms.</comment>
          </item>
         </layout>
        </item>
-       <item>
-        <layout class="QHBoxLayout">
+      </layout>
+     </widget>
+     <widget class="QWidget" name="page_2">
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
-          <widget class="QLabel" name="_targetItemNumberLit">
+          <widget class="XCheckBox" name="_copyBOM">
            <property name="text">
-            <string>&amp;Target Item Number:</string>
+            <string>Copy Bill of Materials</string>
            </property>
-           <property name="buddy">
-            <cstring>_targetItemNumber</cstring>
+           <property name="forgetful" stdset="0">
+            <bool>false</bool>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="XLineEdit" name="_targetItemNumber"/>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_6">
-         <item>
-          <widget class="QLabel" name="_targetItemDescripLit">
-           <property name="text">
-            <string>Target Item Description:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="XLineEdit" name="_targetItemDescrip"/>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="gridLayout">
-         <item row="0" column="1">
           <widget class="XCheckBox" name="_copyItemsite">
            <property name="text">
             <string>Copy Item Sites</string>
            </property>
           </widget>
          </item>
-         <item row="0" column="0">
-          <widget class="XCheckBox" name="_copyBOM">
+        </layout>
+       </item>
+       <item row="0" column="2" rowspan="2">
+        <layout class="QVBoxLayout">
+         <item>
+          <widget class="QPushButton" name="_close">
            <property name="text">
-            <string>Copy Bill of Materials</string>
-           </property>
-           <property name="forgetful">
-            <bool>false</bool>
+            <string>&amp;Cancel</string>
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QPushButton" name="_copy">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Co&amp;py</string>
+           </property>
+           <property name="default">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer>
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Expanding</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>87</width>
+             <height>0</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
         </layout>
        </item>
-       <item>
+       <item row="1" column="0">
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
           <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -189,7 +275,20 @@ to be bound by its terms.</comment>
          </item>
         </layout>
        </item>
-       <item>
+       <item row="1" column="1">
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>84</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="0">
         <spacer>
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -205,216 +304,194 @@ to be bound by its terms.</comment>
          </property>
         </spacer>
        </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QVBoxLayout">
-       <item>
-        <widget class="QPushButton" name="_close">
-         <property name="text">
-          <string>&amp;Cancel</string>
+       <item row="3" column="0" colspan="3">
+        <widget class="QTabWidget" name="_tab">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>1</verstretch>
+          </sizepolicy>
          </property>
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="_bomTab">
+          <attribute name="title">
+           <string>Bill of Material</string>
+          </attribute>
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <item>
+            <layout class="QVBoxLayout" name="verticalLayout_5">
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_2">
+               <item>
+                <widget class="QLabel" name="_searchForLit">
+                 <property name="text">
+                  <string>Search For Item:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="XLineEdit" name="_searchForBOM"/>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <widget class="XTreeWidget" name="_availablebomitems">
+               <column>
+                <property name="text">
+                 <string notr="true">1</string>
+                </property>
+               </column>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QVBoxLayout" name="verticalLayout_3">
+             <item>
+              <spacer>
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Expanding</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <layout class="QVBoxLayout" name="verticalLayout">
+               <item>
+                <widget class="QPushButton" name="_addBOM">
+                 <property name="text">
+                  <string>Add-&gt;</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="_revokeBOM">
+                 <property name="text">
+                  <string>&lt;-Remove</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <spacer>
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Expanding</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QVBoxLayout" name="verticalLayout_4">
+             <item>
+              <widget class="QLabel" name="_addedbomitemsLit">
+               <property name="text">
+                <string>Component Items:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="XTreeWidget" name="_addedbomitems">
+               <column>
+                <property name="text">
+                 <string notr="true">1</string>
+                </property>
+               </column>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="_itemsiteTab">
+          <attribute name="title">
+           <string>Item Site</string>
+          </attribute>
+          <layout class="QHBoxLayout" name="horizontalLayout_7">
+           <item>
+            <layout class="QVBoxLayout" name="verticalLayout_10">
+             <item>
+              <widget class="QLabel" name="_addeditemsitesLit">
+               <property name="text">
+                <string>Item Sites:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="XTreeWidget" name="_addeditemsites">
+               <column>
+                <property name="text">
+                 <string notr="true">1</string>
+                </property>
+               </column>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QVBoxLayout" name="verticalLayout_11">
+             <item>
+              <layout class="QVBoxLayout" name="verticalLayout_12">
+               <item>
+                <widget class="QPushButton" name="_addItemsite">
+                 <property name="text">
+                  <string>Copy</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="_revokeItemsite">
+                 <property name="text">
+                  <string>Remove</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <spacer>
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Expanding</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
         </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="_copy">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string>Co&amp;py</string>
-         </property>
-         <property name="default">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Expanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>87</width>
-           <height>0</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QTabWidget" name="_tab">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>1</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="_bomTab">
-      <attribute name="title">
-       <string>Bill of Material</string>
-      </attribute>
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout_5">
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
-           <item>
-            <widget class="QLabel" name="_searchForLit">
-             <property name="text">
-              <string>Search For Item:</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="XLineEdit" name="_searchForBOM"/>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <widget class="XTreeWidget" name="_availablebomitems"/>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout_3">
-         <item>
-          <spacer>
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Expanding</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout">
-           <item>
-            <widget class="QPushButton" name="_addBOM">
-             <property name="text">
-              <string>Add-&gt;</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="_revokeBOM">
-             <property name="text">
-              <string>&lt;-Remove</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <spacer>
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Expanding</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout_4">
-         <item>
-          <widget class="QLabel" name="_addedbomitemsLit">
-           <property name="text">
-            <string>Component Items:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="XTreeWidget" name="_addedbomitems"/>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="_itemsiteTab">
-      <attribute name="title">
-       <string>Item Site</string>
-      </attribute>
-      <layout class="QHBoxLayout" name="horizontalLayout_7">
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout_10">
-         <item>
-          <widget class="QLabel" name="_addeditemsitesLit">
-           <property name="text">
-            <string>Item Sites:</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="XTreeWidget" name="_addeditemsites"/>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout_11">
-         <item>
-          <layout class="QVBoxLayout" name="verticalLayout_12">
-           <item>
-            <widget class="QPushButton" name="_addItemsite">
-             <property name="text">
-              <string>Copy</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="_revokeItemsite">
-             <property name="text">
-              <string>Remove</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <spacer>
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Expanding</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
        </item>
       </layout>
      </widget>
@@ -458,7 +535,6 @@ to be bound by its terms.</comment>
   <tabstop>_listPrice</tabstop>
   <tabstop>_listCost</tabstop>
   <tabstop>_copy</tabstop>
-  <tabstop>_close</tabstop>
   <tabstop>_tab</tabstop>
   <tabstop>_searchForBOM</tabstop>
   <tabstop>_availablebomitems</tabstop>
@@ -500,6 +576,22 @@ to be bound by its terms.</comment>
     <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>_cancel</sender>
+   <signal>clicked()</signal>
+   <receiver>copyItem</receiver>
+   <slot>close()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>546</x>
+     <y>39</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>305</x>
+     <y>248</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
This commit addresses a race condition.  When selecting an available item number for the new item, the number was being selected within a transaction block.  Until it was committed, other users could select the same item number.  The attempt to find a number by appending an integer to it was not sufficient.

In this proposed solution, I split the copy process into two steps.  After identifying what item to copy, the user must first enter an item number and click "Next".  A database call immediately checks if the item number is available before creating the new item.  When the new item is created successfully, that item exists in the database, and the number can be found by other users.  After clicking "Next", the user can decide what children to copy (item sites, BOMs, etc.)

If after clicking "Next", the user decides to cancel, changes on the second page of the screen are rolled back, and the new item is removed from the database.  A click on "Copy" on this second page of the screen completes the copy operation.