### PR TITLE
Network fixes

### DIFF
--- a/scriptapi/engineevaluate.cpp
+++ b/scriptapi/engineevaluate.cpp
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which(including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#include "engineevaluate.h"
+#include <QtScript>
+
+QScriptValue engineEvaluateForJS(QScriptContext* context, QScriptEngine* engine)
+{
+  if (context->argumentCount() == 2 &&
+      context->argument(0).isString() &&
+      context->argument(1).isString()) {
+
+    context->setActivationObject(context->parentContext()->activationObject());
+    context->setThisObject(context->parentContext()->thisObject());
+
+    QString script = context->argument(0).toString();
+    QString scriptname = context->argument(1).toString();
+    QScriptValue result = engine->evaluate(script, scriptname, 1);
+
+    if (engine->hasUncaughtException()) {
+      qWarning() << "Uncaught exception in script: " << scriptname
+                 << " at line: "
+                 << engine->uncaughtExceptionLineNumber() << ":"
+                 << result.toString();
+      return engine->toScriptValue(false);
+    } else {
+      return result;
+    }
+  } else {
+    context->throwError(QScriptContext::UnknownError,
+                          "The engineEvaluate() method takes two arguments.");
+    return engine->toScriptValue(false);
+  }
+}
+
+void setupEngineEvaluate(QScriptEngine *engine)
+{
+  QScriptValue engineEvaluate = engine->newFunction(engineEvaluateForJS);
+  engine->globalObject().setProperty("engineEvaluate", engineEvaluate);
+}

--- a/scriptapi/engineevaluate.h
+++ b/scriptapi/engineevaluate.h
@@ -1,0 +1,8 @@
+#ifndef __ENGINEEVALUATE_H__
+#define __ENGINEEVALUATE_H__
+
+class QScriptEngine;
+
+void setupEngineEvaluate(QScriptEngine *engine);
+
+#endif // __ENGINEEVALUATE_H__

--- a/scriptapi/qbytearrayproto.cpp
+++ b/scriptapi/qbytearrayproto.cpp
@@ -10,6 +10,7 @@
 
 #include "qbytearrayproto.h"
 #include <QScriptValueIterator>
+#include <QDataStream>
 
 static QByteArray nullBA = QByteArray();
 
@@ -1053,7 +1054,6 @@ QString QByteArrayProto::toString() const
 }
 
 // Node.js Buffer emulation helper functions.
-#include <QDataStream>
 int QByteArrayProto::readInt16BE(int offset, bool noAssert) const
 {
   QByteArray *item = qscriptvalue_cast<QByteArray*>(thisObject());

--- a/scriptapi/qdnsdomainnamerecordproto.cpp
+++ b/scriptapi/qdnsdomainnamerecordproto.cpp
@@ -28,14 +28,20 @@ QScriptValue QListQDnsDomainNameRecordToScriptValue(QScriptEngine *engine, const
 void QListQDnsDomainNameRecordFromScriptValue(const QScriptValue &obj, QList<QDnsDomainNameRecord> &list)
 {
   list = QList<QDnsDomainNameRecord>();
-  QScriptValueIterator it(obj);
 
-  while (it.hasNext()) {
-    it.next();
-    if (it.flags() & QScriptValue::SkipInEnumeration)
-      continue;
-    QDnsDomainNameRecord item = qscriptvalue_cast<QDnsDomainNameRecord>(it.value());
-    list.insert(it.name().toInt(), item);
+  if (obj.isArray()) {
+    QScriptValueIterator it(obj);
+
+    while (it.hasNext()) {
+      it.next();
+      if (it.flags() & QScriptValue::SkipInEnumeration)
+        continue;
+
+      if (it.value().isString()) {
+        QDnsDomainNameRecord item = qscriptvalue_cast<QDnsDomainNameRecord>(it.value());
+        list.insert(it.name().toInt(), item);
+      }
+    }
   }
 }
 

--- a/scriptapi/qdnsdomainnamerecordproto.cpp
+++ b/scriptapi/qdnsdomainnamerecordproto.cpp
@@ -11,6 +11,11 @@
 #include "qdnsdomainnamerecordproto.h"
 
 #if QT_VERSION < 0x050000
+void setupQDnsDomainNameRecordProto(QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+}
+#else
 
 QScriptValue QListQDnsDomainNameRecordToScriptValue(QScriptEngine *engine, const QList<QDnsDomainNameRecord> &list)
 {
@@ -67,7 +72,7 @@ QDnsDomainNameRecordProto::~QDnsDomainNameRecordProto()
 
 QString QDnsDomainNameRecordProto::name() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsDomainNameRecord *item = qscriptvalue_cast<QDnsDomainNameRecord*>(thisObject());
   if (item)
     return item->name();
   return QString();
@@ -75,14 +80,14 @@ QString QDnsDomainNameRecordProto::name() const
 
 void QDnsDomainNameRecordProto::swap(QDnsDomainNameRecord &other)
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsDomainNameRecord *item = qscriptvalue_cast<QDnsDomainNameRecord*>(thisObject());
   if (item)
     item->swap(other);
 }
 
 quint32 QDnsDomainNameRecordProto::timeToLive() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsDomainNameRecord *item = qscriptvalue_cast<QDnsDomainNameRecord*>(thisObject());
   if (item)
     return item->timeToLive();
   return quint32();
@@ -90,7 +95,7 @@ quint32 QDnsDomainNameRecordProto::timeToLive() const
 
 QString QDnsDomainNameRecordProto::value() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsDomainNameRecord *item = qscriptvalue_cast<QDnsDomainNameRecord*>(thisObject());
   if (item)
     return item->value();
   return QString();
@@ -98,9 +103,9 @@ QString QDnsDomainNameRecordProto::value() const
 
 QString QDnsDomainNameRecordProto::toString() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsDomainNameRecord *item = qscriptvalue_cast<QDnsDomainNameRecord*>(thisObject());
   if (item)
-    return item->toString();
+    return item->value();
   return QString();
 }
 

--- a/scriptapi/qdnsdomainnamerecordproto.cpp
+++ b/scriptapi/qdnsdomainnamerecordproto.cpp
@@ -1,0 +1,107 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which(including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#include "qdnsdomainnamerecordproto.h"
+
+#if QT_VERSION < 0x050000
+
+QScriptValue QListQDnsDomainNameRecordToScriptValue(QScriptEngine *engine, const QList<QDnsDomainNameRecord> &list)
+{
+  QScriptValue newArray = engine->newArray();
+  for (int i = 0; i < list.size(); i += 1) {
+    newArray.setProperty(i, engine->toScriptValue(list.at(i)));
+  }
+  return newArray;
+}
+void QListQDnsDomainNameRecordFromScriptValue(const QScriptValue &obj, QList<QDnsDomainNameRecord> &list)
+{
+  list = QList<QDnsDomainNameRecord>();
+  QScriptValueIterator it(obj);
+
+  while (it.hasNext()) {
+    it.next();
+    if (it.flags() & QScriptValue::SkipInEnumeration)
+      continue;
+    QDnsDomainNameRecord item = qscriptvalue_cast<QDnsDomainNameRecord>(it.value());
+    list.insert(it.name().toInt(), item);
+  }
+}
+
+void setupQDnsDomainNameRecordProto(QScriptEngine *engine)
+{
+  QScriptValue proto = engine->newQObject(new QDnsDomainNameRecordProto(engine));
+  engine->setDefaultPrototype(qMetaTypeId<QDnsDomainNameRecord*>(), proto);
+  engine->setDefaultPrototype(qMetaTypeId<QDnsDomainNameRecord>(),  proto);
+
+  QScriptValue constructor = engine->newFunction(constructQDnsDomainNameRecord, proto);
+  engine->globalObject().setProperty("QDnsDomainNameRecord",  constructor);
+
+  qScriptRegisterMetaType(engine, QListQDnsDomainNameRecordToScriptValue, QListQDnsDomainNameRecordFromScriptValue);
+}
+
+QScriptValue constructQDnsDomainNameRecord(QScriptContext *context, QScriptEngine *engine)
+{
+  QDnsDomainNameRecord *obj = 0;
+  if (context->argumentCount() == 1 && context->argument(0).isObject()) {
+    obj = new QDnsDomainNameRecord(qscriptvalue_cast<QDnsDomainNameRecord>(context->argument(0)));
+  } else {
+    obj = new QDnsDomainNameRecord();
+  }
+
+  return engine->toScriptValue(obj);
+}
+
+QDnsDomainNameRecordProto::QDnsDomainNameRecordProto(QObject *parent) : QObject(parent)
+{
+}
+QDnsDomainNameRecordProto::~QDnsDomainNameRecordProto()
+{
+}
+
+QString QDnsDomainNameRecordProto::name() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->name();
+  return QString();
+}
+
+void QDnsDomainNameRecordProto::swap(QDnsDomainNameRecord &other)
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    item->swap(other);
+}
+
+quint32 QDnsDomainNameRecordProto::timeToLive() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->timeToLive();
+  return quint32();
+}
+
+QString QDnsDomainNameRecordProto::value() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->value();
+  return QString();
+}
+
+QString QDnsDomainNameRecordProto::toString() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->toString();
+  return QString();
+}
+
+#endif

--- a/scriptapi/qdnsdomainnamerecordproto.h
+++ b/scriptapi/qdnsdomainnamerecordproto.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which(including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#ifndef __QDNSDOMAINNAMERECORDPROTO_H__
+#define __QDNSDOMAINNAMERECORDPROTO_H__
+
+#include <QtScript>
+
+void setupQDnsDomainNameRecordProto(engine);
+
+#if QT_VERSION >= 0x050000
+
+#include <QDnsDomainNameRecord>
+
+Q_DECLARE_METATYPE(QDnsDomainNameRecord*)
+Q_DECLARE_METATYPE(QDnsDomainNameRecord)
+
+QScriptValue constructQDnsDomainNameRecord(QScriptContext *context, QScriptEngine *engine);
+
+class QDnsDomainNameRecordProto : public QObject, public QScriptable
+{
+  Q_OBJECT
+
+  public:
+    QDnsDomainNameRecordProto(QObject *parent);
+    Q_INVOKABLE virtual ~QDnsDomainNameRecordProto();
+
+    Q_INVOKABLE QString   name() const;
+    Q_INVOKABLE void      swap(QDnsDomainNameRecord &other);
+    Q_INVOKABLE quint32   timeToLive() const;
+    Q_INVOKABLE QString   value() const;
+
+    Q_INVOKABLE QString   toString() const;
+
+};
+
+#endif
+
+#endif // __QDNSDOMAINNAMERECORDPROTO_H__

--- a/scriptapi/qdnsdomainnamerecordproto.h
+++ b/scriptapi/qdnsdomainnamerecordproto.h
@@ -13,7 +13,7 @@
 
 #include <QtScript>
 
-void setupQDnsDomainNameRecordProto(engine);
+void setupQDnsDomainNameRecordProto(QScriptEngine *engine);
 
 #if QT_VERSION >= 0x050000
 

--- a/scriptapi/qdnshostaddressrecordproto.cpp
+++ b/scriptapi/qdnshostaddressrecordproto.cpp
@@ -1,0 +1,107 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which(including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#include "qdnshostaddressrecordproto.h"
+
+#if QT_VERSION < 0x050000
+
+QScriptValue QListQDnsHostAddressRecordToScriptValue(QScriptEngine *engine, const QList<QDnsHostAddressRecord> &list)
+{
+  QScriptValue newArray = engine->newArray();
+  for (int i = 0; i < list.size(); i += 1) {
+    newArray.setProperty(i, engine->toScriptValue(list.at(i)));
+  }
+  return newArray;
+}
+void QListQDnsHostAddressRecordFromScriptValue(const QScriptValue &obj, QList<QDnsHostAddressRecord> &list)
+{
+  list = QList<QDnsHostAddressRecord>();
+  QScriptValueIterator it(obj);
+
+  while (it.hasNext()) {
+    it.next();
+    if (it.flags() & QScriptValue::SkipInEnumeration)
+      continue;
+    QDnsHostAddressRecord item = qscriptvalue_cast<QDnsHostAddressRecord>(it.value());
+    list.insert(it.name().toInt(), item);
+  }
+}
+
+void setupQDnsHostAddressRecordProto(QScriptEngine *engine)
+{
+  QScriptValue proto = engine->newQObject(new QDnsHostAddressRecordProto(engine));
+  engine->setDefaultPrototype(qMetaTypeId<QDnsHostAddressRecord*>(), proto);
+  engine->setDefaultPrototype(qMetaTypeId<QDnsHostAddressRecord>(),  proto);
+
+  QScriptValue constructor = engine->newFunction(constructQDnsHostAddressRecord, proto);
+  engine->globalObject().setProperty("QDnsHostAddressRecord",  constructor);
+
+  qScriptRegisterMetaType(engine, QListQDnsHostAddressRecordToScriptValue, QListQDnsHostAddressRecordFromScriptValue);
+}
+
+QScriptValue constructQDnsHostAddressRecord(QScriptContext *context, QScriptEngine *engine)
+{
+  QDnsHostAddressRecord *obj = 0;
+  if (context->argumentCount() == 1 && context->argument(0).isObject()) {
+    obj = new QDnsHostAddressRecord(qscriptvalue_cast<QDnsHostAddressRecord>(context->argument(0)));
+  } else {
+    obj = new QDnsHostAddressRecord();
+  }
+
+  return engine->toScriptValue(obj);
+}
+
+QDnsHostAddressRecordProto::QDnsHostAddressRecordProto(QObject *parent) : QObject(parent)
+{
+}
+QDnsHostAddressRecordProto::~QDnsHostAddressRecordProto()
+{
+}
+
+QString QDnsHostAddressRecordProto::name() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->name();
+  return QString();
+}
+
+void QDnsHostAddressRecordProto::swap(QDnsHostAddressRecord &other)
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    item->swap(other);
+}
+
+quint32 QDnsHostAddressRecordProto::timeToLive() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->timeToLive();
+  return quint32();
+}
+
+QHostAddress QDnsHostAddressRecordProto::value() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->value();
+  return QHostAddress();
+}
+
+QString QDnsHostAddressRecordProto::toString() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->toString();
+  return QString();
+}
+
+#endif

--- a/scriptapi/qdnshostaddressrecordproto.cpp
+++ b/scriptapi/qdnshostaddressrecordproto.cpp
@@ -11,6 +11,11 @@
 #include "qdnshostaddressrecordproto.h"
 
 #if QT_VERSION < 0x050000
+void setupQDnsHostAddressRecordProto(QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+}
+#else
 
 QScriptValue QListQDnsHostAddressRecordToScriptValue(QScriptEngine *engine, const QList<QDnsHostAddressRecord> &list)
 {
@@ -67,7 +72,7 @@ QDnsHostAddressRecordProto::~QDnsHostAddressRecordProto()
 
 QString QDnsHostAddressRecordProto::name() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsHostAddressRecord *item = qscriptvalue_cast<QDnsHostAddressRecord*>(thisObject());
   if (item)
     return item->name();
   return QString();
@@ -75,14 +80,14 @@ QString QDnsHostAddressRecordProto::name() const
 
 void QDnsHostAddressRecordProto::swap(QDnsHostAddressRecord &other)
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsHostAddressRecord *item = qscriptvalue_cast<QDnsHostAddressRecord*>(thisObject());
   if (item)
     item->swap(other);
 }
 
 quint32 QDnsHostAddressRecordProto::timeToLive() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsHostAddressRecord *item = qscriptvalue_cast<QDnsHostAddressRecord*>(thisObject());
   if (item)
     return item->timeToLive();
   return quint32();
