### PR TITLE
Issue #19902: CRM Account translatable error messages

### DIFF
--- a/common/storedProcErrorLookup.cpp
+++ b/common/storedProcErrorLookup.cpp
@@ -302,6 +302,12 @@ const struct {
   { "createWo",	-2, QT_TRANSLATE_NOOP("storedProcErrorLookup", "Work Order can not be exploded because items on "
 			       "the BOM exist without itemsites."),	0, "" }, 
 
+  { "CRMAccount",	-1, QT_TRANSLATE_NOOP("storedProcErrorLookup", "The CRM Account is associated with a system user "
+                               " so the number cannot be changed."),		 0, "" },
+  { "CRMAccount",	-2, QT_TRANSLATE_NOOP("storedProcErrorLookup", "User does not exist so this CRM Account Number is invalid."
+                                                                  ),		 0, "" },
+  { "CRMAccount",	-3, QT_TRANSLATE_NOOP("storedProcErrorLookup", "Cannot change the Username"), 0, "" },
+
   { "deleteAccount",  -1, QT_TRANSLATE_NOOP("storedProcErrorLookup", "The selected Ledger Account cannot be deleted as it "
                              "is currently used in one or more Cost Categories."
                              "  You must reassign these Cost Category "


### PR DESCRIPTION
requires xtuple/xtuple#2936

For some reason the additional argument from the function is not being added to the storedProcError message so I left that out for the moment.