### PR TITLE
Removed deprecated method call for Qt5

### DIFF
--- a/guiclient/creditcardprocessor.cpp
+++ b/guiclient/creditcardprocessor.cpp
@@ -342,11 +342,14 @@ CreditCardProcessor::CreditCardProcessor()
       if (DEBUG) qDebug() << "opening" << filename;
       QString suffix = QFileInfo(certfile).suffix().toLower();
       QSslCertificate *cert = new QSslCertificate(&certfile, QSsl::Pem);
-      if (cert && ! cert->isValid()) {
+      auto valid = [](QSslCertificate *cert)->bool {
+        return !cert->isNull() && !cert->isBlacklisted() && (cert->expiryDate() >= QDateTime::currentDateTime()) && (cert->effectiveDate() <= QDateTime::currentDateTime());
+      };
+      if (cert && ! valid(cert)) {
         delete cert;
         cert = new QSslCertificate(&certfile, QSsl::Der);
       }
-      if (cert->isValid()) {
+      if (valid(cert)) {
         certs.append(*cert);
         if (DEBUG) qDebug() << "adding certificate" << cert;
       }


### PR DESCRIPTION
Removed `QSslCertificate::isValid()` use in builds using Qt5 or above.