@@ -90,7 +95,7 @@ quint32 QDnsHostAddressRecordProto::timeToLive() const
 
 QHostAddress QDnsHostAddressRecordProto::value() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsHostAddressRecord *item = qscriptvalue_cast<QDnsHostAddressRecord*>(thisObject());
   if (item)
     return item->value();
   return QHostAddress();
@@ -98,9 +103,9 @@ QHostAddress QDnsHostAddressRecordProto::value() const
 
 QString QDnsHostAddressRecordProto::toString() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsHostAddressRecord *item = qscriptvalue_cast<QDnsHostAddressRecord*>(thisObject());
   if (item)
-    return item->toString();
+    return item->value().toString();
   return QString();
 }
 

--- a/scriptapi/qdnshostaddressrecordproto.cpp
+++ b/scriptapi/qdnshostaddressrecordproto.cpp
@@ -28,14 +28,20 @@ QScriptValue QListQDnsHostAddressRecordToScriptValue(QScriptEngine *engine, cons
 void QListQDnsHostAddressRecordFromScriptValue(const QScriptValue &obj, QList<QDnsHostAddressRecord> &list)
 {
   list = QList<QDnsHostAddressRecord>();
-  QScriptValueIterator it(obj);
 
-  while (it.hasNext()) {
-    it.next();
-    if (it.flags() & QScriptValue::SkipInEnumeration)
-      continue;
-    QDnsHostAddressRecord item = qscriptvalue_cast<QDnsHostAddressRecord>(it.value());
-    list.insert(it.name().toInt(), item);
+  if (obj.isArray()) {
+    QScriptValueIterator it(obj);
+
+    while (it.hasNext()) {
+      it.next();
+      if (it.flags() & QScriptValue::SkipInEnumeration)
+        continue;
+
+      if (it.value().isString()) {
+        QDnsHostAddressRecord item = qscriptvalue_cast<QDnsHostAddressRecord>(it.value());
+        list.insert(it.name().toInt(), item);
+      }
+    }
   }
 }
 

--- a/scriptapi/qdnshostaddressrecordproto.h
+++ b/scriptapi/qdnshostaddressrecordproto.h
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which(including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#ifndef __QDNSHOSTADDRESSRECORDPROTO_H__
+#define __QDNSHOSTADDRESSRECORDPROTO_H__
+
+#include <QtScript>
+
+void setupQDnsHostAddressRecordProto(engine);
+
+#if QT_VERSION >= 0x050000
+
+#include <QDnsHostAddressRecord>
+#include <QHostAddress>
+
+Q_DECLARE_METATYPE(QDnsHostAddressRecord*)
+Q_DECLARE_METATYPE(QDnsHostAddressRecord)
+
+QScriptValue constructQDnsHostAddressRecord(QScriptContext *context, QScriptEngine *engine);
+
+class QDnsHostAddressRecordProto : public QObject, public QScriptable
+{
+  Q_OBJECT
+
+  public:
+    QDnsHostAddressRecordProto(QObject *parent);
+    Q_INVOKABLE virtual ~QDnsHostAddressRecordProto();
+
+    Q_INVOKABLE QString         name() const;
+    Q_INVOKABLE void            swap(QDnsHostAddressRecord &other);
+    Q_INVOKABLE quint32         timeToLive() const;
+    Q_INVOKABLE QHostAddress    value() const;
+
+    Q_INVOKABLE QString         toString() const;
+
+};
+
+#endif
+
+#endif // __QDNSHOSTADDRESSRECORDPROTO_H__

--- a/scriptapi/qdnshostaddressrecordproto.h
+++ b/scriptapi/qdnshostaddressrecordproto.h
@@ -13,7 +13,7 @@
 
 #include <QtScript>
 
-void setupQDnsHostAddressRecordProto(engine);
+void setupQDnsHostAddressRecordProto(QScriptEngine *engine);
 
 #if QT_VERSION >= 0x050000
 

--- a/scriptapi/qdnslookupproto.cpp
+++ b/scriptapi/qdnslookupproto.cpp
@@ -17,20 +17,20 @@ void setupQDnsLookupProto(QScriptEngine *engine)
 }
 #else
 
-QScriptValue ErrorToScriptValue(QScriptEngine *engine, const QDnsLookup::Error &item)
+QScriptValue DnsLookupErrorToScriptValue(QScriptEngine *engine, const QDnsLookup::Error &item)
 {
   return engine->newVariant(item);
 }
-void ErrorFromScriptValue(const QScriptValue &obj, QDnsLookup::Error &item)
+void DnsLookupErrorFromScriptValue(const QScriptValue &obj, QDnsLookup::Error &item)
 {
   item = (QDnsLookup::Error)obj.toInt32();
 }
 
-QScriptValue TypeToScriptValue(QScriptEngine *engine, const QDnsLookup::Type &item)
+QScriptValue DnsLookupTypeToScriptValue(QScriptEngine *engine, const QDnsLookup::Type &item)
 {
   return engine->newVariant(item);
 }
-void TypeFromScriptValue(const QScriptValue &obj, QDnsLookup::Type &item)
+void DnsLookupTypeFromScriptValue(const QScriptValue &obj, QDnsLookup::Type &item)
 {
   item = (QDnsLookup::Type)obj.toInt32();
 }
@@ -46,7 +46,7 @@ void setupQDnsLookupProto(QScriptEngine *engine)
   QScriptValue constructor = engine->newFunction(constructQDnsLookup, proto);
   engine->globalObject().setProperty("QDnsLookup",  constructor);
 
-  qScriptRegisterMetaType(engine, ErrorToScriptValue, ErrorFromScriptValue);
+  qScriptRegisterMetaType(engine, DnsLookupErrorToScriptValue, DnsLookupErrorFromScriptValue);
   constructor.setProperty("NoError", QScriptValue(engine, QDnsLookup::NoError), permanent);
   constructor.setProperty("ResolverError", QScriptValue(engine, QDnsLookup::ResolverError), permanent);
   constructor.setProperty("OperationCancelledError", QScriptValue(engine, QDnsLookup::OperationCancelledError), permanent);
@@ -56,7 +56,7 @@ void setupQDnsLookupProto(QScriptEngine *engine)
   constructor.setProperty("ServerRefusedError", QScriptValue(engine, QDnsLookup::ServerRefusedError), permanent);
   constructor.setProperty("NotFoundError", QScriptValue(engine, QDnsLookup::NotFoundError), permanent);
 
-  qScriptRegisterMetaType(engine, TypeToScriptValue, TypeFromScriptValue);
+  qScriptRegisterMetaType(engine, DnsLookupTypeToScriptValue, DnsLookupTypeFromScriptValue);
   constructor.setProperty("A", QScriptValue(engine, QDnsLookup::A), permanent);
   constructor.setProperty("AAAA", QScriptValue(engine, QDnsLookup::AAAA), permanent);
   constructor.setProperty("ANY", QScriptValue(engine, QDnsLookup::ANY), permanent);

--- a/scriptapi/qdnslookupproto.cpp
+++ b/scriptapi/qdnslookupproto.cpp
@@ -11,6 +11,11 @@
 #include "qdnslookupproto.h"
 
 #if QT_VERSION < 0x050000
+void setupQDnsLookupProto(QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+}
+#else
 
 QScriptValue ErrorToScriptValue(QScriptEngine *engine, const QDnsLookup::Error &item)
 {
@@ -36,7 +41,7 @@ void setupQDnsLookupProto(QScriptEngine *engine)
 
   QScriptValue proto = engine->newQObject(new QDnsLookupProto(engine));
   engine->setDefaultPrototype(qMetaTypeId<QDnsLookup*>(), proto);
-  engine->setDefaultPrototype(qMetaTypeId<QDnsLookup>(),  proto);
+  //engine->setDefaultPrototype(qMetaTypeId<QDnsLookup>(),  proto);
 
   QScriptValue constructor = engine->newFunction(constructQDnsLookup, proto);
   engine->globalObject().setProperty("QDnsLookup",  constructor);
@@ -67,19 +72,19 @@ QScriptValue constructQDnsLookup(QScriptContext *context, QScriptEngine *engine)
 {
   QDnsLookup *obj = 0;
   if (context->argumentCount() == 2 &&
-      context->argument(0).isString() &&
+      context->argument(0).isNumber() &&
       context->argument(1).isString()) {
 
-    obj = new QDnsLookup(context->argument(0).toString(),
-                         context->argument(1)).toString());
+    obj = new QDnsLookup((QDnsLookup::Type)context->argument(0).toInt32(),
+                         context->argument(1).toString());
   } else if (context->argumentCount() == 3 &&
-             context->argument(0).isString() &&
+             context->argument(0).isNumber() &&
              context->argument(1).isString() &&
              context->argument(2).isObject()) {
 
-    obj = new QDnsLookup(context->argument(0).toString(),
+    obj = new QDnsLookup((QDnsLookup::Type)context->argument(0).toInt32(),
                          context->argument(1).toString(),
-                         qscriptvalue_cast<QHostAddress>(context->argument(2)));
+                         QHostAddress(context->argument(2).toString()));
   } else {
     obj = new QDnsLookup();
   }
@@ -96,7 +101,7 @@ QDnsLookupProto::~QDnsLookupProto()
 
 QList<QDnsDomainNameRecord> QDnsLookupProto::canonicalNameRecords() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsLookup *item = qscriptvalue_cast<QDnsLookup*>(thisObject());
   if (item)
     return item->canonicalNameRecords();
   return QList<QDnsDomainNameRecord>();
@@ -104,7 +109,7 @@ QList<QDnsDomainNameRecord> QDnsLookupProto::canonicalNameRecords() const
 
 QDnsLookup::Error QDnsLookupProto::error() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsLookup *item = qscriptvalue_cast<QDnsLookup*>(thisObject());
   if (item)
     return item->error();
   return QDnsLookup::Error();
@@ -112,7 +117,7 @@ QDnsLookup::Error QDnsLookupProto::error() const
 
 QString QDnsLookupProto::errorString() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsLookup *item = qscriptvalue_cast<QDnsLookup*>(thisObject());
   if (item)
     return item->errorString();
   return QString();
@@ -120,7 +125,7 @@ QString QDnsLookupProto::errorString() const
 
 QList<QDnsHostAddressRecord> QDnsLookupProto::hostAddressRecords() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsLookup *item = qscriptvalue_cast<QDnsLookup*>(thisObject());
   if (item)
     return item->hostAddressRecords();
   return QList<QDnsHostAddressRecord>();
@@ -128,7 +133,7 @@ QList<QDnsHostAddressRecord> QDnsLookupProto::hostAddressRecords() const
 
 bool QDnsLookupProto::isFinished() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsLookup *item = qscriptvalue_cast<QDnsLookup*>(thisObject());
   if (item)
     return item->isFinished();
   return false;
@@ -136,7 +141,7 @@ bool QDnsLookupProto::isFinished() const
 
 QList<QDnsMailExchangeRecord> QDnsLookupProto::mailExchangeRecords() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsLookup *item = qscriptvalue_cast<QDnsLookup*>(thisObject());
   if (item)
     return item->mailExchangeRecords();
   return QList<QDnsMailExchangeRecord>();
@@ -144,7 +149,7 @@ QList<QDnsMailExchangeRecord> QDnsLookupProto::mailExchangeRecords() const
 
 QString QDnsLookupProto::name() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsLookup *item = qscriptvalue_cast<QDnsLookup*>(thisObject());
   if (item)
     return item->name();
   return QString();
@@ -152,7 +157,7 @@ QString QDnsLookupProto::name() const
 
 QList<QDnsDomainNameRecord> QDnsLookupProto::nameServerRecords() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsLookup *item = qscriptvalue_cast<QDnsLookup*>(thisObject());
   if (item)
     return item->nameServerRecords();
   return QList<QDnsDomainNameRecord>();
@@ -160,7 +165,7 @@ QList<QDnsDomainNameRecord> QDnsLookupProto::nameServerRecords() const
 
 QHostAddress QDnsLookupProto::nameserver() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsLookup *item = qscriptvalue_cast<QDnsLookup*>(thisObject());
   if (item)
     return item->nameserver();
   return QHostAddress();
@@ -168,7 +173,7 @@ QHostAddress QDnsLookupProto::nameserver() const
 
 QList<QDnsDomainNameRecord> QDnsLookupProto::pointerRecords() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsLookup *item = qscriptvalue_cast<QDnsLookup*>(thisObject());
   if (item)
     return item->pointerRecords();
   return QList<QDnsDomainNameRecord>();
@@ -176,7 +181,7 @@ QList<QDnsDomainNameRecord> QDnsLookupProto::pointerRecords() const
 
 QList<QDnsServiceRecord> QDnsLookupProto::serviceRecords() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsLookup *item = qscriptvalue_cast<QDnsLookup*>(thisObject());
   if (item)
     return item->serviceRecords();
   return QList<QDnsServiceRecord>();
@@ -184,28 +189,28 @@ QList<QDnsServiceRecord> QDnsLookupProto::serviceRecords() const
 
 void QDnsLookupProto::setName(const QString &name)
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsLookup *item = qscriptvalue_cast<QDnsLookup*>(thisObject());
   if (item)
     item->setName(name);
 }
 
 void QDnsLookupProto::setNameserver(const QHostAddress &nameserver)
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsLookup *item = qscriptvalue_cast<QDnsLookup*>(thisObject());
   if (item)
     item->setNameserver(nameserver);
 }
 
 void QDnsLookupProto::setType(QDnsLookup::Type type)
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsLookup *item = qscriptvalue_cast<QDnsLookup*>(thisObject());
   if (item)
     item->setType(type);
 }
 
 QList<QDnsTextRecord> QDnsLookupProto::textRecords() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsLookup *item = qscriptvalue_cast<QDnsLookup*>(thisObject());
   if (item)
     return item->textRecords();
   return QList<QDnsTextRecord>();
@@ -213,7 +218,7 @@ QList<QDnsTextRecord> QDnsLookupProto::textRecords() const
 
 QDnsLookup::Type QDnsLookupProto::type() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsLookup *item = qscriptvalue_cast<QDnsLookup*>(thisObject());
   if (item)
     return item->type();
   return QDnsLookup::Type();
@@ -221,10 +226,25 @@ QDnsLookup::Type QDnsLookupProto::type() const
 
 QString QDnsLookupProto::toString() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsLookup *item = qscriptvalue_cast<QDnsLookup*>(thisObject());
   if (item)
-    return item->toString();
+    return item->name();
   return QString();
 }
 
