### PR TITLE
issue #25946 Remove option to use same currency as Sales Order for Authorize.net s…

### DIFF
--- a/guiclient/configauthorizedotnetprocessor.cpp
+++ b/guiclient/configauthorizedotnetprocessor.cpp
@@ -38,13 +38,8 @@ ConfigAuthorizeDotNetProcessor::ConfigAuthorizeDotNetProcessor(QWidget* parent, 
   _anMD5HashWarn->setChecked(_metrics->value("CCANMD5HashAction") == "W");
   _anMD5HashFail->setChecked(_metrics->value("CCANMD5HashAction") == "F");
 
-  if (_metrics->value("CCANCurrency") == "TRANS")
-    _anCurrTransaction->setChecked(true);
-  else if (! _metrics->value("CCANCurrency").isEmpty())
-  {
-    _anCurrFixed->setChecked(true);
+  if (! _metrics->value("CCANCurrency").isEmpty())
     _anCurrFixedValue->setId(_metrics->value("CCANCurrency").toInt());
-  }
 
   _anUsingWellsFargoSecureSource->setChecked(_metrics->boolean("CCANWellsFargoSecureSource"));
   _anIgnoreSSLErrors->setChecked(_metrics->boolean("CCANIgnoreSSLErrors"));
@@ -79,10 +74,7 @@ bool ConfigAuthorizeDotNetProcessor::sSave()
   else if (_anMD5HashFail->isChecked())
     _metrics->set("CCANMD5HashAction", QString("F"));
 
-  if (_anCurrFixed->isChecked())
-    _metrics->set("CCANCurrency", _anCurrFixedValue->id());
-  else // if (_anCurrTransaction->isChecked())
-    _metrics->set("CCANCurrency", QString("TRANS"));
+  _metrics->set("CCANCurrency", _anCurrFixedValue->id());
   _metrics->set("CCANWellsFargoSecureSource", _anUsingWellsFargoSecureSource->isChecked());
   _metrics->set("CCANMD5HashSetOnGateway", _anMD5HashSetOnGateway->isChecked());
   _metrics->set("CCANIgnoreSSLErrors",     _anIgnoreSSLErrors->isChecked());

--- a/guiclient/configauthorizedotnetprocessor.ui
+++ b/guiclient/configauthorizedotnetprocessor.ui
@@ -224,17 +224,7 @@ to be bound by its terms.</comment>
          <number>12</number>
         </property>
         <item>
-         <widget class="QRadioButton" name="_anCurrTransaction">
-          <property name="text">
-           <string>Same as Order</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="_anCurrFixed">
+         <widget class="QLabel" name="_anCurrFixedLit">
           <property name="text">
            <string>Always Use:</string>
           </property>
@@ -242,9 +232,6 @@ to be bound by its terms.</comment>
         </item>
         <item>
          <widget class="XComboBox" name="_anCurrFixedValue">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
           <property name="type">
            <enum>XComboBox::Currencies</enum>
           </property>


### PR DESCRIPTION
…ince each account can only support one currency.