### PR TITLE
Skip credit card processing if it's not enabled.

### DIFF
--- a/guiclient/cashReceipt.cpp
+++ b/guiclient/cashReceipt.cpp
@@ -827,7 +827,7 @@ bool cashReceipt::save(bool partial)
   }
   _received->setCurrencyDisabled(true);
 
-  if (!partial)
+  if (!partial && _metrics->boolean("CCAccept") && _privileges->check("ProcessCreditCards"))
   {
     XSqlQuery isCreditCardQry;
     bool isCreditCard = false;


### PR DESCRIPTION
Now that Card on File has switch to use the old `A`, `D`, `M` and `V` fundstypes, I have to skip processing the charge through the old Credit Card processor code when the Cash Receipt is being handled by the new Card on File processor. Making sure `_metrics->boolean("CCAccept")` is disabled is how that works.