+// Slots
+
+void QDnsLookupProto::abort()
+{
+  QDnsLookup *item = qscriptvalue_cast<QDnsLookup*>(thisObject());
+  if (item)
+    item->abort();
+}
+
+void QDnsLookupProto::lookup()
+{
+  QDnsLookup *item = qscriptvalue_cast<QDnsLookup*>(thisObject());
+  if (item)
+    item->lookup();
+}
 #endif

--- a/scriptapi/qdnslookupproto.cpp
+++ b/scriptapi/qdnslookupproto.cpp
@@ -1,0 +1,230 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which(including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#include "qdnslookupproto.h"
+
+#if QT_VERSION < 0x050000
+
+QScriptValue ErrorToScriptValue(QScriptEngine *engine, const QDnsLookup::Error &item)
+{
+  return engine->newVariant(item);
+}
+void ErrorFromScriptValue(const QScriptValue &obj, QDnsLookup::Error &item)
+{
+  item = (QDnsLookup::Error)obj.toInt32();
+}
+
+QScriptValue TypeToScriptValue(QScriptEngine *engine, const QDnsLookup::Type &item)
+{
+  return engine->newVariant(item);
+}
+void TypeFromScriptValue(const QScriptValue &obj, QDnsLookup::Type &item)
+{
+  item = (QDnsLookup::Type)obj.toInt32();
+}
+
+void setupQDnsLookupProto(QScriptEngine *engine)
+{
+  QScriptValue::PropertyFlags permanent = QScriptValue::ReadOnly | QScriptValue::Undeletable;
+
+  QScriptValue proto = engine->newQObject(new QDnsLookupProto(engine));
+  engine->setDefaultPrototype(qMetaTypeId<QDnsLookup*>(), proto);
+  engine->setDefaultPrototype(qMetaTypeId<QDnsLookup>(),  proto);
+
+  QScriptValue constructor = engine->newFunction(constructQDnsLookup, proto);
+  engine->globalObject().setProperty("QDnsLookup",  constructor);
+
+  qScriptRegisterMetaType(engine, ErrorToScriptValue, ErrorFromScriptValue);
+  constructor.setProperty("NoError", QScriptValue(engine, QDnsLookup::NoError), permanent);
+  constructor.setProperty("ResolverError", QScriptValue(engine, QDnsLookup::ResolverError), permanent);
+  constructor.setProperty("OperationCancelledError", QScriptValue(engine, QDnsLookup::OperationCancelledError), permanent);
+  constructor.setProperty("InvalidRequestError", QScriptValue(engine, QDnsLookup::InvalidRequestError), permanent);
+  constructor.setProperty("InvalidReplyError", QScriptValue(engine, QDnsLookup::InvalidReplyError), permanent);
+  constructor.setProperty("ServerFailureError", QScriptValue(engine, QDnsLookup::ServerFailureError), permanent);
+  constructor.setProperty("ServerRefusedError", QScriptValue(engine, QDnsLookup::ServerRefusedError), permanent);
+  constructor.setProperty("NotFoundError", QScriptValue(engine, QDnsLookup::NotFoundError), permanent);
+
+  qScriptRegisterMetaType(engine, TypeToScriptValue, TypeFromScriptValue);
+  constructor.setProperty("A", QScriptValue(engine, QDnsLookup::A), permanent);
+  constructor.setProperty("AAAA", QScriptValue(engine, QDnsLookup::AAAA), permanent);
+  constructor.setProperty("ANY", QScriptValue(engine, QDnsLookup::ANY), permanent);
+  constructor.setProperty("CNAME", QScriptValue(engine, QDnsLookup::CNAME), permanent);
+  constructor.setProperty("MX", QScriptValue(engine, QDnsLookup::MX), permanent);
+  constructor.setProperty("NS", QScriptValue(engine, QDnsLookup::NS), permanent);
+  constructor.setProperty("PTR", QScriptValue(engine, QDnsLookup::PTR), permanent);
+  constructor.setProperty("SRV", QScriptValue(engine, QDnsLookup::SRV), permanent);
+  constructor.setProperty("TXT", QScriptValue(engine, QDnsLookup::TXT), permanent);
+}
+
+QScriptValue constructQDnsLookup(QScriptContext *context, QScriptEngine *engine)
+{
+  QDnsLookup *obj = 0;
+  if (context->argumentCount() == 2 &&
+      context->argument(0).isString() &&
+      context->argument(1).isString()) {
+
+    obj = new QDnsLookup(context->argument(0).toString(),
+                         context->argument(1)).toString());
+  } else if (context->argumentCount() == 3 &&
+             context->argument(0).isString() &&
+             context->argument(1).isString() &&
+             context->argument(2).isObject()) {
+
+    obj = new QDnsLookup(context->argument(0).toString(),
+                         context->argument(1).toString(),
+                         qscriptvalue_cast<QHostAddress>(context->argument(2)));
+  } else {
+    obj = new QDnsLookup();
+  }
+
+  return engine->toScriptValue(obj);
+}
+
+QDnsLookupProto::QDnsLookupProto(QObject *parent) : QObject(parent)
+{
+}
+QDnsLookupProto::~QDnsLookupProto()
+{
+}
+
+QList<QDnsDomainNameRecord> QDnsLookupProto::canonicalNameRecords() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->canonicalNameRecords();
+  return QList<QDnsDomainNameRecord>();
+}
+
+QDnsLookup::Error QDnsLookupProto::error() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->error();
+  return QDnsLookup::Error();
+}
+
+QString QDnsLookupProto::errorString() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->errorString();
+  return QString();
+}
+
+QList<QDnsHostAddressRecord> QDnsLookupProto::hostAddressRecords() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->hostAddressRecords();
+  return QList<QDnsHostAddressRecord>();
+}
+
+bool QDnsLookupProto::isFinished() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->isFinished();
+  return false;
+}
+
+QList<QDnsMailExchangeRecord> QDnsLookupProto::mailExchangeRecords() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->mailExchangeRecords();
+  return QList<QDnsMailExchangeRecord>();
+}
+
+QString QDnsLookupProto::name() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->name();
+  return QString();
+}
+
+QList<QDnsDomainNameRecord> QDnsLookupProto::nameServerRecords() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->nameServerRecords();
+  return QList<QDnsDomainNameRecord>();
+}
+
+QHostAddress QDnsLookupProto::nameserver() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->nameserver();
+  return QHostAddress();
+}
+
+QList<QDnsDomainNameRecord> QDnsLookupProto::pointerRecords() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->pointerRecords();
+  return QList<QDnsDomainNameRecord>();
+}
+
+QList<QDnsServiceRecord> QDnsLookupProto::serviceRecords() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->serviceRecords();
+  return QList<QDnsServiceRecord>();
+}
+
+void QDnsLookupProto::setName(const QString &name)
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    item->setName(name);
+}
+
+void QDnsLookupProto::setNameserver(const QHostAddress &nameserver)
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    item->setNameserver(nameserver);
+}
+
+void QDnsLookupProto::setType(QDnsLookup::Type type)
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    item->setType(type);
+}
+
+QList<QDnsTextRecord> QDnsLookupProto::textRecords() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->textRecords();
+  return QList<QDnsTextRecord>();
+}
+
+QDnsLookup::Type QDnsLookupProto::type() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->type();
+  return QDnsLookup::Type();
+}
+
+QString QDnsLookupProto::toString() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->toString();
+  return QString();
+}
+
+#endif

--- a/scriptapi/qdnslookupproto.h
+++ b/scriptapi/qdnslookupproto.h
@@ -13,7 +13,7 @@
 
 #include <QtScript>
 
-void setupQDnsLookupProto(engine);
+void setupQDnsLookupProto(QScriptEngine *engine);
 
 #if QT_VERSION >= 0x050000
 
@@ -26,7 +26,7 @@ void setupQDnsLookupProto(engine);
 #include <QHostAddress>
 
 Q_DECLARE_METATYPE(QDnsLookup*)
-Q_DECLARE_METATYPE(QDnsLookup)
+//Q_DECLARE_METATYPE(QDnsLookup)
 
 Q_DECLARE_METATYPE(enum QDnsLookup::Error)
 Q_DECLARE_METATYPE(enum QDnsLookup::Type)
@@ -40,7 +40,7 @@ class QDnsLookupProto : public QObject, public QScriptable
   Q_PROPERTY(QDnsLookup::Error    error           READ error)
   Q_PROPERTY(QString              errorString     READ errorString)
   Q_PROPERTY(QString              name            READ name           WRITE setName)
-  Q_PROPERTY(QString              nameserver      READ nameserver     WRITE setNameserver)
+  Q_PROPERTY(QHostAddress         nameserver      READ nameserver     WRITE setNameserver)
   Q_PROPERTY(QDnsLookup::Type     type            READ type           WRITE setType)
 
   public:
@@ -74,7 +74,7 @@ class QDnsLookupProto : public QObject, public QScriptable
     void  finished();
     void  nameChanged(const QString &name);
     void  nameserverChanged(const QHostAddress &nameserver);
-    void  typeChanged(Type type);
+    void  typeChanged(QDnsLookup::Type type);
 
 };
 

--- a/scriptapi/qdnslookupproto.h
+++ b/scriptapi/qdnslookupproto.h
@@ -1,0 +1,84 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which(including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#ifndef __QDNSLOOKUPPROTO_H__
+#define __QDNSLOOKUPPROTO_H__
+
+#include <QtScript>
+
+void setupQDnsLookupProto(engine);
+
+#if QT_VERSION >= 0x050000
+
+#include <QDnsDomainNameRecord>
+#include <QDnsHostAddressRecord>
+#include <QDnsLookup>
+#include <QDnsMailExchangeRecord>
+#include <QDnsServiceRecord>
+#include <QDnsTextRecord>
+#include <QHostAddress>
+
+Q_DECLARE_METATYPE(QDnsLookup*)
+Q_DECLARE_METATYPE(QDnsLookup)
+
+Q_DECLARE_METATYPE(enum QDnsLookup::Error)
+Q_DECLARE_METATYPE(enum QDnsLookup::Type)
+
+QScriptValue constructQDnsLookup(QScriptContext *context, QScriptEngine *engine);
+
+class QDnsLookupProto : public QObject, public QScriptable
+{
+  Q_OBJECT
+
+  Q_PROPERTY(QDnsLookup::Error    error           READ error)
+  Q_PROPERTY(QString              errorString     READ errorString)
+  Q_PROPERTY(QString              name            READ name           WRITE setName)
+  Q_PROPERTY(QString              nameserver      READ nameserver     WRITE setNameserver)
+  Q_PROPERTY(QDnsLookup::Type     type            READ type           WRITE setType)
+
+  public:
+    QDnsLookupProto(QObject *parent);
+    Q_INVOKABLE virtual ~QDnsLookupProto();
+
+    Q_INVOKABLE QList<QDnsDomainNameRecord>     canonicalNameRecords() const;
+    Q_INVOKABLE QDnsLookup::Error               error() const;
+    Q_INVOKABLE QString                         errorString() const;
+    Q_INVOKABLE QList<QDnsHostAddressRecord>    hostAddressRecords() const;
+    Q_INVOKABLE bool                            isFinished() const;
+    Q_INVOKABLE QList<QDnsMailExchangeRecord>   mailExchangeRecords() const;
+    Q_INVOKABLE QString                         name() const;
+    Q_INVOKABLE QList<QDnsDomainNameRecord>     nameServerRecords() const;
+    Q_INVOKABLE QHostAddress                    nameserver() const;
+    Q_INVOKABLE QList<QDnsDomainNameRecord>     pointerRecords() const;
+    Q_INVOKABLE QList<QDnsServiceRecord>        serviceRecords() const;
+    Q_INVOKABLE void                            setName(const QString &name);
+    Q_INVOKABLE void                            setNameserver(const QHostAddress &nameserver);
+    Q_INVOKABLE void                            setType(QDnsLookup::Type type);
+    Q_INVOKABLE QList<QDnsTextRecord>           textRecords() const;
+    Q_INVOKABLE QDnsLookup::Type                type() const;
+
+    Q_INVOKABLE QString                         toString() const;
+
+  public slots:
+    void  abort();
+    void  lookup();
+
+  signals:
+    void  finished();
+    void  nameChanged(const QString &name);
+    void  nameserverChanged(const QHostAddress &nameserver);
+    void  typeChanged(Type type);
+
+};
+
+#endif
+
+#endif // __QDNSLOOKUPPROTO_H__
+

--- a/scriptapi/qdnsmailexchangerecordproto.cpp
+++ b/scriptapi/qdnsmailexchangerecordproto.cpp
@@ -11,6 +11,11 @@
 #include "qdnsmailexchangerecordproto.h"
 
 #if QT_VERSION < 0x050000
+void setupQDnsMailExchangeRecordProto(QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+}
+#else
 
 QScriptValue QListQDnsMailExchangeRecordToScriptValue(QScriptEngine *engine, const QList<QDnsMailExchangeRecord> &list)
 {
@@ -67,7 +72,7 @@ QDnsMailExchangeRecordProto::~QDnsMailExchangeRecordProto()
 
 QString QDnsMailExchangeRecordProto::exchange() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsMailExchangeRecord *item = qscriptvalue_cast<QDnsMailExchangeRecord*>(thisObject());
   if (item)
     return item->exchange();
   return QString();
@@ -75,7 +80,7 @@ QString QDnsMailExchangeRecordProto::exchange() const
 
 QString QDnsMailExchangeRecordProto::name() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsMailExchangeRecord *item = qscriptvalue_cast<QDnsMailExchangeRecord*>(thisObject());
   if (item)
     return item->name();
   return QString();
@@ -83,7 +88,7 @@ QString QDnsMailExchangeRecordProto::name() const
 
 quint16 QDnsMailExchangeRecordProto::preference() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsMailExchangeRecord *item = qscriptvalue_cast<QDnsMailExchangeRecord*>(thisObject());
   if (item)
     return item->preference();
   return quint16();
@@ -91,14 +96,14 @@ quint16 QDnsMailExchangeRecordProto::preference() const
 
 void QDnsMailExchangeRecordProto::swap(QDnsMailExchangeRecord &other)
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsMailExchangeRecord *item = qscriptvalue_cast<QDnsMailExchangeRecord*>(thisObject());
   if (item)
     item->swap(other);
 }
 
 quint32 QDnsMailExchangeRecordProto::timeToLive() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsMailExchangeRecord *item = qscriptvalue_cast<QDnsMailExchangeRecord*>(thisObject());
   if (item)
     return item->timeToLive();
   return quint32();
@@ -106,9 +111,9 @@ quint32 QDnsMailExchangeRecordProto::timeToLive() const
 
 QString QDnsMailExchangeRecordProto::toString() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsMailExchangeRecord *item = qscriptvalue_cast<QDnsMailExchangeRecord*>(thisObject());
   if (item)
-    return item->toString();
+    return item->name();
   return QString();
 }
 

