### PR TITLE
issue #28899 - Standard Cost radio button displayed when not allowed in setup

### DIFF
--- a/guiclient/itemSite.cpp
+++ b/guiclient/itemSite.cpp
@@ -137,7 +137,7 @@ itemSite::itemSite(QWidget* parent, const char* name, bool modal, Qt::WindowFlag
   
   _costAvg->setVisible(_metrics->boolean("AllowAvgCostMethod"));
   _costStd->setVisible(_metrics->boolean("AllowStdCostMethod"));
-  _costStd->setVisible(_metrics->boolean("AllowJobCostMethod"));
+  _costJob->setVisible(_metrics->boolean("AllowJobCostMethod"));
   
   adjustSize();
   


### PR DESCRIPTION
Test on costing method made standard cost visible if job costing allowed

job cost test set the standard cost radio button instead of the job cost radio button

Update itemSite.cpp