### PR TITLE
Expose QMenuBar to script

### DIFF
--- a/scriptapi/qmenubarproto.cpp
+++ b/scriptapi/qmenubarproto.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree

--- a/scriptapi/qmenubarproto.cpp
+++ b/scriptapi/qmenubarproto.cpp
@@ -1,0 +1,208 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which (including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#include "qmenubarproto.h"
+
+#define DEBUG false
+
+void setupQMenuBarProto(QScriptEngine *engine)
+{
+  QScriptValue proto = engine->newQObject(new QMenuBarProto(engine));
+  engine->setDefaultPrototype(qMetaTypeId<QMenuBar*>(), proto);
+  //engine->setDefaultPrototype(qMetaTypeId<QMenu>(),  proto);
+
+  QScriptValue constructor = engine->newFunction(constructQMenuBar,
+                                                 proto);
+  engine->globalObject().setProperty("QMenuBar", constructor);
+}
+
+QScriptValue constructQMenuBar(QScriptContext *context,
+                            QScriptEngine  *engine)
+{
+  QMenuBar *obj = 0;
+  if (context->argumentCount() == 1 && context->argument(0).isQObject())
+    obj = new QMenuBar(qobject_cast<QWidget*>(context->argument(0).toQObject()));
+  else
+    obj = new QMenuBar();
+  return engine->toScriptValue(obj);
+}
+
+QMenuBarProto::QMenuBarProto(QObject *parent)
+    : QObject(parent)
+{
+}
+
+QAction *QMenuBarProto::actionAt(const QPoint &pt) const
+{
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    return item->actionAt(pt);
+  return 0;
+}
+
+QRect QMenuBarProto::actionGeometry(QAction *act) const
+{
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    return item->actionGeometry(act);
+  return QRect();
+}
+
+QAction *QMenuBarProto::activeAction() const
+{
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    return item->activeAction();
+  return 0;
+}
+
+QAction *QMenuBarProto::addAction(const QString &text)
+{
+  if (DEBUG) qDebug("addAction(QString = %s)", qPrintable(text));
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    return item->addAction(text);
+  return 0;
+}
+
+QAction *QMenuBarProto::addAction(const QString &text, const QObject *receiver, const char *member)
+{
+  if (DEBUG) qDebug("addAction(QString = %s, QObject, char* = %s)", qPrintable(text), member);
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    return item->addAction(text, receiver, member);
+  return 0;
+}
+
+void QMenuBarProto::addAction(QAction *action)
+{
+  // Can't use addAction here because of ambiguity problem
+  if (DEBUG) qDebug("addAction(QAction)");
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    item->addAction(action);
+}
+
+QAction *QMenuBarProto::addMenu(QMenu *menu)
+{
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    return item->addMenu(menu);
+  return 0;
+}
+
+QMenu *QMenuBarProto::addMenu(const QString &title)
+{
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    return item->addMenu(title);
+  return 0;
+}
+
+QMenu *QMenuBarProto::addMenu(const QIcon &icon, const QString &title)
+{
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    return item->addMenu(icon, title);
+  return 0;
+}
+
+QAction *QMenuBarProto::addSeparator()
+{
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    return item->addSeparator();
+  return 0;
+}
+
+void QMenuBarProto::clear()
+{
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    item->clear();
+}
+
+QWidget *QMenuBarProto::cornerWidget(Qt::Corner corner) const
+{
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    return item->cornerWidget(corner);
+  return 0;
+}
+
+QAction *QMenuBarProto::insertMenu(QAction *before, QMenu *menu)
+{
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    return item->insertMenu(before, menu);
+  return 0;
+}
+
+QAction *QMenuBarProto::insertSeparator(QAction *before)
+{
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    return item->insertSeparator(before);
+  return 0;
+}
+
+bool QMenuBarProto::isDefaultUp() const
+{
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    return item->isDefaultUp();
+  return false;
+}
+
+bool QMenuBarProto::isNativeMenuBar() const
+{
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    return item->isNativeMenuBar();
+  return false;
+}
+
+void QMenuBarProto::setActiveAction(QAction *act)
+{
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    item->setActiveAction(act);
+}
+
+void QMenuBarProto::setCornerWidget(QWidget * widget, Qt::Corner corner)
+{
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    item->setCornerWidget(widget, corner);
+}
+
+
+void QMenuBarProto::setDefaultUp(bool choice)
+{
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    item->setDefaultUp(choice);
+}
+
+void QMenuBarProto::setNativeMenuBar(bool nativeMenuBar)
+{
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    item->setNativeMenuBar(nativeMenuBar);
+}
+
+QString QMenuBarProto::toString() const
+{
+  QMenuBar *item = qscriptvalue_cast<QMenuBar*>(thisObject());
+  if (item)
+    return QString("[QMenuBar named %1]")
+                  .arg(item->objectName());
+  return QString("QMenuBar(unknown)");
+}

--- a/scriptapi/qmenubarproto.h
+++ b/scriptapi/qmenubarproto.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree

--- a/scriptapi/qmenubarproto.h
+++ b/scriptapi/qmenubarproto.h
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which (including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#ifndef __QMENUBARPROTO_H__
+#define __QMENUBARPROTO_H__
+
+#include <QMenu>
+#include <QMenuBar>
+#include <QObject>
+#include <QtScript>
+#include <QWidget>
+
+#include "qactionproto.h"
+
+Q_DECLARE_METATYPE(QMenuBar*)
+
+void setupQMenuBarProto(QScriptEngine *engine);
+QScriptValue constructQMenuBar(QScriptContext *context, QScriptEngine *engine);
+
+class QMenuBarProto : public QObject, public QScriptable
+{
+  Q_OBJECT
+
+  public:
+    QMenuBarProto(QObject *parent);
+
+    Q_INVOKABLE QAction *actionAt(const QPoint &pt)	const;
+    Q_INVOKABLE QRect    actionGeometry(QAction *act)	const;
+    Q_INVOKABLE QAction *activeAction()	                const;
+    Q_INVOKABLE QAction *addAction(const QString &text);
+    Q_INVOKABLE QAction *addAction(const QString &text, const QObject *receiver, const char *member);
+    Q_INVOKABLE void     addAction(QAction *action);
+    Q_INVOKABLE QAction *addMenu(QMenu *menu);
+    Q_INVOKABLE QMenu   *addMenu(const QString &title);
+    Q_INVOKABLE QMenu   *addMenu(const QIcon &icon, const QString &title);
+    Q_INVOKABLE QAction *addSeparator();
+    Q_INVOKABLE void     clear();
+    Q_INVOKABLE QWidget *cornerWidget(Qt::Corner corner = Qt::TopRightCorner) const;
+    Q_INVOKABLE QAction *insertMenu(QAction *before, QMenu *menu);
+    Q_INVOKABLE QAction *insertSeparator(QAction *before);
+    Q_INVOKABLE bool     isDefaultUp()                const;
+    Q_INVOKABLE bool     isNativeMenuBar()	        const;
+    Q_INVOKABLE void     setActiveAction(QAction *act);
+    Q_INVOKABLE void     setCornerWidget(QWidget * widget, Qt::Corner corner = Qt::TopRightCorner);
+    Q_INVOKABLE void     setDefaultUp(bool choice);
+    Q_INVOKABLE void     setNativeMenuBar(bool nativeMenuBar);
+    Q_INVOKABLE QString  toString()                     const;
+
+};
+
+#endif

--- a/scriptapi/scriptapi.pro
+++ b/scriptapi/scriptapi.pro
@@ -87,6 +87,7 @@ HEADERS += setupscriptapi.h \
     qlayoutitemproto.h \
     qmainwindowproto.h \
     qmenuproto.h \
+    qmenubarproto.h \
     qmessageboxsetup.h \
     qnetworkaccessmanagerproto.h \
     qnetworkinterfaceproto.h \
@@ -240,6 +241,7 @@ SOURCES += setupscriptapi.cpp \
     qlayoutproto.cpp \
     qmainwindowproto.cpp \
     qmenuproto.cpp \
+    qmenubarproto.cpp \
     qmessageboxsetup.cpp \
     qnetworkaccessmanagerproto.cpp \
     qnetworkinterfaceproto.cpp \

--- a/scriptapi/setupscriptapi.cpp
+++ b/scriptapi/setupscriptapi.cpp
@@ -89,6 +89,7 @@
 #include "qlayoutproto.h"
 #include "qmainwindowproto.h"
 #include "qmenuproto.h"
+#include "qmenubarproto.h"
 #include "qmessageboxsetup.h"
 #include "qnetworkaccessmanagerproto.h"
 #include "qnetworkinterfaceproto.h"
@@ -263,6 +264,7 @@ void setupScriptApi(QScriptEngine *engine)
   setupQLayoutProto(engine);
   setupQMainWindowProto(engine);
   setupQMenuProto(engine);
+  setupQMenuBarProto(engine);
   setupQMessageBox(engine);
   setupQNetworkAccessManagerProto(engine);
   setupQNetworkInterfaceProto(engine);

--- a/scriptapi/setupscriptapi.cpp
+++ b/scriptapi/setupscriptapi.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree


### PR DESCRIPTION
This allows you to use GUIClient::menuBar(), since prior to this it would error out complaining about needing QMenuBar* registered to the script engine. 

This allows for scripts like:
```
var mb = mainwindow.menuBar();
var accntact;
var kids = mb.findChildren("", 0);
for (var i = 0; i < kids.length; i += 1) {
  if (kids[i].toString().indexOf("QMenu") >=0) {
    var actions = kids[i].actions();
    for (var a = 0; a < actions.length; a += 1) {
      if (actions[a].toString().indexOf("Account") >= 0) {
        accntact = actions[a];
      }
    }
  }
}
if (accntact) {
  var rentalsMenu = new QMenu("R&entals", mb);
  rentalsMenu.objectName = "menu.rental";
  var rentalContractMenu = new QMenu("&Contract", rentalsMenu);
  rentalsMenu.addMenu(rentalContractMenu);
  var action = rentalContractMenu.addAction("&New", rentalContractMenu);
  action.triggered.connect(sNewContract);

  rentalsMenu.addSeparator();
  
  var rentalReportsMenu = new QMenu("&Reports", rentalsMenu);
  rentalsMenu.addMenu(rentalReportsMenu);
  mb.insertMenu(accntact, rentalsMenu);
}
```
To add a menu like:
![Scripted Menu Screenshot](http://i.imgur.com/Kzg6NNa.png)