--- a/scriptapi/qdnsmailexchangerecordproto.cpp
+++ b/scriptapi/qdnsmailexchangerecordproto.cpp
@@ -28,14 +28,20 @@ QScriptValue QListQDnsMailExchangeRecordToScriptValue(QScriptEngine *engine, con
 void QListQDnsMailExchangeRecordFromScriptValue(const QScriptValue &obj, QList<QDnsMailExchangeRecord> &list)
 {
   list = QList<QDnsMailExchangeRecord>();
-  QScriptValueIterator it(obj);
 
-  while (it.hasNext()) {
-    it.next();
-    if (it.flags() & QScriptValue::SkipInEnumeration)
-      continue;
-    QDnsMailExchangeRecord item = qscriptvalue_cast<QDnsMailExchangeRecord>(it.value());
-    list.insert(it.name().toInt(), item);
+  if (obj.isArray()) {
+    QScriptValueIterator it(obj);
+
+    while (it.hasNext()) {
+      it.next();
+      if (it.flags() & QScriptValue::SkipInEnumeration)
+        continue;
+
+      if (it.value().isString()) {
+        QDnsMailExchangeRecord item = qscriptvalue_cast<QDnsMailExchangeRecord>(it.value());
+        list.insert(it.name().toInt(), item);
+      }
+    }
   }
 }
 

--- a/scriptapi/qdnsmailexchangerecordproto.cpp
+++ b/scriptapi/qdnsmailexchangerecordproto.cpp
@@ -1,0 +1,115 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which(including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#include "qdnsmailexchangerecordproto.h"
+
+#if QT_VERSION < 0x050000
+
+QScriptValue QListQDnsMailExchangeRecordToScriptValue(QScriptEngine *engine, const QList<QDnsMailExchangeRecord> &list)
+{
+  QScriptValue newArray = engine->newArray();
+  for (int i = 0; i < list.size(); i += 1) {
+    newArray.setProperty(i, engine->toScriptValue(list.at(i)));
+  }
+  return newArray;
+}
+void QListQDnsMailExchangeRecordFromScriptValue(const QScriptValue &obj, QList<QDnsMailExchangeRecord> &list)
+{
+  list = QList<QDnsMailExchangeRecord>();
+  QScriptValueIterator it(obj);
+
+  while (it.hasNext()) {
+    it.next();
+    if (it.flags() & QScriptValue::SkipInEnumeration)
+      continue;
+    QDnsMailExchangeRecord item = qscriptvalue_cast<QDnsMailExchangeRecord>(it.value());
+    list.insert(it.name().toInt(), item);
+  }
+}
+
+void setupQDnsMailExchangeRecordProto(QScriptEngine *engine)
+{
+  QScriptValue proto = engine->newQObject(new QDnsMailExchangeRecordProto(engine));
+  engine->setDefaultPrototype(qMetaTypeId<QDnsMailExchangeRecord*>(), proto);
+  engine->setDefaultPrototype(qMetaTypeId<QDnsMailExchangeRecord>(),  proto);
+
+  QScriptValue constructor = engine->newFunction(constructQDnsMailExchangeRecord, proto);
+  engine->globalObject().setProperty("QDnsMailExchangeRecord",  constructor);
+
+  qScriptRegisterMetaType(engine, QListQDnsMailExchangeRecordToScriptValue, QListQDnsMailExchangeRecordFromScriptValue);
+}
+
+QScriptValue constructQDnsMailExchangeRecord(QScriptContext *context, QScriptEngine *engine)
+{
+  QDnsMailExchangeRecord *obj = 0;
+  if (context->argumentCount() == 1 && context->argument(0).isObject()) {
+    obj = new QDnsMailExchangeRecord(qscriptvalue_cast<QDnsMailExchangeRecord>(context->argument(0)));
+  } else {
+    obj = new QDnsMailExchangeRecord();
+  }
+
+  return engine->toScriptValue(obj);
+}
+
+QDnsMailExchangeRecordProto::QDnsMailExchangeRecordProto(QObject *parent) : QObject(parent)
+{
+}
+QDnsMailExchangeRecordProto::~QDnsMailExchangeRecordProto()
+{
+}
+
+QString QDnsMailExchangeRecordProto::exchange() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->exchange();
+  return QString();
+}
+
+QString QDnsMailExchangeRecordProto::name() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->name();
+  return QString();
+}
+
+quint16 QDnsMailExchangeRecordProto::preference() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->preference();
+  return quint16();
+}
+
+void QDnsMailExchangeRecordProto::swap(QDnsMailExchangeRecord &other)
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    item->swap(other);
+}
+
+quint32 QDnsMailExchangeRecordProto::timeToLive() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->timeToLive();
+  return quint32();
+}
+
+QString QDnsMailExchangeRecordProto::toString() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->toString();
+  return QString();
+}
+
+#endif

--- a/scriptapi/qdnsmailexchangerecordproto.h
+++ b/scriptapi/qdnsmailexchangerecordproto.h
@@ -13,7 +13,7 @@
 
 #include <QtScript>
 
-void setupQDnsMailExchangeRecordProto(engine);
+void setupQDnsMailExchangeRecordProto(QScriptEngine *engine);
 
 #if QT_VERSION >= 0x050000
 

--- a/scriptapi/qdnsmailexchangerecordproto.h
+++ b/scriptapi/qdnsmailexchangerecordproto.h
@@ -1,0 +1,48 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which(including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#ifndef __QDNSMAILEXCHANGERECORDPROTO_H__
+#define __QDNSMAILEXCHANGERECORDPROTO_H__
+
+#include <QtScript>
+
+void setupQDnsMailExchangeRecordProto(engine);
+
+#if QT_VERSION >= 0x050000
+
+#include <QDnsMailExchangeRecord>
+
+Q_DECLARE_METATYPE(QDnsMailExchangeRecord*)
+Q_DECLARE_METATYPE(QDnsMailExchangeRecord)
+
+QScriptValue constructQDnsMailExchangeRecord(QScriptContext *context, QScriptEngine *engine);
+
+class QDnsMailExchangeRecordProto : public QObject, public QScriptable
+{
+  Q_OBJECT
+
+  public:
+    QDnsMailExchangeRecordProto(QObject *parent);
+    Q_INVOKABLE virtual ~QDnsMailExchangeRecordProto();
+
+    Q_INVOKABLE QString   exchange() const;
+    Q_INVOKABLE QString   name() const;
+    Q_INVOKABLE quint16   preference() const;
+    Q_INVOKABLE void      swap(QDnsMailExchangeRecord &other);
+    Q_INVOKABLE quint32   timeToLive() const;
+
+    Q_INVOKABLE QString   toString() const;
+
+};
+
+#endif
+
+#endif // __QDNSMAILEXCHANGERECORDPROTO_H__
+

--- a/scriptapi/qdnsservicerecordproto.cpp
+++ b/scriptapi/qdnsservicerecordproto.cpp
@@ -28,14 +28,20 @@ QScriptValue QListQDnsServiceRecordToScriptValue(QScriptEngine *engine, const QL
 void QListQDnsServiceRecordFromScriptValue(const QScriptValue &obj, QList<QDnsServiceRecord> &list)
 {
   list = QList<QDnsServiceRecord>();
-  QScriptValueIterator it(obj);
 
-  while (it.hasNext()) {
-    it.next();
-    if (it.flags() & QScriptValue::SkipInEnumeration)
-      continue;
-    QDnsServiceRecord item = qscriptvalue_cast<QDnsServiceRecord>(it.value());
-    list.insert(it.name().toInt(), item);
+  if (obj.isArray()) {
+    QScriptValueIterator it(obj);
+
+    while (it.hasNext()) {
+      it.next();
+      if (it.flags() & QScriptValue::SkipInEnumeration)
+        continue;
+
+      if (it.value().isString()) {
+        QDnsServiceRecord item = qscriptvalue_cast<QDnsServiceRecord>(it.value());
+        list.insert(it.name().toInt(), item);
+      }
+    }
   }
 }
 

--- a/scriptapi/qdnsservicerecordproto.cpp
+++ b/scriptapi/qdnsservicerecordproto.cpp
@@ -1,0 +1,131 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which(including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#include "qdnsservicerecordproto.h"
+
+#if QT_VERSION < 0x050000
+
+QScriptValue QListQDnsServiceRecordToScriptValue(QScriptEngine *engine, const QList<QDnsServiceRecord> &list)
+{
+  QScriptValue newArray = engine->newArray();
+  for (int i = 0; i < list.size(); i += 1) {
+    newArray.setProperty(i, engine->toScriptValue(list.at(i)));
+  }
+  return newArray;
+}
+void QListQDnsServiceRecordFromScriptValue(const QScriptValue &obj, QList<QDnsServiceRecord> &list)
+{
+  list = QList<QDnsServiceRecord>();
+  QScriptValueIterator it(obj);
+
+  while (it.hasNext()) {
+    it.next();
+    if (it.flags() & QScriptValue::SkipInEnumeration)
+      continue;
+    QDnsServiceRecord item = qscriptvalue_cast<QDnsServiceRecord>(it.value());
+    list.insert(it.name().toInt(), item);
+  }
+}
+
+void setupQDnsServiceRecordProto(QScriptEngine *engine)
+{
+  QScriptValue proto = engine->newQObject(new QDnsServiceRecordProto(engine));
+  engine->setDefaultPrototype(qMetaTypeId<QDnsServiceRecord*>(), proto);
+  engine->setDefaultPrototype(qMetaTypeId<QDnsServiceRecord>(),  proto);
+
+  QScriptValue constructor = engine->newFunction(constructQDnsServiceRecord, proto);
+  engine->globalObject().setProperty("QDnsServiceRecord",  constructor);
+
+  qScriptRegisterMetaType(engine, QListQDnsServiceRecordToScriptValue, QListQDnsServiceRecordFromScriptValue);
+}
+
+QScriptValue constructQDnsServiceRecord(QScriptContext *context, QScriptEngine *engine)
+{
+  QDnsServiceRecord *obj = 0;
+  if (context->argumentCount() == 1 && context->argument(0).isObject()) {
+    obj = new QDnsServiceRecord(qscriptvalue_cast<QDnsServiceRecord>(context->argument(0)));
+  } else {
+    obj = new QDnsServiceRecord();
+  }
+
+  return engine->toScriptValue(obj);
+}
+
+QDnsServiceRecordProto::QDnsServiceRecordProto(QObject *parent) : QObject(parent)
+{
+}
+QDnsServiceRecordProto::~QDnsServiceRecordProto()
+{
+}
+
+QString QDnsServiceRecordProto::name() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->name();
+  return QString();
+}
+
+quint16 QDnsServiceRecordProto::port() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->port();
+  return quint16();
+}
+
+quint16 QDnsServiceRecordProto::priority() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->priority();
+  return quint16();
+}
+
+void QDnsServiceRecordProto::swap(QDnsServiceRecord &other)
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    item->swap(other);
+}
+
+QString QDnsServiceRecordProto::target() const
+{
+   *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->target();
+  return QString();
+}
+
+quint32 QDnsServiceRecordProto::timeToLive() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->timeToLive();
+  return quint32();
+}
+
+quint16 QDnsServiceRecordProto::weight() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->weight();
+  return quint16();
+}
+
+QString QDnsServiceRecordProto::toString() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->toString();
+  return QString();
+}
+
+#endif

--- a/scriptapi/qdnsservicerecordproto.cpp
+++ b/scriptapi/qdnsservicerecordproto.cpp
@@ -11,6 +11,11 @@
 #include "qdnsservicerecordproto.h"
 
 #if QT_VERSION < 0x050000
+void setupQDnsServiceRecordProto(QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+}
+#else
 
 QScriptValue QListQDnsServiceRecordToScriptValue(QScriptEngine *engine, const QList<QDnsServiceRecord> &list)
 {
@@ -67,7 +72,7 @@ QDnsServiceRecordProto::~QDnsServiceRecordProto()
 
 QString QDnsServiceRecordProto::name() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsServiceRecord *item = qscriptvalue_cast<QDnsServiceRecord*>(thisObject());
   if (item)
     return item->name();
   return QString();
@@ -75,7 +80,7 @@ QString QDnsServiceRecordProto::name() const
 
 quint16 QDnsServiceRecordProto::port() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsServiceRecord *item = qscriptvalue_cast<QDnsServiceRecord*>(thisObject());
   if (item)
     return item->port();
   return quint16();
@@ -83,7 +88,7 @@ quint16 QDnsServiceRecordProto::port() const
 
 quint16 QDnsServiceRecordProto::priority() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsServiceRecord *item = qscriptvalue_cast<QDnsServiceRecord*>(thisObject());
   if (item)
     return item->priority();
   return quint16();
@@ -91,14 +96,14 @@ quint16 QDnsServiceRecordProto::priority() const
 
 void QDnsServiceRecordProto::swap(QDnsServiceRecord &other)
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsServiceRecord *item = qscriptvalue_cast<QDnsServiceRecord*>(thisObject());
   if (item)
     item->swap(other);
 }
 
 QString QDnsServiceRecordProto::target() const
 {
-   *item = qscriptvalue_cast<*>(thisObject());
+  QDnsServiceRecord *item = qscriptvalue_cast<QDnsServiceRecord*>(thisObject());
   if (item)
     return item->target();
   return QString();
@@ -106,7 +111,7 @@ QString QDnsServiceRecordProto::target() const
 
 quint32 QDnsServiceRecordProto::timeToLive() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsServiceRecord *item = qscriptvalue_cast<QDnsServiceRecord*>(thisObject());
   if (item)
     return item->timeToLive();
   return quint32();
@@ -114,7 +119,7 @@ quint32 QDnsServiceRecordProto::timeToLive() const
 
 quint16 QDnsServiceRecordProto::weight() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsServiceRecord *item = qscriptvalue_cast<QDnsServiceRecord*>(thisObject());
   if (item)
     return item->weight();
   return quint16();
@@ -122,9 +127,9 @@ quint16 QDnsServiceRecordProto::weight() const
 
 QString QDnsServiceRecordProto::toString() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsServiceRecord *item = qscriptvalue_cast<QDnsServiceRecord*>(thisObject());
   if (item)
-    return item->toString();
+    return item->name();
   return QString();
 }
 

