### PR TITLE
Issue #26504: Add Fixed Asset and Maintenance Order Comments Types

### DIFF
--- a/widgets/comments.cpp
+++ b/widgets/comments.cpp
@@ -89,6 +89,8 @@ QMap<QString, struct CommentMap *> &Comments::commentMap() {
 //  addToMap(CreditMemoItem,    "CMI",   tr("Return Item")                                                   );
     addToMap(Customer,          "C",     tr("Customer"),                 "cust_id",      "customer"          );
     addToMap(Employee,          "EMP",   tr("Employee"),                 "emp_id",       "employee"          );
+    addToMap(FixedAsset,        "FADOC", tr("Fixed Asset"),              "id",           "fixedAsset"        );
+    addToMap(MaintOrder,        "FAMAINT", tr("Maintenance Order"),      "maintord_id",  "maintOrder"        );
     addToMap(ExchangeRate,      "FX",    tr("Exchange Rate")                                                 );
     addToMap(Incident,          "INCDT", tr("Incident"),                 "incdt_id",     "incident",     "MaintainPersonalIncidents MaintainAllIncidents");
 //  addToMap(Invoice,           "INV",   tr("Invoice"),                  "invchead_id",  "invoice"           );

--- a/widgets/comments.h
+++ b/widgets/comments.h
@@ -71,6 +71,7 @@ class XTUPLEWIDGETS_EXPORT Comments : public QWidget
       BOOHead,           BOOItem,
       CRMAccount,        Contact,
       Customer,          Employee,
+      FixedAsset,        MaintOrder,
       ExchangeRate,      Incident,
       Item,              ItemSite,
       ItemSource,        Location,


### PR DESCRIPTION
Be nice if we could squeeze this into 4.10  :+1: 