### PR TITLE
Issue #29119: Dont show inactive items in relocate screen

### DIFF
--- a/guiclient/item.cpp
+++ b/guiclient/item.cpp
@@ -1752,6 +1752,7 @@ void item::sFillListItemSites()
   params.append("average", tr("Average"));
   params.append("na", tr("N/A"));
   params.append("never", tr("Never"));
+  params.append("showInactive");
 
   itemFillListItemSites  = mql.toQuery(params);
   _itemSite->populate(itemFillListItemSites);

--- a/guiclient/relocateInventory.cpp
+++ b/guiclient/relocateInventory.cpp
@@ -29,7 +29,7 @@ relocateInventory::relocateInventory(QWidget* parent, const char* name, bool mod
 
   _captive = false;
 
-  _item->setType(ItemLineEdit::cLocationControlled);
+  _item->setType(ItemLineEdit::cLocationControlled | ItemLineEdit::cActive);
   _qty->setValidator(omfgThis->transQtyVal());
 
   omfgThis->inputManager()->notify(cBCItem, this, _item, SLOT(setItemid(int)));


### PR DESCRIPTION
Also resolves bug in Item screen where inactive Items Sites were not listed.