### PR TITLE
Expose additional QHostAddress constructors to Qt Script.

### DIFF
--- a/scriptapi/qhostaddressproto.cpp
+++ b/scriptapi/qhostaddressproto.cpp
@@ -73,10 +73,21 @@ void setupQHostAddressProto(QScriptEngine *engine)
 QScriptValue constructQHostAddress(QScriptContext *context, QScriptEngine  *engine)
 {
   QHostAddress *obj = 0;
-  if (context->argumentCount() == 1 && context->argument(0).isString())
+  if (context->argumentCount() == 1 && context->argument(0).isString()) {
     obj = new QHostAddress(context->argument(0).toString());
-  else
+  } else if (context->argumentCount() == 1 && context->argument(0).isNumber()) {
+    if (context->argument(0).isNumber() >= 0 && context->argument(0).isNumber() <= 6) {
+      QHostAddress::SpecialAddress addr = qscriptvalue_cast<QHostAddress::SpecialAddress>(context->argument(0));
+      obj = new QHostAddress(addr);
+    } else {
+      obj = new QHostAddress(context->argument(0).toInt32());
+    }
+  } else if (context->argumentCount() == 1 && context->argument(0).isObject()) {
+    QHostAddress hostAddr = qscriptvalue_cast<QHostAddress>(context->argument(0));
+    obj = new QHostAddress(hostAddr);
+  } else {
     obj = new QHostAddress();
+  }
   return engine->toScriptValue(obj);
 }
 

--- a/scriptapi/qtcpserverproto.cpp
+++ b/scriptapi/qtcpserverproto.cpp
@@ -89,7 +89,7 @@ bool QTcpServerProto::isListening() const
   return false;
 }
 
-bool QTcpServerProto::listen(const QHostAddress::SpecialAddress & address, quint16 port)
+bool QTcpServerProto::listen(const QHostAddress & address, quint16 port)
 {
   QTcpServer *item = qscriptvalue_cast<QTcpServer*>(thisObject());
   if (item)

--- a/scriptapi/qtcpserverproto.h
+++ b/scriptapi/qtcpserverproto.h
@@ -28,7 +28,7 @@ class QTcpServerProto : public QObject, public QScriptable
     Q_INVOKABLE QString                      errorString() const;
     Q_INVOKABLE bool                         hasPendingConnections() const;
     Q_INVOKABLE bool                         isListening() const;
-    Q_INVOKABLE bool                         listen(const QHostAddress::SpecialAddress &address = QHostAddress::Any, quint16 port = 0);
+    Q_INVOKABLE bool                         listen(const QHostAddress &address = QHostAddress::Any, quint16 port = 0);
     Q_INVOKABLE virtual QTcpSocket*          nextPendingConnection();
     Q_INVOKABLE void                         pauseAccepting();
     Q_INVOKABLE QNetworkProxy                proxy() const;


### PR DESCRIPTION
Ran into an issue in linux with dashboards and notices we're missing the other non-string constructors here.
https://doc.qt.io/qt-5/qhostaddress.html