--- a/scriptapi/qdnsservicerecordproto.h
+++ b/scriptapi/qdnsservicerecordproto.h
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which(including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#ifndef __QDNSSERVICERECORDPROTO_H__
+#define __QDNSSERVICERECORDPROTO_H__
+
+#include <QtScript>
+
+void setupQDnsServiceRecordProto(engine);
+
+#if QT_VERSION >= 0x050000
+
+#include <QDnsServiceRecord>
+
+Q_DECLARE_METATYPE(QDnsServiceRecord*)
+Q_DECLARE_METATYPE(QDnsServiceRecord)
+
+QScriptValue constructQDnsServiceRecord(QScriptContext *context, QScriptEngine *engine);
+
+class QDnsServiceRecordProto : public QObject, public QScriptable
+{
+  Q_OBJECT
+
+  public:
+    QDnsServiceRecordProto(QObject *parent);
+    Q_INVOKABLE virtual ~QDnsServiceRecordProto();
+
+    Q_INVOKABLE QString   name() const;
+    Q_INVOKABLE quint16   port() const;
+    Q_INVOKABLE quint16   priority() const;
+    Q_INVOKABLE void      swap(QDnsServiceRecord &other);
+    Q_INVOKABLE QString   target() const;
+    Q_INVOKABLE quint32   timeToLive() const;
+    Q_INVOKABLE quint16   weight() const;
+
+    Q_INVOKABLE QString   toString() const;
+
+};
+
+#endif
+
+#endif // __QDNSSERVICERECORDPROTO_H__

--- a/scriptapi/qdnsservicerecordproto.h
+++ b/scriptapi/qdnsservicerecordproto.h
@@ -13,7 +13,7 @@
 
 #include <QtScript>
 
-void setupQDnsServiceRecordProto(engine);
+void setupQDnsServiceRecordProto(QScriptEngine *engine);
 
 #if QT_VERSION >= 0x050000
 

--- a/scriptapi/qdnstextrecordproto.cpp
+++ b/scriptapi/qdnstextrecordproto.cpp
@@ -11,6 +11,11 @@
 #include "qdnstextrecordproto.h"
 
 #if QT_VERSION < 0x050000
+void setupQDnsTextRecordProto(QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+}
+#else
 
 QScriptValue QListQDnsTextRecordToScriptValue(QScriptEngine *engine, const QList<QDnsTextRecord> &list)
 {
@@ -67,7 +72,7 @@ QDnsTextRecordProto::~QDnsTextRecordProto()
 
 QString QDnsTextRecordProto::name() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsTextRecord *item = qscriptvalue_cast<QDnsTextRecord*>(thisObject());
   if (item)
     return item->name();
   return QString();
@@ -75,14 +80,14 @@ QString QDnsTextRecordProto::name() const
 
 void QDnsTextRecordProto::swap(QDnsTextRecord &other)
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsTextRecord *item = qscriptvalue_cast<QDnsTextRecord*>(thisObject());
   if (item)
     item->swap(other);
 }
 
 quint32 QDnsTextRecordProto::timeToLive() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsTextRecord *item = qscriptvalue_cast<QDnsTextRecord*>(thisObject());
   if (item)
     return item->timeToLive();
   return quint32();
@@ -90,7 +95,7 @@ quint32 QDnsTextRecordProto::timeToLive() const
 
 QList<QByteArray> QDnsTextRecordProto::values() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsTextRecord *item = qscriptvalue_cast<QDnsTextRecord*>(thisObject());
   if (item)
     return item->values();
   return QList<QByteArray>();
@@ -98,9 +103,9 @@ QList<QByteArray> QDnsTextRecordProto::values() const
 
 QString QDnsTextRecordProto::toString() const
 {
-  *item = qscriptvalue_cast<*>(thisObject());
+  QDnsTextRecord *item = qscriptvalue_cast<QDnsTextRecord*>(thisObject());
   if (item)
-    return item->toString();
+    return item->name();
   return QString();
 }
 

--- a/scriptapi/qdnstextrecordproto.cpp
+++ b/scriptapi/qdnstextrecordproto.cpp
@@ -28,14 +28,20 @@ QScriptValue QListQDnsTextRecordToScriptValue(QScriptEngine *engine, const QList
 void QListQDnsTextRecordFromScriptValue(const QScriptValue &obj, QList<QDnsTextRecord> &list)
 {
   list = QList<QDnsTextRecord>();
-  QScriptValueIterator it(obj);
 
-  while (it.hasNext()) {
-    it.next();
-    if (it.flags() & QScriptValue::SkipInEnumeration)
-      continue;
-    QDnsTextRecord item = qscriptvalue_cast<QDnsTextRecord>(it.value());
-    list.insert(it.name().toInt(), item);
+  if (obj.isArray()) {
+    QScriptValueIterator it(obj);
+
+    while (it.hasNext()) {
+      it.next();
+      if (it.flags() & QScriptValue::SkipInEnumeration)
+        continue;
+
+      if (it.value().isString()) {
+        QDnsTextRecord item = qscriptvalue_cast<QDnsTextRecord>(it.value());
+        list.insert(it.name().toInt(), item);
+      }
+    }
   }
 }
 

--- a/scriptapi/qdnstextrecordproto.cpp
+++ b/scriptapi/qdnstextrecordproto.cpp
@@ -1,0 +1,107 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which(including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#include "qdnstextrecordproto.h"
+
+#if QT_VERSION < 0x050000
+
+QScriptValue QListQDnsTextRecordToScriptValue(QScriptEngine *engine, const QList<QDnsTextRecord> &list)
+{
+  QScriptValue newArray = engine->newArray();
+  for (int i = 0; i < list.size(); i += 1) {
+    newArray.setProperty(i, engine->toScriptValue(list.at(i)));
+  }
+  return newArray;
+}
+void QListQDnsTextRecordFromScriptValue(const QScriptValue &obj, QList<QDnsTextRecord> &list)
+{
+  list = QList<QDnsTextRecord>();
+  QScriptValueIterator it(obj);
+
+  while (it.hasNext()) {
+    it.next();
+    if (it.flags() & QScriptValue::SkipInEnumeration)
+      continue;
+    QDnsTextRecord item = qscriptvalue_cast<QDnsTextRecord>(it.value());
+    list.insert(it.name().toInt(), item);
+  }
+}
+
+void setupQDnsTextRecordProto(QScriptEngine *engine)
+{
+  QScriptValue proto = engine->newQObject(new QDnsTextRecordProto(engine));
+  engine->setDefaultPrototype(qMetaTypeId<QDnsTextRecord*>(), proto);
+  engine->setDefaultPrototype(qMetaTypeId<QDnsTextRecord>(),  proto);
+
+  QScriptValue constructor = engine->newFunction(constructQDnsTextRecord, proto);
+  engine->globalObject().setProperty("QDnsTextRecord",  constructor);
+
+  qScriptRegisterMetaType(engine, QListQDnsTextRecordToScriptValue, QListQDnsTextRecordFromScriptValue);
+}
+
+QScriptValue constructQDnsTextRecord(QScriptContext *context, QScriptEngine *engine)
+{
+  QDnsTextRecord *obj = 0;
+  if (context->argumentCount() == 1 && context->argument(0).isObject()) {
+    obj = new QDnsTextRecord(qscriptvalue_cast<QDnsTextRecord>(context->argument(0)));
+  } else {
+    obj = new QDnsTextRecord();
+  }
+
+  return engine->toScriptValue(obj);
+}
+
+QDnsTextRecordProto::QDnsTextRecordProto(QObject *parent) : QObject(parent)
+{
+}
+QDnsTextRecordProto::~QDnsTextRecordProto()
+{
+}
+
+QString QDnsTextRecordProto::name() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->name();
+  return QString();
+}
+
+void QDnsTextRecordProto::swap(QDnsTextRecord &other)
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    item->swap(other);
+}
+
+quint32 QDnsTextRecordProto::timeToLive() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->timeToLive();
+  return quint32();
+}
+
+QList<QByteArray> QDnsTextRecordProto::values() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->values();
+  return QList<QByteArray>();
+}
+
+QString QDnsTextRecordProto::toString() const
+{
+  *item = qscriptvalue_cast<*>(thisObject());
+  if (item)
+    return item->toString();
+  return QString();
+}
+
+#endif

--- a/scriptapi/qdnstextrecordproto.h
+++ b/scriptapi/qdnstextrecordproto.h
@@ -13,7 +13,7 @@
 
 #include <QtScript>
 
-void setupQDnsTextRecordProto(engine);
+void setupQDnsTextRecordProto(QScriptEngine *engine);
 
 #if QT_VERSION >= 0x050000
 

--- a/scriptapi/qdnstextrecordproto.h
+++ b/scriptapi/qdnstextrecordproto.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which(including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#ifndef __QDNSTEXTRECORDPROTO_H__
+#define __QDNSTEXTRECORDPROTO_H__
+
+#include <QtScript>
+
+void setupQDnsTextRecordProto(engine);
+
+#if QT_VERSION >= 0x050000
+
+#include <QDnsTextRecord>
+
+Q_DECLARE_METATYPE(QDnsTextRecord*)
+Q_DECLARE_METATYPE(QDnsTextRecord)
+
+QScriptValue constructQDnsTextRecord(QScriptContext *context, QScriptEngine *engine);
+
+class QDnsTextRecordProto : public QObject, public QScriptable
+{
+  Q_OBJECT
+
+  public:
+    QDnsTextRecordProto(QObject *parent);
+    Q_INVOKABLE virtual ~QDnsTextRecordProto();
+
+    Q_INVOKABLE QString             name() const;
+    Q_INVOKABLE void                swap(QDnsTextRecord &other);
+    Q_INVOKABLE quint32             timeToLive() const;
+    Q_INVOKABLE QList<QByteArray>   values() const;
+
+    Q_INVOKABLE QString             toString() const;
+
+};
+
+#endif
+
+#endif // __QDNSTEXTRECORDPROTO_H__

--- a/scriptapi/qnetworkreplyproto.cpp
+++ b/scriptapi/qnetworkreplyproto.cpp
@@ -12,11 +12,11 @@
 
 #include <QNetworkReply>
 
-QScriptValue NetworkErrorToScriptValue(QScriptEngine *engine, const QNetworkReply::NetworkError &item)
+QScriptValue NetworkReplyNetworkErrorToScriptValue(QScriptEngine *engine, const QNetworkReply::NetworkError &item)
 {
   return engine->newVariant(item);
 }
-void NetworkErrorFromScriptValue(const QScriptValue &obj, QNetworkReply::NetworkError &item)
+void NetworkReplyNetworkErrorFromScriptValue(const QScriptValue &obj, QNetworkReply::NetworkError &item)
 {
   item = (QNetworkReply::NetworkError)obj.toInt32();
 }
@@ -38,7 +38,7 @@ void setupQNetworkReplyProto(QScriptEngine *engine)
   QScriptValue proto = engine->newQObject(new QNetworkReplyProto(engine));
   engine->setDefaultPrototype(qMetaTypeId<QNetworkReply*>(), proto);
 
-  qScriptRegisterMetaType(engine, NetworkErrorToScriptValue, NetworkErrorFromScriptValue);
+  qScriptRegisterMetaType(engine, NetworkReplyNetworkErrorToScriptValue, NetworkReplyNetworkErrorFromScriptValue);
   proto.setProperty("NoError", QScriptValue(engine, QNetworkReply::NoError), permanent);
   proto.setProperty("ConnectionRefusedError", QScriptValue(engine, QNetworkReply::ConnectionRefusedError), permanent);
   proto.setProperty("RemoteHostClosedError", QScriptValue(engine, QNetworkReply::RemoteHostClosedError), permanent);

--- a/scriptapi/qnetworkreplyproto.cpp
+++ b/scriptapi/qnetworkreplyproto.cpp
@@ -47,8 +47,10 @@ void setupQNetworkReplyProto(QScriptEngine *engine)
   proto.setProperty("OperationCanceledError", QScriptValue(engine, QNetworkReply::OperationCanceledError), permanent);
   proto.setProperty("SslHandshakeFailedError", QScriptValue(engine, QNetworkReply::SslHandshakeFailedError), permanent);
   proto.setProperty("TemporaryNetworkFailureError", QScriptValue(engine, QNetworkReply::TemporaryNetworkFailureError), permanent);
+#if QT_VERSION >= 0x050000
   proto.setProperty("NetworkSessionFailedError", QScriptValue(engine, QNetworkReply::NetworkSessionFailedError), permanent);
   proto.setProperty("BackgroundRequestNotAllowedError", QScriptValue(engine, QNetworkReply::BackgroundRequestNotAllowedError), permanent);
+#endif
   // Not in Qt 5.5 //proto.setProperty("TooManyRedirectsError", QScriptValue(engine, QNetworkReply::TooManyRedirectsError), permanent);
   // Not in Qt 5.5 //proto.setProperty("InsecureRedirectError", QScriptValue(engine, QNetworkReply::InsecureRedirectError), permanent);
   proto.setProperty("ProxyConnectionRefusedError", QScriptValue(engine, QNetworkReply::ProxyConnectionRefusedError), permanent);
@@ -61,18 +63,22 @@ void setupQNetworkReplyProto(QScriptEngine *engine)
   proto.setProperty("ContentNotFoundError", QScriptValue(engine, QNetworkReply::ContentNotFoundError), permanent);
   proto.setProperty("AuthenticationRequiredError", QScriptValue(engine, QNetworkReply::AuthenticationRequiredError), permanent);
   proto.setProperty("ContentReSendError", QScriptValue(engine, QNetworkReply::ContentReSendError), permanent);
+#if QT_VERSION >= 0x050000
   proto.setProperty("ContentConflictError", QScriptValue(engine, QNetworkReply::ContentConflictError), permanent);
   proto.setProperty("ContentGoneError", QScriptValue(engine, QNetworkReply::ContentGoneError), permanent);
   proto.setProperty("InternalServerError", QScriptValue(engine, QNetworkReply::InternalServerError), permanent);
   proto.setProperty("OperationNotImplementedError", QScriptValue(engine, QNetworkReply::OperationNotImplementedError), permanent);
   proto.setProperty("ServiceUnavailableError", QScriptValue(engine, QNetworkReply::ServiceUnavailableError), permanent);
+#endif
   proto.setProperty("ProtocolUnknownError", QScriptValue(engine, QNetworkReply::ProtocolUnknownError), permanent);
   proto.setProperty("ProtocolInvalidOperationError", QScriptValue(engine, QNetworkReply::ProtocolInvalidOperationError), permanent);
   proto.setProperty("UnknownNetworkError", QScriptValue(engine, QNetworkReply::UnknownNetworkError), permanent);
   proto.setProperty("UnknownProxyError", QScriptValue(engine, QNetworkReply::UnknownProxyError), permanent);
   proto.setProperty("UnknownContentError", QScriptValue(engine, QNetworkReply::UnknownContentError), permanent);
   proto.setProperty("ProtocolFailure", QScriptValue(engine, QNetworkReply::ProtocolFailure), permanent);
+#if QT_VERSION >= 0x050000
   proto.setProperty("UnknownServerError", QScriptValue(engine, QNetworkReply::UnknownServerError), permanent);
+#endif
 }
 
 QNetworkReplyProto::QNetworkReplyProto(QObject *parent)

--- a/scriptapi/qnetworkreplyproto.cpp
+++ b/scriptapi/qnetworkreplyproto.cpp
@@ -12,25 +12,67 @@
 
 #include <QNetworkReply>
 
-QScriptValue QNetworkReplytoScriptValue(QScriptEngine *engine, QNetworkReply* const &item)
+QScriptValue NetworkErrorToScriptValue(QScriptEngine *engine, const QNetworkReply::NetworkError &item)
+{
+  return engine->newVariant(item);
+}
+void NetworkErrorFromScriptValue(const QScriptValue &obj, QNetworkReply::NetworkError &item)
+{
+  item = (QNetworkReply::NetworkError)obj.toInt32();
+}
+
+QScriptValue QNetworkReplyToScriptValue(QScriptEngine *engine, QNetworkReply* const &item)
 {
   return engine->newQObject(item);
 }
