### PR TITLE
Issue #29130: Allow user override of PO item invUOM ratio

### DIFF
--- a/guiclient/purchaseOrderItem.ui
+++ b/guiclient/purchaseOrderItem.ui
@@ -933,9 +933,6 @@ to be bound by its terms.</comment>
                 </item>
                 <item row="3" column="1">
                  <widget class="XLineEdit" name="_invVendorUOMRatio">
-                  <property name="enabled">
-                   <bool>false</bool>
-                  </property>
                   <property name="minimumSize">
                    <size>
                     <width>80</width>


### PR DESCRIPTION
Populate and save functions already exist but the ui widget was permanently disabled.