### PR TITLE
issue #29022 - remove optimizations that gave wrong results

### DIFF
--- a/guiclient/salesOrderItem.cpp
+++ b/guiclient/salesOrderItem.cpp
@@ -2245,7 +2245,7 @@ void salesOrderItem::sDetermineAvailability( bool p )
         (!p) )
     return;
   
-  if (_partialsaved)
+  if (_qtyOrdered->toDouble() > 0)
     sSave(true);
 
   _availabilityLastItemid      = _item->id();
@@ -2281,16 +2281,8 @@ void salesOrderItem::sDetermineAvailability( bool p )
     params.append("qty", _availabilityQtyOrdered);
     params.append("origQtyOrd", _originalQtyOrd);
     
-    if (_partialsaved)
-    {
-      params.append("qtyOrdered", _qtyOrdered->toDouble());
-      params.append("supplyOrderQty", _supplyOrderQty->toDouble());
-    }
-    else
-    {
-      params.append("qtyOrdered", 0.0);
-      params.append("supplyOrderQty", 0.0);
-    }
+    params.append("qtyOrdered",     0); // set to 0 to fix bug 29022 with
+    params.append("supplyOrderQty", 0); // only client-side changes
     
     availability = mql.toQuery(params);
     if (availability.first())
@@ -2595,21 +2587,6 @@ void salesOrderItem::sCheckSupplyOrder()
 
 void salesOrderItem::sHandleSupplyOrder()
 {
-  /*
-  if (_createSupplyOrder->isChecked())
-    QMessageBox::critical(this, tr("Debug"),
-                          tr("sHandleSupplyOrder called with _createSupplyOrder checked."));
-  else
-    QMessageBox::critical(this, tr("Debug"),
-                          tr("sHandleSupplyOrder called with _createSupplyOrder unchecked."));
-  if (_supplyOrderId == -1)
-    QMessageBox::critical(this, tr("Debug"),
-                          tr("sHandleSupplyOrder called with _supplyOrderId=-1."));
-  else
-    QMessageBox::critical(this, tr("Debug"),
-                          tr("sHandleSupplyOrder called with _supplyOrderId set."));
-  */
-  
   if (ISQUOTE(_mode))
     return;
   
@@ -3470,6 +3447,7 @@ void salesOrderItem::sHandleSupplyOrder()
       _woIndentedList->clear();
     }
   }  // end createSupplyOrder is not checked
+  sDetermineAvailability(true);
 }
 
 void salesOrderItem::sPopulateOrderInfo()


### PR DESCRIPTION
This is a minimal change for 4.10.1: Add an availability check after
changing supply orders, and remove an optimization that tried to
replace a save with an in-line calculation. The in-line calculation
incorrectly assumed that the previous line item qty had always been
saved.