### PR TITLE
Issue #29129: Resolve Item Availability confusing error message

### DIFF
--- a/guiclient/itemAvailabilityWorkbench.cpp
+++ b/guiclient/itemAvailabilityWorkbench.cpp
@@ -371,7 +371,12 @@ void itemAvailabilityWorkbench::sFillList()
     if (_costedIndentedBOMButton->isChecked())
       _dspCostedIndentedBOM->sFillList();
     else if (_whereUsedButton->isChecked())
-      _dspSingleLevelWhereUsed->sFillList();
+    {
+      if (_dspSingleLevelWhereUsed->findChild<ItemCluster*>("_item")->isValid())
+        _dspSingleLevelWhereUsed->sFillList();
+      else
+        _dspSingleLevelWhereUsed->list()->clear();
+    }
     else if (_singleLevelBOMButton->isChecked())
       _dspSingleLevelBOM->sFillList();
   }


### PR DESCRIPTION
Hide error message if the item is not used in any BOM and hence the item widget on the subform is invalid