### PR TITLE
Sigtracker

### DIFF
--- a/common/xtuplecommon.h
+++ b/common/xtuplecommon.h
@@ -1,0 +1,53 @@
+#include <QDebug>
+#define SIGTRACK false
+#define FUNTRACK false
+
+/**	@addtogroup globals Global Variables and Functions
+	@}
+	*/
+/**
+	@def SIGTRACK
+	Add "#define SIGTRACK true" to any file that inherits @c guiclient.h or @c widgets.h to enable Signature tracking by the @c TATTLE macro.
+	Please note, this must be added below the @c include statements for @c guiclient.h or @c widgets.h , or the value will be reset to @c false.
+*/
+/**
+	@def FUNTRACK
+	Add "#define FUNTRACK true" to any file that inherits @c guiclient.h or @c widgets.h to enable Function tracking by the @c TATTLE macro.
+	Please note, this must be added below the @c include statements for @c guiclient.h or @c widgets.h , or the value will be reset to @c false.
+*/
+/**
+	@def TATTLE
+	Use in classes that inherit @c guiclient.h or @c widgets.h .
+	TATTLE may be written after the opening bracked of most member functions to allow signal and function call information to be written to the output stream.
+	If only @c SIGTRACK is defined true for a class, then only member functions that are called by a Qt Signal will be written to the output stream with information about the sender.
+	If only @c FUNTRACK is defined true for a class, then all member functions that are called will be written to the output stream.
+	If both @c SIGTRACK and @c FUNTRACK are defined true for a class, then all member functions that are called will be written to the output stream, but functions that
+	are called by a Qt Signal will include additional information about the sender of the Signal.
+*/
+/** @} */
+
+#define TATTLE                                          \
+{                                                       \
+    if (SIGTRACK && sender())                           \
+    {                                                   \
+        qDebug() << "EZGREP..."                         \
+                 << "QObject:"  << sender()             \
+                 << "Index:"    << senderSignalIndex()  \
+                 << "calls "    << __FILE__ << "::"     \
+                                << __func__ << "()";    \
+    }                                                   \
+    else if (SIGTRACK && FUNTRACK)                      \
+    {                                                   \
+        qDebug() << "EZGREP..."                         \
+		 << QString().sprintf("%-8p", this)	\
+                 << __FILE__ << "::"                    \
+                 << __func__ << "()";                   \
+    }                                                   \
+    if (!SIGTRACK && FUNTRACK)                          \
+    {                                                   \
+        qDebug() << "EZGREP..."                         \
+		 << QString().sprintf("%-8p", this)	\
+                 << __FILE__ << "::"                    \
+                 << __func__ << "()";                   \
+    }                                                   \
+}

--- a/common/xtuplecommon.h
+++ b/common/xtuplecommon.h
@@ -3,7 +3,7 @@
 #define FUNTRACK false
 
 /**	@addtogroup globals Global Variables and Functions
-	@}
+	@{
 	*/
 /**
 	@def SIGTRACK

--- a/common/xtuplecommon.h
+++ b/common/xtuplecommon.h
@@ -18,7 +18,7 @@
 /**
 	@def TATTLE
 	Use in classes that inherit @c guiclient.h or @c widgets.h .
-	TATTLE may be written after the opening bracked of most member functions to allow signal and function call information to be written to the output stream.
+	TATTLE may be written after the opening bracket of most member functions to allow signal and function call information to be written to the output stream.
 	If only @c SIGTRACK is defined true for a class, then only member functions that are called by a Qt Signal will be written to the output stream with information about the sender.
 	If only @c FUNTRACK is defined true for a class, then all member functions that are called will be written to the output stream.
 	If both @c SIGTRACK and @c FUNTRACK are defined true for a class, then all member functions that are called will be written to the output stream, but functions that

--- a/guiclient/guiclient.h
+++ b/guiclient/guiclient.h
@@ -21,6 +21,8 @@
 #include "../common/format.h"
 #include "../hunspell/hunspell.hxx"
 
+#include <xtuplecommon.h>
+
 class QCheckBox;
 class QCloseEvent;
 class QDockWidget;

--- a/widgets/widgets.h
+++ b/widgets/widgets.h
@@ -19,6 +19,8 @@
 
 #include "parameter.h"
 
+#include <xtuplecommon.h>
+
 #ifdef Q_OS_WIN
   #ifdef MAKEDLL
     #define XTUPLEWIDGETS_EXPORT __declspec(dllexport)


### PR DESCRIPTION
Created common/xtuplecommon.h.
-Contains definition and default value for SIGTRACK macro.
-Contains definition and default value for FUNTRACK macro.
-Contains definition for TATTLE macro.
Added include statement for xtuplecommon.h to guiclient.h
Added include statement for xtuplecommon.h to widgets.h