-
-void QNetworkReplyfromScriptValue(const QScriptValue &obj, QNetworkReply* &item)
+void QNetworkReplyFromScriptValue(const QScriptValue &obj, QNetworkReply* &item)
 {
   item = qobject_cast<QNetworkReply*>(obj.toQObject());
 }
 
 void setupQNetworkReplyProto(QScriptEngine *engine)
 {
-  qScriptRegisterMetaType(engine, QNetworkReplytoScriptValue, QNetworkReplyfromScriptValue);
+  qScriptRegisterMetaType(engine, QNetworkReplyToScriptValue, QNetworkReplyFromScriptValue);
   QScriptValue::PropertyFlags permanent = QScriptValue::ReadOnly | QScriptValue::Undeletable;
 
   QScriptValue proto = engine->newQObject(new QNetworkReplyProto(engine));
   engine->setDefaultPrototype(qMetaTypeId<QNetworkReply*>(), proto);
 
-  proto.setProperty("UnknownNetworkError",    QScriptValue(engine, QNetworkReply::UnknownNetworkError),    permanent);
+  qScriptRegisterMetaType(engine, NetworkErrorToScriptValue, NetworkErrorFromScriptValue);
+  proto.setProperty("NoError", QScriptValue(engine, QNetworkReply::NoError), permanent);
+  proto.setProperty("ConnectionRefusedError", QScriptValue(engine, QNetworkReply::ConnectionRefusedError), permanent);
+  proto.setProperty("RemoteHostClosedError", QScriptValue(engine, QNetworkReply::RemoteHostClosedError), permanent);
+  proto.setProperty("HostNotFoundError", QScriptValue(engine, QNetworkReply::HostNotFoundError), permanent);
+  proto.setProperty("TimeoutError", QScriptValue(engine, QNetworkReply::TimeoutError), permanent);
+  proto.setProperty("OperationCanceledError", QScriptValue(engine, QNetworkReply::OperationCanceledError), permanent);
+  proto.setProperty("SslHandshakeFailedError", QScriptValue(engine, QNetworkReply::SslHandshakeFailedError), permanent);
+  proto.setProperty("TemporaryNetworkFailureError", QScriptValue(engine, QNetworkReply::TemporaryNetworkFailureError), permanent);
+  proto.setProperty("NetworkSessionFailedError", QScriptValue(engine, QNetworkReply::NetworkSessionFailedError), permanent);
+  proto.setProperty("BackgroundRequestNotAllowedError", QScriptValue(engine, QNetworkReply::BackgroundRequestNotAllowedError), permanent);
+  // Not in Qt 5.5 //proto.setProperty("TooManyRedirectsError", QScriptValue(engine, QNetworkReply::TooManyRedirectsError), permanent);
+  // Not in Qt 5.5 //proto.setProperty("InsecureRedirectError", QScriptValue(engine, QNetworkReply::InsecureRedirectError), permanent);
+  proto.setProperty("ProxyConnectionRefusedError", QScriptValue(engine, QNetworkReply::ProxyConnectionRefusedError), permanent);
+  proto.setProperty("ProxyConnectionClosedError", QScriptValue(engine, QNetworkReply::ProxyConnectionClosedError), permanent);
+  proto.setProperty("ProxyNotFoundError", QScriptValue(engine, QNetworkReply::ProxyNotFoundError), permanent);
+  proto.setProperty("ProxyTimeoutError", QScriptValue(engine, QNetworkReply::ProxyTimeoutError), permanent);
+  proto.setProperty("ProxyAuthenticationRequiredError", QScriptValue(engine, QNetworkReply::ProxyAuthenticationRequiredError), permanent);
+  proto.setProperty("ContentAccessDenied", QScriptValue(engine, QNetworkReply::ContentAccessDenied), permanent);
+  proto.setProperty("ContentOperationNotPermittedError", QScriptValue(engine, QNetworkReply::ContentOperationNotPermittedError), permanent);
+  proto.setProperty("ContentNotFoundError", QScriptValue(engine, QNetworkReply::ContentNotFoundError), permanent);
+  proto.setProperty("AuthenticationRequiredError", QScriptValue(engine, QNetworkReply::AuthenticationRequiredError), permanent);
+  proto.setProperty("ContentReSendError", QScriptValue(engine, QNetworkReply::ContentReSendError), permanent);
+  proto.setProperty("ContentConflictError", QScriptValue(engine, QNetworkReply::ContentConflictError), permanent);
+  proto.setProperty("ContentGoneError", QScriptValue(engine, QNetworkReply::ContentGoneError), permanent);
+  proto.setProperty("InternalServerError", QScriptValue(engine, QNetworkReply::InternalServerError), permanent);
+  proto.setProperty("OperationNotImplementedError", QScriptValue(engine, QNetworkReply::OperationNotImplementedError), permanent);
+  proto.setProperty("ServiceUnavailableError", QScriptValue(engine, QNetworkReply::ServiceUnavailableError), permanent);
+  proto.setProperty("ProtocolUnknownError", QScriptValue(engine, QNetworkReply::ProtocolUnknownError), permanent);
+  proto.setProperty("ProtocolInvalidOperationError", QScriptValue(engine, QNetworkReply::ProtocolInvalidOperationError), permanent);
+  proto.setProperty("UnknownNetworkError", QScriptValue(engine, QNetworkReply::UnknownNetworkError), permanent);
+  proto.setProperty("UnknownProxyError", QScriptValue(engine, QNetworkReply::UnknownProxyError), permanent);
+  proto.setProperty("UnknownContentError", QScriptValue(engine, QNetworkReply::UnknownContentError), permanent);
+  proto.setProperty("ProtocolFailure", QScriptValue(engine, QNetworkReply::ProtocolFailure), permanent);
+  proto.setProperty("UnknownServerError", QScriptValue(engine, QNetworkReply::UnknownServerError), permanent);
 }
 
 QNetworkReplyProto::QNetworkReplyProto(QObject *parent)
@@ -138,7 +180,7 @@ QByteArray QNetworkReplyProto::rawHeader(const QByteArray &headerName) const
 {
   QNetworkReply *item = qscriptvalue_cast<QNetworkReply*>(thisObject());
   if (item)
-    item->rawHeader(headerName);
+    return item->rawHeader(headerName);
   return QByteArray();
 }
 

--- a/scriptapi/qnetworkreplyproto.h
+++ b/scriptapi/qnetworkreplyproto.h
@@ -22,6 +22,7 @@
 class QByteArray;
 
 Q_DECLARE_METATYPE(QNetworkReply*)
+Q_DECLARE_METATYPE(enum QNetworkReply::NetworkError)
 
 void setupQNetworkReplyProto(QScriptEngine *engine);
 

--- a/scriptapi/qnetworkreplyproto.h
+++ b/scriptapi/qnetworkreplyproto.h
@@ -93,6 +93,12 @@ class QNetworkReplyProto : public QObject, public QScriptable
   public slots:
     Q_INVOKABLE void                              abort() const;
     Q_INVOKABLE void                              ignoreSslErrors();
+
+  signals:
+    void aboutToClose();
+    void bytesWritten(qint64 bytes);
+    void readChannelFinished();
+    void readyRead();
 };
 
 #endif

--- a/scriptapi/qnetworkrequestproto.cpp
+++ b/scriptapi/qnetworkrequestproto.cpp
@@ -18,15 +18,110 @@
 
 #define DEBUG false
 
