### PR TITLE
Issue #28110 #28292: Resolve display of tax on AR/AP memos (after posting)

### DIFF
--- a/guiclient/apOpenItem.cpp
+++ b/guiclient/apOpenItem.cpp
@@ -132,10 +132,11 @@ enum SetResponse apOpenItem::set(const ParameterList &pParams)
       _docNumber->setEnabled(false);
       _poNumber->setEnabled(false);
       _journalNumber->setEnabled(false);
-      _amount->setCurrencyEditable(false);
+      _amount->setEnabled(false);
       _terms->setEnabled(false);
       _notes->setReadOnly(false);
       _usePrepaid->setEnabled(false);
+      _taxzone->setEnabled(false);
       _accntId->setEnabled(false);
     }
     else if (param.toString() == "view")
@@ -156,6 +157,7 @@ enum SetResponse apOpenItem::set(const ParameterList &pParams)
       _usePrepaid->setEnabled(false);
       _accntId->setEnabled(false);
       _status->setEnabled(false);
+      _taxzone->setEnabled(false);
       _buttonBox->setStandardButtons(QDialogButtonBox::Close);
     }
   }
@@ -652,6 +654,9 @@ void apOpenItem::sTaxDetail()
 
 void apOpenItem::sDetermineTaxAmount()
 {
+  if (_mode != cNew)
+    return;
+
   XSqlQuery ap;
   if (_apopenid == -1)
   {

--- a/guiclient/arOpenItem.cpp
+++ b/guiclient/arOpenItem.cpp
@@ -156,6 +156,8 @@ enum SetResponse arOpenItem::set( const ParameterList &pParams )
       _docNumber->setEnabled(false);
       _orderNumber->setEnabled(false);
       _journalNumber->setEnabled(false);
+      _amount->setEnabled(false);
+      _taxzone->setEnabled(false);
       _terms->setEnabled(false);
       _useAltPrepaid->setEnabled(false);
       _altPrepaid->setEnabled(false);
@@ -177,6 +179,7 @@ enum SetResponse arOpenItem::set( const ParameterList &pParams )
       _salesrep->setEnabled(false);
       _commissionDue->setEnabled(false);
       _rsnCode->setEnabled(false);
+      _taxzone->setEnabled(false);
       _useAltPrepaid->setEnabled(false);
       _altPrepaid->setEnabled(false);
       _notes->setReadOnly(true);
@@ -737,6 +740,9 @@ void arOpenItem::sTaxDetail()
 
 void arOpenItem::sDetermineTaxAmount()
 {
+  if (_mode != cNew)
+    return;
+
   XSqlQuery ar;
   if (_aropenid == -1)
   {


### PR DESCRIPTION
#28292 Remove ability to edit memo amounts AFTER document has been posted.