### PR TITLE
Fix QHostAddress constructor conversions.

### DIFF
--- a/scriptapi/qhostaddressproto.cpp
+++ b/scriptapi/qhostaddressproto.cpp
@@ -76,15 +76,15 @@ QScriptValue constructQHostAddress(QScriptContext *context, QScriptEngine  *engi
   if (context->argumentCount() == 1 && context->argument(0).isString()) {
     obj = new QHostAddress(context->argument(0).toString());
   } else if (context->argumentCount() == 1 && context->argument(0).isNumber()) {
-    if (context->argument(0).isNumber() >= 0 && context->argument(0).isNumber() <= 6) {
-      QHostAddress::SpecialAddress addr = qscriptvalue_cast<QHostAddress::SpecialAddress>(context->argument(0));
+    if (context->argument(0).toInteger() >= 0 && context->argument(0).toInteger() < 7) {
+      QHostAddress::SpecialAddress addr = (QHostAddress::SpecialAddress)context->argument(0).toInt32();
       obj = new QHostAddress(addr);
     } else {
       obj = new QHostAddress(context->argument(0).toInt32());
     }
   } else if (context->argumentCount() == 1 && context->argument(0).isObject()) {
-    QHostAddress hostAddr = qscriptvalue_cast<QHostAddress>(context->argument(0));
-    obj = new QHostAddress(hostAddr);
+    QHostAddress *hostAddr = qscriptvalue_cast<QHostAddress*>(context->argument(0));
+    obj = new QHostAddress(*(hostAddr));
   } else {
     obj = new QHostAddress();
   }


### PR DESCRIPTION
This now works correctly for:
```
var strAddr = QHostAddress('127.0.0.1');
var enumAddr = QHostAddress(QHostAddress.LocalHost);
var intIPAddr= QHostAddress(strAddr.toIPv4Address());
var objAddr = QHostAddress(strAddr);
```