+QScriptValue AttributeToScriptValue(QScriptEngine *engine, const QNetworkRequest::Attribute &item)
+{
+  return engine->newVariant(item);
+}
+void AttributeFromScriptValue(const QScriptValue &obj, QNetworkRequest::Attribute &item)
+{
+  item = (QNetworkRequest::Attribute)obj.toInt32();
+}
+
+QScriptValue CacheLoadControlToScriptValue(QScriptEngine *engine, const QNetworkRequest::CacheLoadControl &item)
+{
+  return engine->newVariant(item);
+}
+void CacheLoadControlFromScriptValue(const QScriptValue &obj, QNetworkRequest::CacheLoadControl &item)
+{
+  item = (QNetworkRequest::CacheLoadControl)obj.toInt32();
+}
+
+QScriptValue KnownHeadersToScriptValue(QScriptEngine *engine, const QNetworkRequest::KnownHeaders &item)
+{
+  return engine->newVariant(item);
+}
+void KnownHeadersFromScriptValue(const QScriptValue &obj, QNetworkRequest::KnownHeaders &item)
+{
+  item = (QNetworkRequest::KnownHeaders)obj.toInt32();
+}
+
+QScriptValue LoadControlToScriptValue(QScriptEngine *engine, const QNetworkRequest::LoadControl &item)
+{
+  return engine->newVariant(item);
+}
+void LoadControlFromScriptValue(const QScriptValue &obj, QNetworkRequest::LoadControl &item)
+{
+  item = (QNetworkRequest::LoadControl)obj.toInt32();
+}
+
+QScriptValue PriorityToScriptValue(QScriptEngine *engine, const QNetworkRequest::Priority &item)
+{
+  return engine->newVariant(item);
+}
+void PriorityFromScriptValue(const QScriptValue &obj, QNetworkRequest::Priority &item)
+{
+  item = (QNetworkRequest::Priority)obj.toInt32();
+}
+
 void setupQNetworkRequestProto(QScriptEngine *engine)
 {
   if (DEBUG) qDebug("setupQNetworkRequestProto entered");
 
+  QScriptValue::PropertyFlags permanent = QScriptValue::ReadOnly | QScriptValue::Undeletable;
+
   QScriptValue netreqproto = engine->newQObject(new QNetworkRequestProto(engine));
   engine->setDefaultPrototype(qMetaTypeId<QNetworkRequest*>(), netreqproto);
-  QScriptValue netreqConstructor = engine->newFunction(constructQNetworkRequest,
-                                                       netreqproto);
-  engine->globalObject().setProperty("QNetworkRequest", netreqConstructor);
+  QScriptValue constructor = engine->newFunction(constructQNetworkRequest,  netreqproto);
+  engine->globalObject().setProperty("QNetworkRequest", constructor);
+
+  qScriptRegisterMetaType(engine, AttributeToScriptValue, AttributeFromScriptValue);
+  constructor.setProperty("HttpStatusCodeAttribute", QScriptValue(engine, QNetworkRequest::HttpStatusCodeAttribute), permanent);
+  constructor.setProperty("HttpReasonPhraseAttribute", QScriptValue(engine, QNetworkRequest::HttpReasonPhraseAttribute), permanent);
+  constructor.setProperty("RedirectionTargetAttribute", QScriptValue(engine, QNetworkRequest::RedirectionTargetAttribute), permanent);
+  constructor.setProperty("ConnectionEncryptedAttribute", QScriptValue(engine, QNetworkRequest::ConnectionEncryptedAttribute), permanent);
+  constructor.setProperty("CacheLoadControlAttribute", QScriptValue(engine, QNetworkRequest::CacheLoadControlAttribute), permanent);
+  constructor.setProperty("CacheSaveControlAttribute", QScriptValue(engine, QNetworkRequest::CacheSaveControlAttribute), permanent);
+  constructor.setProperty("SourceIsFromCacheAttribute", QScriptValue(engine, QNetworkRequest::SourceIsFromCacheAttribute), permanent);
+  constructor.setProperty("DoNotBufferUploadDataAttribute", QScriptValue(engine, QNetworkRequest::DoNotBufferUploadDataAttribute), permanent);
+  constructor.setProperty("HttpPipeliningAllowedAttribute", QScriptValue(engine, QNetworkRequest::HttpPipeliningAllowedAttribute), permanent);
+  constructor.setProperty("HttpPipeliningWasUsedAttribute", QScriptValue(engine, QNetworkRequest::HttpPipeliningWasUsedAttribute), permanent);
+  constructor.setProperty("CustomVerbAttribute", QScriptValue(engine, QNetworkRequest::CustomVerbAttribute), permanent);
+  constructor.setProperty("CookieLoadControlAttribute", QScriptValue(engine, QNetworkRequest::CookieLoadControlAttribute), permanent);
+  constructor.setProperty("CookieSaveControlAttribute", QScriptValue(engine, QNetworkRequest::CookieSaveControlAttribute), permanent);
+  constructor.setProperty("AuthenticationReuseAttribute", QScriptValue(engine, QNetworkRequest::AuthenticationReuseAttribute), permanent);
+  constructor.setProperty("BackgroundRequestAttribute", QScriptValue(engine, QNetworkRequest::BackgroundRequestAttribute), permanent);
+  // Not needed //constructor.setProperty("SpdyAllowedAttribute", QScriptValue(engine, QNetworkRequest::SpdyAllowedAttribute), permanent);
+  // Not needed //constructor.setProperty("SpdyWasUsedAttribute", QScriptValue(engine, QNetworkRequest::SpdyWasUsedAttribute), permanent);
+  constructor.setProperty("EmitAllUploadProgressSignalsAttribute", QScriptValue(engine, QNetworkRequest::EmitAllUploadProgressSignalsAttribute), permanent);
+  // Not in Qt 5.5 //constructor.setProperty("FollowRedirectsAttribute", QScriptValue(engine, QNetworkRequest::FollowRedirectsAttribute), permanent);
+  constructor.setProperty("User", QScriptValue(engine, QNetworkRequest::User), permanent);
+  constructor.setProperty("UserMax", QScriptValue(engine, QNetworkRequest::UserMax), permanent);
+
+  qScriptRegisterMetaType(engine, CacheLoadControlToScriptValue, CacheLoadControlFromScriptValue);
+  constructor.setProperty("AlwaysNetwork", QScriptValue(engine, QNetworkRequest::AlwaysNetwork), permanent);
+  constructor.setProperty("PreferNetwork", QScriptValue(engine, QNetworkRequest::PreferNetwork), permanent);
+  constructor.setProperty("PreferCache", QScriptValue(engine, QNetworkRequest::PreferCache), permanent);
+  constructor.setProperty("AlwaysCache", QScriptValue(engine, QNetworkRequest::AlwaysCache), permanent);
+
+  qScriptRegisterMetaType(engine, KnownHeadersToScriptValue, KnownHeadersFromScriptValue);
+  constructor.setProperty("ContentDispositionHeader", QScriptValue(engine, QNetworkRequest::ContentDispositionHeader), permanent);
+  constructor.setProperty("ContentTypeHeader", QScriptValue(engine, QNetworkRequest::ContentTypeHeader), permanent);
+  constructor.setProperty("ContentLengthHeader", QScriptValue(engine, QNetworkRequest::ContentLengthHeader), permanent);
+  constructor.setProperty("LocationHeader", QScriptValue(engine, QNetworkRequest::LocationHeader), permanent);
+  constructor.setProperty("LastModifiedHeader", QScriptValue(engine, QNetworkRequest::LastModifiedHeader), permanent);
+  constructor.setProperty("CookieHeader", QScriptValue(engine, QNetworkRequest::CookieHeader), permanent);
+  constructor.setProperty("SetCookieHeader", QScriptValue(engine, QNetworkRequest::SetCookieHeader), permanent);
+  constructor.setProperty("UserAgentHeader", QScriptValue(engine, QNetworkRequest::UserAgentHeader), permanent);
+  constructor.setProperty("ServerHeader", QScriptValue(engine, QNetworkRequest::ServerHeader), permanent);
+
+  qScriptRegisterMetaType(engine, LoadControlToScriptValue, LoadControlFromScriptValue);
+  constructor.setProperty("Automatic", QScriptValue(engine, QNetworkRequest::Automatic), permanent);
+  constructor.setProperty("Manual", QScriptValue(engine, QNetworkRequest::Manual), permanent);
+
+  qScriptRegisterMetaType(engine, PriorityToScriptValue, PriorityFromScriptValue);
+  constructor.setProperty("HighPriority", QScriptValue(engine, QNetworkRequest::HighPriority), permanent);
+  constructor.setProperty("NormalPriority", QScriptValue(engine, QNetworkRequest::NormalPriority), permanent);
+  constructor.setProperty("LowPriority", QScriptValue(engine, QNetworkRequest::LowPriority), permanent);
 }
 
 QScriptValue constructQNetworkRequest(QScriptContext *context,

--- a/scriptapi/qnetworkrequestproto.cpp
+++ b/scriptapi/qnetworkrequestproto.cpp
@@ -18,47 +18,47 @@
 
 #define DEBUG false
 
-QScriptValue AttributeToScriptValue(QScriptEngine *engine, const QNetworkRequest::Attribute &item)
+QScriptValue NetworkRequestAttributeToScriptValue(QScriptEngine *engine, const QNetworkRequest::Attribute &item)
 {
   return engine->newVariant(item);
 }
-void AttributeFromScriptValue(const QScriptValue &obj, QNetworkRequest::Attribute &item)
+void NetworkRequestAttributeFromScriptValue(const QScriptValue &obj, QNetworkRequest::Attribute &item)
 {
   item = (QNetworkRequest::Attribute)obj.toInt32();
 }
 
-QScriptValue CacheLoadControlToScriptValue(QScriptEngine *engine, const QNetworkRequest::CacheLoadControl &item)
+QScriptValue NetworkRequestCacheLoadControlToScriptValue(QScriptEngine *engine, const QNetworkRequest::CacheLoadControl &item)
 {
   return engine->newVariant(item);
 }
-void CacheLoadControlFromScriptValue(const QScriptValue &obj, QNetworkRequest::CacheLoadControl &item)
+void NetworkRequestCacheLoadControlFromScriptValue(const QScriptValue &obj, QNetworkRequest::CacheLoadControl &item)
 {
   item = (QNetworkRequest::CacheLoadControl)obj.toInt32();
 }
 
-QScriptValue KnownHeadersToScriptValue(QScriptEngine *engine, const QNetworkRequest::KnownHeaders &item)
+QScriptValue NetworkRequestKnownHeadersToScriptValue(QScriptEngine *engine, const QNetworkRequest::KnownHeaders &item)
 {
   return engine->newVariant(item);
 }
-void KnownHeadersFromScriptValue(const QScriptValue &obj, QNetworkRequest::KnownHeaders &item)
+void NetworkRequestKnownHeadersFromScriptValue(const QScriptValue &obj, QNetworkRequest::KnownHeaders &item)
 {
   item = (QNetworkRequest::KnownHeaders)obj.toInt32();
 }
 
-QScriptValue LoadControlToScriptValue(QScriptEngine *engine, const QNetworkRequest::LoadControl &item)
+QScriptValue NetworkRequestLoadControlToScriptValue(QScriptEngine *engine, const QNetworkRequest::LoadControl &item)
 {
   return engine->newVariant(item);
 }
-void LoadControlFromScriptValue(const QScriptValue &obj, QNetworkRequest::LoadControl &item)
+void NetworkRequestLoadControlFromScriptValue(const QScriptValue &obj, QNetworkRequest::LoadControl &item)
 {
   item = (QNetworkRequest::LoadControl)obj.toInt32();
 }
 
-QScriptValue PriorityToScriptValue(QScriptEngine *engine, const QNetworkRequest::Priority &item)
+QScriptValue NetworkRequestPriorityToScriptValue(QScriptEngine *engine, const QNetworkRequest::Priority &item)
 {
   return engine->newVariant(item);
 }
-void PriorityFromScriptValue(const QScriptValue &obj, QNetworkRequest::Priority &item)
+void NetworkRequestPriorityFromScriptValue(const QScriptValue &obj, QNetworkRequest::Priority &item)
 {
   item = (QNetworkRequest::Priority)obj.toInt32();
 }
@@ -74,7 +74,7 @@ void setupQNetworkRequestProto(QScriptEngine *engine)
   QScriptValue constructor = engine->newFunction(constructQNetworkRequest,  netreqproto);
   engine->globalObject().setProperty("QNetworkRequest", constructor);
 
-  qScriptRegisterMetaType(engine, AttributeToScriptValue, AttributeFromScriptValue);
+  qScriptRegisterMetaType(engine, NetworkRequestAttributeToScriptValue, NetworkRequestAttributeFromScriptValue);
   constructor.setProperty("HttpStatusCodeAttribute", QScriptValue(engine, QNetworkRequest::HttpStatusCodeAttribute), permanent);
   constructor.setProperty("HttpReasonPhraseAttribute", QScriptValue(engine, QNetworkRequest::HttpReasonPhraseAttribute), permanent);
   constructor.setProperty("RedirectionTargetAttribute", QScriptValue(engine, QNetworkRequest::RedirectionTargetAttribute), permanent);
@@ -99,13 +99,13 @@ void setupQNetworkRequestProto(QScriptEngine *engine)
   constructor.setProperty("User", QScriptValue(engine, QNetworkRequest::User), permanent);
   constructor.setProperty("UserMax", QScriptValue(engine, QNetworkRequest::UserMax), permanent);
 
-  qScriptRegisterMetaType(engine, CacheLoadControlToScriptValue, CacheLoadControlFromScriptValue);
+  qScriptRegisterMetaType(engine, NetworkRequestCacheLoadControlToScriptValue, NetworkRequestCacheLoadControlFromScriptValue);
   constructor.setProperty("AlwaysNetwork", QScriptValue(engine, QNetworkRequest::AlwaysNetwork), permanent);
   constructor.setProperty("PreferNetwork", QScriptValue(engine, QNetworkRequest::PreferNetwork), permanent);
   constructor.setProperty("PreferCache", QScriptValue(engine, QNetworkRequest::PreferCache), permanent);
   constructor.setProperty("AlwaysCache", QScriptValue(engine, QNetworkRequest::AlwaysCache), permanent);
 
-  qScriptRegisterMetaType(engine, KnownHeadersToScriptValue, KnownHeadersFromScriptValue);
+  qScriptRegisterMetaType(engine, NetworkRequestKnownHeadersToScriptValue, NetworkRequestKnownHeadersFromScriptValue);
   constructor.setProperty("ContentDispositionHeader", QScriptValue(engine, QNetworkRequest::ContentDispositionHeader), permanent);
   constructor.setProperty("ContentTypeHeader", QScriptValue(engine, QNetworkRequest::ContentTypeHeader), permanent);
   constructor.setProperty("ContentLengthHeader", QScriptValue(engine, QNetworkRequest::ContentLengthHeader), permanent);
@@ -118,11 +118,11 @@ void setupQNetworkRequestProto(QScriptEngine *engine)
   constructor.setProperty("ServerHeader", QScriptValue(engine, QNetworkRequest::ServerHeader), permanent);
 #endif
 
-  qScriptRegisterMetaType(engine, LoadControlToScriptValue, LoadControlFromScriptValue);
+  qScriptRegisterMetaType(engine, NetworkRequestLoadControlToScriptValue, NetworkRequestLoadControlFromScriptValue);
   constructor.setProperty("Automatic", QScriptValue(engine, QNetworkRequest::Automatic), permanent);
   constructor.setProperty("Manual", QScriptValue(engine, QNetworkRequest::Manual), permanent);
 
-  qScriptRegisterMetaType(engine, PriorityToScriptValue, PriorityFromScriptValue);
+  qScriptRegisterMetaType(engine, NetworkRequestPriorityToScriptValue, NetworkRequestPriorityFromScriptValue);
   constructor.setProperty("HighPriority", QScriptValue(engine, QNetworkRequest::HighPriority), permanent);
   constructor.setProperty("NormalPriority", QScriptValue(engine, QNetworkRequest::NormalPriority), permanent);
   constructor.setProperty("LowPriority", QScriptValue(engine, QNetworkRequest::LowPriority), permanent);

--- a/scriptapi/qnetworkrequestproto.cpp
+++ b/scriptapi/qnetworkrequestproto.cpp
@@ -89,10 +89,12 @@ void setupQNetworkRequestProto(QScriptEngine *engine)
   constructor.setProperty("CookieLoadControlAttribute", QScriptValue(engine, QNetworkRequest::CookieLoadControlAttribute), permanent);
   constructor.setProperty("CookieSaveControlAttribute", QScriptValue(engine, QNetworkRequest::CookieSaveControlAttribute), permanent);
   constructor.setProperty("AuthenticationReuseAttribute", QScriptValue(engine, QNetworkRequest::AuthenticationReuseAttribute), permanent);
+#if QT_VERSION >= 0x050000
   constructor.setProperty("BackgroundRequestAttribute", QScriptValue(engine, QNetworkRequest::BackgroundRequestAttribute), permanent);
   // Not needed //constructor.setProperty("SpdyAllowedAttribute", QScriptValue(engine, QNetworkRequest::SpdyAllowedAttribute), permanent);
   // Not needed //constructor.setProperty("SpdyWasUsedAttribute", QScriptValue(engine, QNetworkRequest::SpdyWasUsedAttribute), permanent);
   constructor.setProperty("EmitAllUploadProgressSignalsAttribute", QScriptValue(engine, QNetworkRequest::EmitAllUploadProgressSignalsAttribute), permanent);
+#endif
   // Not in Qt 5.5 //constructor.setProperty("FollowRedirectsAttribute", QScriptValue(engine, QNetworkRequest::FollowRedirectsAttribute), permanent);
   constructor.setProperty("User", QScriptValue(engine, QNetworkRequest::User), permanent);
   constructor.setProperty("UserMax", QScriptValue(engine, QNetworkRequest::UserMax), permanent);
@@ -111,8 +113,10 @@ void setupQNetworkRequestProto(QScriptEngine *engine)
   constructor.setProperty("LastModifiedHeader", QScriptValue(engine, QNetworkRequest::LastModifiedHeader), permanent);
   constructor.setProperty("CookieHeader", QScriptValue(engine, QNetworkRequest::CookieHeader), permanent);
   constructor.setProperty("SetCookieHeader", QScriptValue(engine, QNetworkRequest::SetCookieHeader), permanent);
+#if QT_VERSION >= 0x050000
   constructor.setProperty("UserAgentHeader", QScriptValue(engine, QNetworkRequest::UserAgentHeader), permanent);
   constructor.setProperty("ServerHeader", QScriptValue(engine, QNetworkRequest::ServerHeader), permanent);
+#endif
 
   qScriptRegisterMetaType(engine, LoadControlToScriptValue, LoadControlFromScriptValue);
   constructor.setProperty("Automatic", QScriptValue(engine, QNetworkRequest::Automatic), permanent);
@@ -159,7 +163,7 @@ bool QNetworkRequestProto::hasRawHeader(const QByteArray &headerName) const
   if (item)
     return item->hasRawHeader(headerName);
   return false;
-}    
+}
 
 QVariant QNetworkRequestProto::header(QNetworkRequest::KnownHeaders header) const
 {

--- a/scriptapi/qnetworkrequestproto.h
+++ b/scriptapi/qnetworkrequestproto.h
@@ -19,6 +19,11 @@
 class QByteArray;
 
 Q_DECLARE_METATYPE(QNetworkRequest*)
+Q_DECLARE_METATYPE(enum QNetworkRequest::Attribute)
+Q_DECLARE_METATYPE(enum QNetworkRequest::CacheLoadControl)
+Q_DECLARE_METATYPE(enum QNetworkRequest::KnownHeaders)
+Q_DECLARE_METATYPE(enum QNetworkRequest::LoadControl)
+Q_DECLARE_METATYPE(enum QNetworkRequest::Priority)
 
 void setupQNetworkRequestProto(QScriptEngine *engine);
 QScriptValue constructQNetworkRequest(QScriptContext *context,

--- a/scriptapi/qtimerproto.cpp
+++ b/scriptapi/qtimerproto.cpp
@@ -89,6 +89,24 @@ bool QTimerProto::isSingleShot() const
   return false;
 }
 
+void QTimerProto::setTimerType(Qt::TimerType atype)
+{
+  QTimer *item = qscriptvalue_cast<QTimer*>(thisObject());
+  if (item) {
+    item->setTimerType(atype);
+  }
+}
+
+Qt::TimerType QTimerProto::timerType()  const
+{
+  QTimer *item = qscriptvalue_cast<QTimer*>(thisObject());
+  if (item) {
+    return item->timerType();
+  }
+
+  return Qt::CoarseTimer;
+}
+
 int QTimerProto::timerId() const
 {
   QTimer *item = qscriptvalue_cast<QTimer*>(thisObject());

--- a/scriptapi/qtimerproto.cpp
+++ b/scriptapi/qtimerproto.cpp
@@ -28,8 +28,7 @@ void setupQTimerProto(QScriptEngine *engine)
   engine->setDefaultPrototype(qMetaTypeId<QTimer*>(), proto);
   //engine->setDefaultPrototype(qMetaTypeId<QTimer>(),  proto);
 
-  QScriptValue constructor = engine->newFunction(constructQTimer,
-                                                 proto);
+  QScriptValue constructor = engine->newFunction(constructQTimer, proto);
   engine->globalObject().setProperty("QTimer", constructor);
 }
 
@@ -89,6 +88,7 @@ bool QTimerProto::isSingleShot() const
   return false;
 }
 
+#if QT_VERSION >= 0x050000
 void QTimerProto::setTimerType(Qt::TimerType atype)
 {
   QTimer *item = qscriptvalue_cast<QTimer*>(thisObject());
@@ -106,6 +106,7 @@ Qt::TimerType QTimerProto::timerType()  const
 
   return Qt::CoarseTimer;
 }
