### PR TITLE
issue #28517 - no need to convert back & forth

### DIFF
--- a/guiclient/inputManager.cpp
+++ b/guiclient/inputManager.cpp
@@ -65,7 +65,10 @@ class ScanEvent
 #endif
 
 ReceiverItem::ReceiverItem()
-  : _null(true)
+  : _type(0),
+    _parent(0),
+    _target(0),
+    _null(true)
 {
 }
 
@@ -153,6 +156,8 @@ void InputManager::notify(int pType, QObject *pParent, QObject *pTarget, const Q
  */
 QString InputManager::slotName(const QString &slotname)
 {
+  if (DEBUG)
+    qDebug("slotName(%s) entered", qPrintable(slotname));
   return QString("1") + slotname;
 }
 
@@ -414,6 +419,11 @@ void InputManagerPrivate::dispatchScan(int type)
   ReceiverItem receiver = findReceiver(type);
   if (! receiver.isNull())
   {
+    if (DEBUG)
+      qDebug() << "dispatchScan() receiver:"     << receiver.type()
+               << receiver.parent()      << "->" << receiver.target()
+               << "[" << receiver.slot() << "]"  << receiver.isNull();
+
     QString number    = _buffer.left(_length1);
     QString subNumber = _buffer.mid(_length1, _length2);
     QString seqNumber = _buffer.right(_length3);

--- a/guiclient/inputManagerPrivate.h
+++ b/guiclient/inputManagerPrivate.h
@@ -28,11 +28,10 @@ class ReceiverItem
     inline int type()        { return _type;   };
     inline QObject *parent() { return _parent; };
     inline QObject *target() { return _target; };
-    inline char* slot()    { return _slot.toLatin1().data();   };
+    inline QString  slot()   { return _slot;   };
     inline bool isNull()     { return _null;   };
     bool operator==(const ReceiverItem &value) const;
 
-  private:
     int     _type;
     QObject *_parent;
     QObject *_target;


### PR DESCRIPTION
The real fix is a one-liner - change the return type of `ReceiverItem::slot()` to QString. The rest of the changes helped debug the problem.