### PR TITLE
Issue #22170: Work-around for copy of large number of rows of rich data from XTreeWidget

### DIFF
--- a/guiclient/userPreferences.cpp
+++ b/guiclient/userPreferences.cpp
@@ -350,7 +350,7 @@ void userPreferences::sSave(bool close)
     _pref->set("InterfaceWindowOption", QString("TopLevel"));
     
   _pref->set("CopyListsPlainText", _plainText->isChecked());
-  _pref->set("XTreeWidgetDataLimit", _richLimit->value());
+  _pref->set("XTreeWidgetDataLimit", QString::number(_richLimit->value()));
   _pref->set("EmailEvents", _emailEvents->isChecked());
 
   _pref->set("AlarmEventDefault", _alarmEvent->isChecked());

--- a/guiclient/userPreferences.cpp
+++ b/guiclient/userPreferences.cpp
@@ -213,6 +213,8 @@ void userPreferences::sPopulate()
   else
     _richText->setChecked(true);
 
+  _richLimit->setValue(_pref->value("XTreeWidgetDataLimit").toDouble());
+
   _enableSpell->setChecked(_pref->boolean("SpellCheck"));
 
   //_rememberCheckBoxes->setChecked(! _pref->boolean("XCheckBox/forgetful"));
@@ -348,6 +350,7 @@ void userPreferences::sSave(bool close)
     _pref->set("InterfaceWindowOption", QString("TopLevel"));
     
   _pref->set("CopyListsPlainText", _plainText->isChecked());
+  _pref->set("XTreeWidgetDataLimit", _richLimit->value());
   _pref->set("EmailEvents", _emailEvents->isChecked());
 
   _pref->set("AlarmEventDefault", _alarmEvent->isChecked());

--- a/guiclient/userPreferences.ui
+++ b/guiclient/userPreferences.ui
@@ -245,7 +245,7 @@ to be bound by its terms.</comment>
          <property name="title">
           <string>Copy Lists to</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_2">
+         <layout class="QGridLayout" name="gridLayout">
           <item row="0" column="0">
            <widget class="QRadioButton" name="_richText">
             <property name="text">
@@ -253,6 +253,32 @@ to be bound by its terms.</comment>
             </property>
             <property name="checked">
              <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="_richLimitLit">
+            <property name="text">
+             <string>Limit:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QDoubleSpinBox" name="_richLimit">
+            <property name="prefix">
+             <string/>
+            </property>
+            <property name="suffix">
+             <string> GB</string>
+            </property>
+            <property name="maximum">
+             <double>100.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.250000000000000</double>
             </property>
            </widget>
           </item>

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -2631,7 +2631,7 @@ QString XTreeWidget::toHtml() const
     if (maxDataCount > 0 && dataCount > maxDataCount)
     {
       QString overflowMsg = tr("Maximum data limit was encountered.  Only %1 of %2 rows could be processed.");
-      QMessageBox::warning(this, tr("Data Limit Reached"), overflowMsg.arg(row).arg(rowcnt));
+      QMessageBox::warning(NULL, tr("Data Limit Reached"), overflowMsg.arg(row).arg(rowcnt));
     }
   }
   return doc->toHtml();

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -2549,12 +2549,15 @@ QString XTreeWidget::toHtml() const
   int     colcnt = 0;
   int     rowcnt = 0;
   int     row = 0;
+  double  limit = 0;
   qlonglong maxDataCount = 0;
   qlonglong dataCount = 0;
 
-  if (_x_metrics->boolean("XTreeWidgetDataLimit"))
+  if (_x_preferences)
   {
-    maxDataCount = _x_metrics->value("XTreeWidgetDataLimit").toInt() * 1e9;
+    limit = _x_preferences->value("XTreeWidgetDataLimit").toDouble();
+    if (limit > 0)
+      maxDataCount = (qlonglong)(limit * 1e9);
   }
 
   tableFormat.setHeaderRowCount(1);

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -2625,7 +2625,7 @@ QString XTreeWidget::toHtml() const
             cursor->insertText(item->text(counter));
             cursor->movePosition(QTextCursor::NextCell);
 
-            dataCount += (qlonglong)(header->text(counter).size());
+            dataCount += (qlonglong)(item->text(counter).size());
           }
         }
       }


### PR DESCRIPTION
The root cause of this issue is that the number of bytes needed to perform the copy of the rich data to the clipboard was exceeding the amount of memory addressable by a 32 bit integer, thus causing xTuple to crash.  The most straightforward solution would seem to be to build xTuple as a 64 bit binary.

Barring this, I looked for some way to determine how much addressable space was available, but did not find any approach that would work cross-platform.

What is presented here is a work-around that I feel leaves something to be desired but does address the issue.  I introduced a new preference and placed it on the userPreferences screen beside the choice of copying rich or plain text.  The new preference puts an approximate limit how many bytes of data the XTreeWidget is allowed to export as HTML.  By default the value is 0 GB, which means no limit (which would probably be appropriate for a 64 bit xTuple and probably for the majority of users out there who don't copy a ton of data to the clipboard).  If a crash is observed, the user can modify the preference to limit the amount of data the XTreeWidget will copy.

The process is essentially this:
* Copy the headers and include them in the data count
* Start adding rows until the data count exceeds the limit set
* If the limit is reached, a message box is displayed showing the user how many rows (X of Y) were processed.  No more row data is added, and the copy to clipboard is attempted.

The data count is the current sum of the character length of the data that has been added.  It does NOT include HTML formatting bytes, so the limit is strictly on the text length of the data being copied.

It is still possible to crash the 32 bit client if the limit is not set or is set too high and too much data are added.