+#endif
 
 int QTimerProto::timerId() const
 {

--- a/scriptapi/qtimerproto.h
+++ b/scriptapi/qtimerproto.h
@@ -32,12 +32,14 @@ class QTimerProto : public QObject, public QScriptable
   public:
     QTimerProto(QObject *parent);
 
-                int  interval() const;
-    Q_INVOKABLE bool isActive() const;
-    Q_INVOKABLE bool isSingleShot() const;
-    Q_INVOKABLE void setInterval(int);
-    Q_INVOKABLE void setSingleShot(bool);
-    Q_INVOKABLE int  timerId() const;       
+                int             interval() const;
+    Q_INVOKABLE bool            isActive() const;
+    Q_INVOKABLE bool            isSingleShot() const;
+    Q_INVOKABLE void            setInterval(int);
+    Q_INVOKABLE void            setSingleShot(bool);
+    Q_INVOKABLE void            setTimerType(Qt::TimerType atype = Qt::CoarseTimer);
+    Q_INVOKABLE int             timerId() const;
+    Q_INVOKABLE Qt::TimerType   timerType() const;
 
   public slots:
     void start(int);

--- a/scriptapi/qtimerproto.h
+++ b/scriptapi/qtimerproto.h
@@ -37,9 +37,11 @@ class QTimerProto : public QObject, public QScriptable
     Q_INVOKABLE bool            isSingleShot() const;
     Q_INVOKABLE void            setInterval(int);
     Q_INVOKABLE void            setSingleShot(bool);
+#if QT_VERSION >= 0x050000
     Q_INVOKABLE void            setTimerType(Qt::TimerType atype = Qt::CoarseTimer);
-    Q_INVOKABLE int             timerId() const;
     Q_INVOKABLE Qt::TimerType   timerType() const;
+#endif
+    Q_INVOKABLE int             timerId() const;
 
   public slots:
     void start(int);

--- a/scriptapi/qtsetup.cpp
+++ b/scriptapi/qtsetup.cpp
@@ -739,10 +739,12 @@ void setupQt(QScriptEngine *engine)
   widget.setProperty("TextEditorInteraction", QScriptValue(engine, Qt::TextEditorInteraction), QScriptValue::ReadOnly | QScriptValue::Undeletable);
   widget.setProperty("TextBrowserInteraction", QScriptValue(engine, Qt::TextBrowserInteraction), QScriptValue::ReadOnly | QScriptValue::Undeletable);
 
+#if QT_VERSION >= 0x050000
   qScriptRegisterMetaType(engine, TimerTypetoScriptValue, TimerTypefromScriptValue);
   widget.setProperty("PreciseTimer", QScriptValue(engine, Qt::PreciseTimer), QScriptValue::ReadOnly | QScriptValue::Undeletable);
   widget.setProperty("CoarseTimer", QScriptValue(engine, Qt::CoarseTimer), QScriptValue::ReadOnly | QScriptValue::Undeletable);
   widget.setProperty("VeryCoarseTimer", QScriptValue(engine, Qt::VeryCoarseTimer), QScriptValue::ReadOnly | QScriptValue::Undeletable);
+#endif
 
   qScriptRegisterMetaType(engine, TimeSpectoScriptValue,	TimeSpecfromScriptValue);
   widget.setProperty("LocalTime", QScriptValue(engine, Qt::LocalTime), QScriptValue::ReadOnly | QScriptValue::Undeletable);
@@ -1238,10 +1240,12 @@ QScriptValue TextInteractionFlagtoScriptValue(QScriptEngine *engine, const enum 
   return QScriptValue(engine, (int)p);
 }
 
+#if QT_VERSION >= 0x050000
 QScriptValue TimerTypetoScriptValue(QScriptEngine *engine, const enum Qt::TimerType &p)
 {
   return QScriptValue(engine, (int)p);
 }
+#endif
 
 QScriptValue TimeSpectoScriptValue(QScriptEngine *engine, const enum Qt::TimeSpec &p)
 {
@@ -1555,10 +1559,12 @@ void TextInteractionFlagfromScriptValue(const QScriptValue &obj, enum Qt::TextIn
   p = (enum Qt::TextInteractionFlag)obj.toInt32();
 }
 
+#if QT_VERSION >= 0x050000
 void TimerTypefromScriptValue(const QScriptValue &obj, enum Qt::TimerType &p)
 {
   p = (enum Qt::TimerType)obj.toInt32();
 }
+#endif
 
 void TimeSpecfromScriptValue(const QScriptValue &obj, enum Qt::TimeSpec &p)
 {

--- a/scriptapi/qtsetup.cpp
+++ b/scriptapi/qtsetup.cpp
@@ -739,6 +739,11 @@ void setupQt(QScriptEngine *engine)
   widget.setProperty("TextEditorInteraction", QScriptValue(engine, Qt::TextEditorInteraction), QScriptValue::ReadOnly | QScriptValue::Undeletable);
   widget.setProperty("TextBrowserInteraction", QScriptValue(engine, Qt::TextBrowserInteraction), QScriptValue::ReadOnly | QScriptValue::Undeletable);
 
+  qScriptRegisterMetaType(engine, TimerTypetoScriptValue, TimerTypefromScriptValue);
+  widget.setProperty("PreciseTimer", QScriptValue(engine, Qt::PreciseTimer), QScriptValue::ReadOnly | QScriptValue::Undeletable);
+  widget.setProperty("CoarseTimer", QScriptValue(engine, Qt::CoarseTimer), QScriptValue::ReadOnly | QScriptValue::Undeletable);
+  widget.setProperty("VeryCoarseTimer", QScriptValue(engine, Qt::VeryCoarseTimer), QScriptValue::ReadOnly | QScriptValue::Undeletable);
+
   qScriptRegisterMetaType(engine, TimeSpectoScriptValue,	TimeSpecfromScriptValue);
   widget.setProperty("LocalTime", QScriptValue(engine, Qt::LocalTime), QScriptValue::ReadOnly | QScriptValue::Undeletable);
   widget.setProperty("UTC", QScriptValue(engine, Qt::UTC), QScriptValue::ReadOnly | QScriptValue::Undeletable);
@@ -1233,6 +1238,11 @@ QScriptValue TextInteractionFlagtoScriptValue(QScriptEngine *engine, const enum 
   return QScriptValue(engine, (int)p);
 }
 
+QScriptValue TimerTypetoScriptValue(QScriptEngine *engine, const enum Qt::TimerType &p)
+{
+  return QScriptValue(engine, (int)p);
+}
+
 QScriptValue TimeSpectoScriptValue(QScriptEngine *engine, const enum Qt::TimeSpec &p)
 {
   return QScriptValue(engine, (int)p);
@@ -1543,6 +1553,11 @@ void TextFormatfromScriptValue(const QScriptValue &obj, enum Qt::TextFormat &p)
 void TextInteractionFlagfromScriptValue(const QScriptValue &obj, enum Qt::TextInteractionFlag &p)
 {
   p = (enum Qt::TextInteractionFlag)obj.toInt32();
+}
+
+void TimerTypefromScriptValue(const QScriptValue &obj, enum Qt::TimerType &p)
+{
+  p = (enum Qt::TimerType)obj.toInt32();
 }
 
 void TimeSpecfromScriptValue(const QScriptValue &obj, enum Qt::TimeSpec &p)

--- a/scriptapi/qtsetup.h
+++ b/scriptapi/qtsetup.h
@@ -69,6 +69,7 @@ QScriptValue TextElideModetoScriptValue(QScriptEngine *engine, const enum Qt::Te
 QScriptValue TextFlagtoScriptValue(QScriptEngine *engine, const enum Qt::TextFlag &p);
 QScriptValue TextFormattoScriptValue(QScriptEngine *engine, const enum Qt::TextFormat &p);
 QScriptValue TextInteractionFlagtoScriptValue(QScriptEngine *engine, const enum Qt::TextInteractionFlag &p);
+QScriptValue TimerTypetoScriptValue(QScriptEngine *engine, const enum Qt::TimerType &p);
 QScriptValue TimeSpectoScriptValue(QScriptEngine *engine, const enum Qt::TimeSpec &p);
 QScriptValue ToolBarAreatoScriptValue(QScriptEngine *engine, const enum Qt::ToolBarArea &p);
 QScriptValue ToolButtonStyletoScriptValue(QScriptEngine *engine, const enum Qt::ToolButtonStyle &p);
@@ -133,6 +134,7 @@ void TextElideModefromScriptValue(const QScriptValue &obj, enum Qt::TextElideMod
 void TextFlagfromScriptValue(const QScriptValue &obj, enum Qt::TextFlag &p);
 void TextFormatfromScriptValue(const QScriptValue &obj, enum Qt::TextFormat &p);
 void TextInteractionFlagfromScriptValue(const QScriptValue &obj, enum Qt::TextInteractionFlag &p);
+void TimerTypefromScriptValue(const QScriptValue &obj, enum Qt::TimerType &p);
 void TimeSpecfromScriptValue(const QScriptValue &obj, enum Qt::TimeSpec &p);
 void ToolBarAreafromScriptValue(const QScriptValue &obj, enum Qt::ToolBarArea &p);
 void ToolButtonStylefromScriptValue(const QScriptValue &obj, enum Qt::ToolButtonStyle &p);

--- a/scriptapi/qtsetup.h
+++ b/scriptapi/qtsetup.h
@@ -69,7 +69,9 @@ QScriptValue TextElideModetoScriptValue(QScriptEngine *engine, const enum Qt::Te
 QScriptValue TextFlagtoScriptValue(QScriptEngine *engine, const enum Qt::TextFlag &p);
 QScriptValue TextFormattoScriptValue(QScriptEngine *engine, const enum Qt::TextFormat &p);
 QScriptValue TextInteractionFlagtoScriptValue(QScriptEngine *engine, const enum Qt::TextInteractionFlag &p);
+#if QT_VERSION >= 0x050000
 QScriptValue TimerTypetoScriptValue(QScriptEngine *engine, const enum Qt::TimerType &p);
+#endif
 QScriptValue TimeSpectoScriptValue(QScriptEngine *engine, const enum Qt::TimeSpec &p);
 QScriptValue ToolBarAreatoScriptValue(QScriptEngine *engine, const enum Qt::ToolBarArea &p);
 QScriptValue ToolButtonStyletoScriptValue(QScriptEngine *engine, const enum Qt::ToolButtonStyle &p);
@@ -134,7 +136,9 @@ void TextElideModefromScriptValue(const QScriptValue &obj, enum Qt::TextElideMod
 void TextFlagfromScriptValue(const QScriptValue &obj, enum Qt::TextFlag &p);
 void TextFormatfromScriptValue(const QScriptValue &obj, enum Qt::TextFormat &p);
 void TextInteractionFlagfromScriptValue(const QScriptValue &obj, enum Qt::TextInteractionFlag &p);
+#if QT_VERSION >= 0x050000
 void TimerTypefromScriptValue(const QScriptValue &obj, enum Qt::TimerType &p);
+#endif
 void TimeSpecfromScriptValue(const QScriptValue &obj, enum Qt::TimeSpec &p);
 void ToolBarAreafromScriptValue(const QScriptValue &obj, enum Qt::ToolBarArea &p);
 void ToolButtonStylefromScriptValue(const QScriptValue &obj, enum Qt::ToolButtonStyle &p);

--- a/scriptapi/scriptapi.pro
+++ b/scriptapi/scriptapi.pro
@@ -43,6 +43,12 @@ HEADERS += setupscriptapi.h \
     qdialogbuttonboxproto.h \
     qdialogsetup.h \
     qdirproto.h \
+    qdnsdomainnamerecordproto.h \
+    qdnshostaddressrecordproto.h \
+    qdnslookupproto.h \
+    qdnsmailexchangerecordproto.h \
+    qdnsservicerecordproto.h \
+    qdnstextrecordproto.h \
     qdockwidgetproto.h \
     qdomattrproto.h \
     qdomcdatasectionproto.h \
@@ -188,6 +194,12 @@ SOURCES += setupscriptapi.cpp \
     qdialogbuttonboxproto.cpp \
     qdialogsetup.cpp \
     qdirproto.cpp \
+    qdnsdomainnamerecordproto.cpp \
+    qdnshostaddressrecordproto.cpp \
+    qdnslookupproto.cpp \
+    qdnsmailexchangerecordproto.cpp \
+    qdnsservicerecordproto.cpp \
+    qdnstextrecordproto.cpp \
     qdockwidgetproto.cpp \
     qdomattrproto.cpp \
     qdomcdatasectionproto.cpp \

--- a/scriptapi/scriptapi.pro
+++ b/scriptapi/scriptapi.pro
@@ -150,6 +150,7 @@ HEADERS += setupscriptapi.h \
     crmacctlineeditsetup.h \
     currdisplaysetup.h \
     documentssetup.h \
+    engineevaluate.h \
     glclustersetup.h \
     itemlineeditsetup.h \
     jsconsole.h \
@@ -294,6 +295,7 @@ SOURCES += setupscriptapi.cpp \
     crmacctlineeditsetup.cpp \
     currdisplaysetup.cpp \
     documentssetup.cpp \
+    engineevaluate.cpp \
     glclustersetup.cpp \
     itemlineeditsetup.cpp \
     jsconsole.cpp \

--- a/scriptapi/setupscriptapi.cpp
+++ b/scriptapi/setupscriptapi.cpp
@@ -19,6 +19,7 @@
 #include "currdisplaysetup.h"
 #include "documentssetup.h"
 #include "empcluster.h"
+#include "engineevaluate.h"
 #include "exporthelper.h"
 #include "filemoveselector.h"
 #include "glclustersetup.h"
@@ -183,6 +184,7 @@ void setupScriptApi(QScriptEngine *engine)
   setupDocuments(engine);
   setupEmpCluster(engine);
   setupEmpClusterLineEdit(engine);
+  setupEngineEvaluate(engine);
   setupExportHelper(engine);
   setupFileMoveSelector(engine);
   setupGLCluster(engine);

--- a/scriptapi/setupscriptapi.cpp
+++ b/scriptapi/setupscriptapi.cpp
@@ -45,6 +45,12 @@
 #include "qdialogsetup.h"
 #include "qdialogbuttonboxproto.h"
 #include "qdirproto.h"
+#include "qdnsdomainnamerecordproto.h"
+#include "qdnshostaddressrecordproto.h"
+#include "qdnslookupproto.h"
+#include "qdnsmailexchangerecordproto.h"
+#include "qdnsservicerecordproto.h"
+#include "qdnstextrecordproto.h"
 #include "qdockwidgetproto.h"
 #include "qdomattrproto.h"
 #include "qdomcdatasectionproto.h"
@@ -211,6 +217,12 @@ void setupScriptApi(QScriptEngine *engine)
   setupQDialog(engine);
   setupQDialogButtonBoxProto(engine);
   setupQDirProto(engine);
+  setupQDnsDomainNameRecordProto(engine);
+  setupQDnsHostAddressRecordProto(engine);
+  setupQDnsLookupProto(engine);
+  setupQDnsMailExchangeRecordProto(engine);
+  setupQDnsServiceRecordProto(engine);
+  setupQDnsTextRecordProto(engine);
   setupQDockWidgetProto(engine);
   setupQDomAttrProto(engine);
   setupQDomCDATASectionProto(engine);


### PR DESCRIPTION
Found some issues when working on Address Verification.

1. Add `global.engineEvaluate()` to Qt Script so we can load javascript code from outside of `pkgscript` tables and have it still showup in Qt Script Debugger. This is for js library code that doesn't have anything to do with our window scripting. It avoids name collisions and prevent the loading of multiple scripts you get with `include('foo')`.
2. Expose all the `QDnsFoo` objects so we can do `dns.lookup`.
3. Expose `QNetworkReply::NetworkError` enum.
4. Fix `QNetworkReply.rawHeader()` bug so it actually returns.
5. Expose `QNetworkRequest::foo` enums.
6. Expose `QTimerProto::setTimerType`, `QTimerProto::timerType` and `Qt::TimerType` enum
