### PR TITLE
issue #27953 - remove unused class member

### DIFF
--- a/guiclient/guiclient.cpp
+++ b/guiclient/guiclient.cpp
@@ -394,7 +394,6 @@ GUIClient::GUIClient(const QString &pDatabaseURL, const QString &pUsername)
 {
   XSqlQuery _GGUIClient;
   _menuBar = 0;
-  _activeWindow = 0;
   _shown = false;
   _shuttingDown = false;
 

--- a/guiclient/guiclient.h
+++ b/guiclient/guiclient.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -13,7 +13,6 @@
 
 #include <QAction>
 #include <QDate>
-#include <QList>
 #include <QMainWindow>
 #include <QTimer>
 
@@ -409,7 +408,6 @@ class GUIClient : public QMainWindow
     bool         _showTopLevel;
     QWidgetList  _windowList;
     QMenuBar	*_menuBar;
-    QWidget     *_activeWindow;
 
     InputManager   *_inputManager;
 


### PR DESCRIPTION
Remove `_activeWindow` entirely. See https://github.com/xtuple/qt-client/pull/1233