### PR TITLE
Issue #28497: Prevent Purchase Agent selection for inactive user accounts

### DIFF
--- a/widgets/xcombobox.cpp
+++ b/widgets/xcombobox.cpp
@@ -1109,7 +1109,8 @@ void XComboBox::setType(XComboBoxTypes pType)
     case Agent:
       query.exec( "SELECT usr_id, usr_username, usr_username "
                   "  FROM usr"
-                  " WHERE (usr_agent) "
+                  " WHERE ((usr_agent) "
+                  "   AND  (usr_active)) "
                   " ORDER BY usr_username;" );
       break;
 


### PR DESCRIPTION
This change prevents selection of a Purchasing Agent where their user account has been marked inactive.

Still need to go through all the relevant screens and amend what happens if an agent is selected on a document (like a PO) and then is removed as an agent.  Current system does not populate the combobox and defaults to the currently active user so does not retain the original agent.