### PR TITLE
Issue #28327: restore ability to edit multiple scripts

### DIFF
--- a/guiclient/scripts.cpp
+++ b/guiclient/scripts.cpp
@@ -59,7 +59,7 @@ void scripts::sNew()
   scriptEditor *newdlg = new scriptEditor();
   newdlg->set(params);
 
-  omfgThis->handleNewWindow(newdlg, Qt::ApplicationModal);
+  omfgThis->handleNewWindow(newdlg);
   connect(newdlg, SIGNAL(destroyed()), this, SLOT(sFillList()));
 }
 
@@ -72,7 +72,7 @@ void scripts::sEdit()
   scriptEditor *newdlg = new scriptEditor();
   newdlg->set(params);
 
-  omfgThis->handleNewWindow(newdlg, Qt::ApplicationModal);
+  omfgThis->handleNewWindow(newdlg);
   connect(newdlg, SIGNAL(destroyed()), this, SLOT(sFillList()));
 }
 


### PR DESCRIPTION
Allows proper interaction with other windows and does not exhibit the behavior of embedding itself in the parent window. 