### PR TITLE
Issue #28889: Make search on display class windows respond to both Return AND Enter keys

### DIFF
--- a/guiclient/display.cpp
+++ b/guiclient/display.cpp
@@ -397,7 +397,9 @@ display::display(QWidget* parent, const char* name, Qt::WindowFlags flags)
   _data->_printAct->setShortcut(QKeySequence::Print);
 
   _data->_search->setNullStr(tr("search"));
-  _data->_searchAct->setShortcut(QKeySequence::InsertParagraphSeparator);
+  QList<QKeySequence> shortcuts;
+  shortcuts << QKeySequence(Qt::Key_Enter) << QKeySequence(Qt::Key_Return);
+  _data->_searchAct->setShortcuts(shortcuts);
   _data->_searchAct->setShortcutContext(Qt::WidgetWithChildrenShortcut);
 
   // Set tooltips


### PR DESCRIPTION
While researching the best way to do this I discovered setShortcuts() is available, allowing two shortcuts set from a QList (instead of my alternative idea to instantiate the shortcuts and use their signals). 