### PR TITLE
Issue #27345: WO Material Item enabled save inappropriately

### DIFF
--- a/guiclient/woMaterialItem.cpp
+++ b/guiclient/woMaterialItem.cpp
@@ -31,7 +31,8 @@ woMaterialItem::woMaterialItem(QWidget* parent, const char* name, bool modal, Qt
   connect(_qtyPer, SIGNAL(textChanged(const QString&)), this, SLOT(sUpdateQtyRequired()));
   connect(_scrap, SIGNAL(textChanged(const QString&)), this, SLOT(sUpdateQtyRequired()));
   connect(_uom, SIGNAL(newID(int)), this, SLOT(sUOMChanged()));
-  connect(_item, SIGNAL(valid(bool)), _save, SLOT(setEnabled(bool)));
+  connect(_wo, SIGNAL(valid(bool)), this, SLOT(sEnableSave()));
+  connect(_item, SIGNAL(valid(bool)), this, SLOT(sEnableSave()));
   connect(_item, SIGNAL(newId(int)), this, SLOT(sItemIdChanged()));
   connect(_close, SIGNAL(clicked()), this, SLOT(reject()));
   connect(_save, SIGNAL(clicked()), this, SLOT(sSave()));
@@ -189,6 +190,11 @@ enum SetResponse woMaterialItem::set(const ParameterList &pParams)
   }
 
   return NoError;
+}
+
+void woMaterialItem::sEnableSave()
+{
+  _save->setEnabled(_wo->isValid() && _item->isValid());
 }
 
 void woMaterialItem::sSave()

--- a/guiclient/woMaterialItem.h
+++ b/guiclient/woMaterialItem.h
@@ -37,6 +37,7 @@ protected slots:
     virtual void sItemIdChanged();
     virtual void sPopulateUOM();
     virtual void sUOMChanged();
+    virtual void sEnableSave();
 
 private:
     int _bomitemid;

--- a/guiclient/woMaterialItem.ui
+++ b/guiclient/woMaterialItem.ui
@@ -564,22 +564,6 @@ to be bound by its terms.</comment>
  <resources/>
  <connections>
   <connection>
-   <sender>_item</sender>
-   <signal>valid(bool)</signal>
-   <receiver>_save</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>_close</sender>
    <signal>clicked()</signal>
    <receiver>woMaterialItem</receiver>


### PR DESCRIPTION
Work Order widget is not clearing when order number is cleared.  Need to raise an issue for this.