### PR TITLE
Revert "Issue #28497: Prevent Purchase Agent selection for inactive user accounts"

### DIFF
--- a/widgets/xcombobox.cpp
+++ b/widgets/xcombobox.cpp
@@ -1109,8 +1109,7 @@ void XComboBox::setType(XComboBoxTypes pType)
     case Agent:
       query.exec( "SELECT usr_id, usr_username, usr_username "
                   "  FROM usr"
-                  " WHERE ((usr_agent) "
-                  "   AND  (usr_active)) "
+                  " WHERE (usr_agent) "
                   " ORDER BY usr_username;" );
       break;
 


### PR DESCRIPTION
Reverts xtuple/qt-client#1372

I didn't notice that the PR was against 4_10_x. This is a bit too dangerous to put into a final release after an RC.