### PR TITLE
Use QHostAddress only.

### DIFF
--- a/scriptapi/qtcpserverproto.cpp
+++ b/scriptapi/qtcpserverproto.cpp
@@ -89,7 +89,7 @@ bool QTcpServerProto::isListening() const
   return false;
 }
 
-bool QTcpServerProto::listen(const QHostAddress::SpecialAddress & address, quint16 port)
+bool QTcpServerProto::listen(const QHostAddress & address, quint16 port)
 {
   QTcpServer *item = qscriptvalue_cast<QTcpServer*>(thisObject());
   if (item)

--- a/scriptapi/qtcpserverproto.h
+++ b/scriptapi/qtcpserverproto.h
@@ -28,7 +28,7 @@ class QTcpServerProto : public QObject, public QScriptable
     Q_INVOKABLE QString                      errorString() const;
     Q_INVOKABLE bool                         hasPendingConnections() const;
     Q_INVOKABLE bool                         isListening() const;
-    Q_INVOKABLE bool                         listen(const QHostAddress::SpecialAddress &address = QHostAddress::Any, quint16 port = 0);
+    Q_INVOKABLE bool                         listen(const QHostAddress &address = QHostAddress::Any, quint16 port = 0);
     Q_INVOKABLE virtual QTcpSocket*          nextPendingConnection();
     Q_INVOKABLE void                         pauseAccepting();
     Q_INVOKABLE QNetworkProxy                proxy() const;


### PR DESCRIPTION
Found this when testing dashboards on linux. Worked find on windows, but this is a bug.
https://doc.qt.io/qt-4.8/qtcpserver.html#listen
https://doc.qt.io/qt-5/qtcpserver.html#listen