### PR TITLE
issue #28225, issue #27021 - scripts on widgets part 2

### DIFF
--- a/guiclient/assignItemToPlannerCode.cpp
+++ b/guiclient/assignItemToPlannerCode.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -11,6 +11,7 @@
 #include "assignItemToPlannerCode.h"
 
 #include <QMessageBox>
+#include <QPushButton>
 #include <QVariant>
 
 #include "guiErrorCheck.h"
@@ -20,7 +21,6 @@ assignItemToPlannerCode::assignItemToPlannerCode(QWidget* parent, const char* na
 {
   setupUi(this);
 
-    // signals and slots connections
   connect(_item, SIGNAL(valid(bool)), _buttonBox->button(QDialogButtonBox::Ok), SLOT(setEnabled(bool)));
   connect(_buttonBox, SIGNAL(accepted()), this, SLOT(sAssign()));
   connect(_buttonBox, SIGNAL(rejected()), this, SLOT(reject()));

--- a/guiclient/cashReceipt.cpp
+++ b/guiclient/cashReceipt.cpp
@@ -1001,8 +1001,6 @@ bool cashReceipt::postReceipt()
       return false;
   }
   
-  int journalNumber = -1;
-
   XSqlQuery tx;
   tx.exec("BEGIN;");
 

--- a/guiclient/costCategory.cpp
+++ b/guiclient/costCategory.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -13,6 +13,7 @@
 #include "costCategory.h"
 
 #include <QMessageBox>
+#include <QPushButton>
 #include <QSqlError>
 #include <QVariant>
 

--- a/guiclient/display.h
+++ b/guiclient/display.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree

--- a/guiclient/displays/dspCostedBOMBase.h
+++ b/guiclient/displays/dspCostedBOMBase.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree

--- a/guiclient/displays/dspCostedIndentedBOM.cpp
+++ b/guiclient/displays/dspCostedIndentedBOM.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -12,7 +12,9 @@
 
 #include <QSqlError>
 #include <QVariant>
+
 #include "errorReporter.h"
+#include "xtreewidget.h"
 
 dspCostedIndentedBOM::dspCostedIndentedBOM(QWidget* parent, const char*, Qt::WindowFlags fl)
     : dspCostedBOMBase(parent, "dspCostedIndentedBOM", fl)

--- a/guiclient/displays/dspCostedSingleLevelBOM.cpp
+++ b/guiclient/displays/dspCostedSingleLevelBOM.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -12,7 +12,9 @@
 
 #include <QSqlError>
 #include <QVariant>
+
 #include "errorReporter.h"
+#include "xtreewidget.h"
 
 dspCostedSingleLevelBOM::dspCostedSingleLevelBOM(QWidget* parent, const char*, Qt::WindowFlags fl)
     : dspCostedBOMBase(parent, "dspCostedSingleLevelBOM", fl)

--- a/guiclient/displays/dspCostedSummarizedBOM.cpp
+++ b/guiclient/displays/dspCostedSummarizedBOM.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -12,6 +12,8 @@
 
 #include <QVariant>
 #include <QMessageBox>
+
+#include "xtreewidget.h"
 
 dspCostedSummarizedBOM::dspCostedSummarizedBOM(QWidget* parent, const char*, Qt::WindowFlags fl)
     : display(parent, "dspCostedSummarizedBOM", fl)

--- a/guiclient/displays/dspCostedSummarizedBOM.h
+++ b/guiclient/displays/dspCostedSummarizedBOM.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree

--- a/guiclient/displays/dspCountTagsBase.cpp
+++ b/guiclient/displays/dspCountTagsBase.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -17,6 +17,7 @@
 #include <parameter.h>
 
 #include "countTag.h"
+#include "xtreewidget.h"
 
 dspCountTagsBase::dspCountTagsBase(QWidget* parent, const char* name, Qt::WindowFlags fl)
   : display(parent, name, fl)

--- a/guiclient/displays/dspDetailedInventoryHistoryByLocation.cpp
+++ b/guiclient/displays/dspDetailedInventoryHistoryByLocation.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -21,6 +21,7 @@
 #include "expenseTrans.h"
 #include "materialReceiptTrans.h"
 #include "countTag.h"
+#include "xtreewidget.h"
 
 dspDetailedInventoryHistoryByLocation::dspDetailedInventoryHistoryByLocation(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspDetailedInventoryHistoryByLocation", fl)

--- a/guiclient/displays/dspDetailedInventoryHistoryByLotSerial.cpp
+++ b/guiclient/displays/dspDetailedInventoryHistoryByLotSerial.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -21,6 +21,7 @@
 #include "materialReceiptTrans.h"
 #include "countTag.h"
 #include "parameterwidget.h"
+#include "xtreewidget.h"
 
 dspDetailedInventoryHistoryByLotSerial::dspDetailedInventoryHistoryByLotSerial(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspDetailedInventoryHistoryByLotSerial", fl)

--- a/guiclient/displays/dspExpiredInventoryByClassCode.cpp
+++ b/guiclient/displays/dspExpiredInventoryByClassCode.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -24,6 +24,7 @@
 #include "transferTrans.h"
 #include "createCountTagsByItem.h"
 #include "guiclient.h"
+#include "xtreewidget.h"
 
 #define COST_COL	6
 #define VALUE_COL	7

--- a/guiclient/displays/dspIndentedBOM.cpp
+++ b/guiclient/displays/dspIndentedBOM.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -11,6 +11,7 @@
 #include "dspIndentedBOM.h"
 
 #include <QVariant>
+#include "xtreewidget.h"
 
 dspIndentedBOM::dspIndentedBOM(QWidget* parent, const char*, Qt::WindowFlags fl)
   : dspBOMBase(parent, "dspIndentedBOM", fl)

--- a/guiclient/displays/dspIndentedWhereUsed.cpp
+++ b/guiclient/displays/dspIndentedWhereUsed.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -16,6 +16,7 @@
 #include <QVariant>
 
 #include "dspInventoryHistory.h"
+#include "xtreewidget.h"
 
 dspIndentedWhereUsed::dspIndentedWhereUsed(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspIndentedWhereUsed", fl)

--- a/guiclient/displays/dspItemCostDetail.cpp
+++ b/guiclient/displays/dspItemCostDetail.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -13,7 +13,9 @@
 #include <QSqlError>
 #include <QMessageBox>
 #include <QVariant>
+
 #include "errorReporter.h"
+#include "xtreewidget.h"
 
 dspItemCostDetail::dspItemCostDetail(QWidget* parent, const char*, Qt::WindowFlags fl)
     : display(parent, "dspItemCostDetail", fl)

--- a/guiclient/displays/dspItemCostHistory.cpp
+++ b/guiclient/displays/dspItemCostHistory.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -11,6 +11,8 @@
 #include "dspItemCostHistory.h"
 
 #include <QMessageBox>
+
+#include "xtreewidget.h"
 
 dspItemCostHistory::dspItemCostHistory(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspItemCostHistory", fl)

--- a/guiclient/displays/dspItemCostSummary.cpp
+++ b/guiclient/displays/dspItemCostSummary.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -19,6 +19,7 @@
 
 #include <metasql.h>
 #include "mqlutil.h"
+#include "xtreewidget.h"
 
 #include "dspItemCostDetail.h"
 #include "itemCost.h"

--- a/guiclient/displays/dspJobCosting.cpp
+++ b/guiclient/displays/dspJobCosting.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -12,6 +12,8 @@
 
 #include <QMessageBox>
 #include <QVariant>
+
+#include "xtreewidget.h"
 
 dspJobCosting::dspJobCosting(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspJobCosting", fl)
@@ -29,7 +31,6 @@ dspJobCosting::dspJobCosting(QWidget* parent, const char*, Qt::WindowFlags fl)
   list()->addColumn(tr("Qty."),  _qtyColumn, Qt::AlignRight, true, "qty");
   list()->addColumn(tr("UOM"),   _uomColumn, Qt::AlignCenter,true, "uom");
   list()->addColumn(tr("Cost"),_moneyColumn, Qt::AlignRight, true, "cost");
-
 }
 
 void dspJobCosting::languageChange()

--- a/guiclient/displays/dspMaterialUsageVarianceByBOMItem.cpp
+++ b/guiclient/displays/dspMaterialUsageVarianceByBOMItem.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -12,6 +12,8 @@
 
 #include <QVariant>
 #include <QMessageBox>
+
+#include "xtreewidget.h"
 
 dspMaterialUsageVarianceByBOMItem::dspMaterialUsageVarianceByBOMItem(QWidget* parent, const char* name, Qt::WindowFlags fl)
     : display(parent, "dspMaterialUsageVarianceByBOMItem", fl)

--- a/guiclient/displays/dspMaterialUsageVarianceByComponentItem.cpp
+++ b/guiclient/displays/dspMaterialUsageVarianceByComponentItem.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -12,6 +12,8 @@
 
 #include <QVariant>
 #include <QMessageBox>
+
+#include "xtreewidget.h"
 
 dspMaterialUsageVarianceByComponentItem::dspMaterialUsageVarianceByComponentItem(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspMaterialUsageVarianceByComponentItem", fl)
@@ -71,5 +73,4 @@ bool dspMaterialUsageVarianceByComponentItem::setParams(ParameterList &params)
 
   return true;
 }
-
 

--- a/guiclient/displays/dspMaterialUsageVarianceByItem.cpp
+++ b/guiclient/displays/dspMaterialUsageVarianceByItem.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -12,6 +12,8 @@
 
 #include <QVariant>
 #include <QMessageBox>
+
+#include "xtreewidget.h"
 
 dspMaterialUsageVarianceByItem::dspMaterialUsageVarianceByItem(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspMaterialUsageVarianceByItem", fl)
@@ -73,5 +75,4 @@ bool dspMaterialUsageVarianceByItem::setParams(ParameterList &params)
 
   return true;
 }
-
 

--- a/guiclient/displays/dspMaterialUsageVarianceByWorkOrder.cpp
+++ b/guiclient/displays/dspMaterialUsageVarianceByWorkOrder.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -14,6 +14,7 @@
 #include <QMessageBox>
 
 #include "inputManager.h"
+#include "xtreewidget.h"
 
 dspMaterialUsageVarianceByWorkOrder::dspMaterialUsageVarianceByWorkOrder(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspMaterialUsageVarianceByWorkOrder", fl)

--- a/guiclient/displays/dspOrders.cpp
+++ b/guiclient/displays/dspOrders.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -20,6 +20,7 @@
 #include "reprioritizeWo.h"
 #include "reschedulePoitem.h"
 #include "rescheduleWo.h"
+#include "xtreewidget.h"
 
 dspOrders::dspOrders(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspOrders", fl)

--- a/guiclient/displays/dspPendingAvailability.cpp
+++ b/guiclient/displays/dspPendingAvailability.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -12,6 +12,8 @@
 
 #include <QVariant>
 #include <QMessageBox>
+
+#include "xtreewidget.h"
 
 dspPendingAvailability::dspPendingAvailability(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspPendingAvailability", fl)

--- a/guiclient/displays/dspPoDeliveryDateVariancesByItem.cpp
+++ b/guiclient/displays/dspPoDeliveryDateVariancesByItem.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -11,6 +11,7 @@
 #include "dspPoDeliveryDateVariancesByItem.h"
 
 #include <QMessageBox>
+#include "xtreewidget.h"
 
 dspPoDeliveryDateVariancesByItem::dspPoDeliveryDateVariancesByItem(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspPoDeliveryDateVariancesByItem", fl)

--- a/guiclient/displays/dspPoDeliveryDateVariancesByVendor.cpp
+++ b/guiclient/displays/dspPoDeliveryDateVariancesByVendor.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -12,6 +12,8 @@
 
 #include <QVariant>
 #include <QMessageBox>
+
+#include "xtreewidget.h"
 
 dspPoDeliveryDateVariancesByVendor::dspPoDeliveryDateVariancesByVendor(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspPoDeliveryDateVariancesByVendor", fl)

--- a/guiclient/displays/dspPoItemReceivingsByItem.cpp
+++ b/guiclient/displays/dspPoItemReceivingsByItem.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -13,7 +13,7 @@
 #include <QMessageBox>
 #include <QSqlError>
 
-#include "guiclient.h"
+#include "xtreewidget.h"
 
 dspPoItemReceivingsByItem::dspPoItemReceivingsByItem(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspPoItemReceivingsByItem", fl)

--- a/guiclient/displays/dspPoPriceVariancesByItem.cpp
+++ b/guiclient/displays/dspPoPriceVariancesByItem.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -13,7 +13,7 @@
 #include <QVariant>
 #include <QMessageBox>
 
-#include "guiclient.h"
+#include "xtreewidget.h"
 
 dspPoPriceVariancesByItem::dspPoPriceVariancesByItem(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspPoPriceVariancesByItem", fl)

--- a/guiclient/displays/dspPoPriceVariancesByVendor.cpp
+++ b/guiclient/displays/dspPoPriceVariancesByVendor.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -13,7 +13,7 @@
 #include <QVariant>
 #include <QMessageBox>
 
-#include "guiclient.h"
+#include "xtreewidget.h"
 
 dspPoPriceVariancesByVendor::dspPoPriceVariancesByVendor(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspPoPriceVariancesByVendor", fl)

--- a/guiclient/displays/dspPoReturnsByVendor.cpp
+++ b/guiclient/displays/dspPoReturnsByVendor.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -13,7 +13,7 @@
 #include <QVariant>
 #include <QMessageBox>
 
-#include "guiclient.h"
+#include "xtreewidget.h"
 
 dspPoReturnsByVendor::dspPoReturnsByVendor(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspPoReturnsByVendor", fl)

--- a/guiclient/displays/dspPricesByCustomer.cpp
+++ b/guiclient/displays/dspPricesByCustomer.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -12,7 +12,7 @@
 
 #include <QMessageBox>
 
-#include "guiclient.h"
+#include "xtreewidget.h"
 
 #define CURR_COL	7
 #define COST_COL	8

--- a/guiclient/displays/dspPricesByItem.cpp
+++ b/guiclient/displays/dspPricesByItem.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -12,7 +12,7 @@
 
 #include <QMessageBox>
 
-#include "guiclient.h"
+#include "xtreewidget.h"
 
 #define CURR_COL	5
 #define COST_COL	6

--- a/guiclient/displays/dspQOH.cpp
+++ b/guiclient/displays/dspQOH.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -20,6 +20,7 @@
 #include "createCountTagsByItem.h"
 #include "dspInventoryLocator.h"
 #include "parameterwidget.h"
+#include "xtreewidget.h"
 
 dspQOH::dspQOH(QWidget* parent, const char*, Qt::WindowFlags fl)
     : display(parent, "dspQOH", fl)

--- a/guiclient/displays/dspQOHByZone.cpp
+++ b/guiclient/displays/dspQOHByZone.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -21,6 +21,7 @@
 #include "createCountTagsByItem.h"
 #include "dspInventoryLocator.h"
 #include "parameterwidget.h"
+#include "xtreewidget.h"
 
 dspQOHByZone::dspQOHByZone(QWidget* parent, const char*, Qt::WindowFlags fl)
     : display(parent, "dspQOHByZone", fl)
@@ -37,9 +38,6 @@ dspQOHByZone::dspQOHByZone(QWidget* parent, const char*, Qt::WindowFlags fl)
                     "JOIN whsinfo ON (warehous_id=whsezone_warehous_id) "
                     " ORDER BY warehous_code, whsezone_name;");
 
-  //if (_metrics->boolean("MultiWhs"))
-  //  parameterWidget()->append(tr("Site"), "warehous_id", ParameterWidget::Site, "", true);
-  // TODO filter Zone based on Site selection
   parameterWidget()->appendComboBox(tr("Zone"), "whsezone_id", _zoneSQL, "", true);
 
   if (_metrics->boolean("MultiWhs"))
@@ -53,7 +51,6 @@ dspQOHByZone::dspQOHByZone(QWidget* parent, const char*, Qt::WindowFlags fl)
   list()->addColumn(tr("Aisle"),              -1,          Qt::AlignLeft,   false, "location_aisle"  );
   list()->addColumn(tr("Rack"),               -1,          Qt::AlignLeft,   false, "location_rack"  );
   list()->addColumn(tr("Bin"),                -1,          Qt::AlignLeft,   false, "location_bin"  );
-
 }
 
 void dspQOHByZone::languageChange()

--- a/guiclient/displays/dspReturnAuthorizations.cpp
+++ b/guiclient/displays/dspReturnAuthorizations.cpp
@@ -17,6 +17,7 @@
 
 #include "parameterwidget.h"
 #include "returnAuthorization.h"
+#include "xtreewidget.h"
 
 dspReturnAuthorizations::dspReturnAuthorizations(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspReturnAuthorizations", fl)
@@ -57,7 +58,6 @@ enum SetResponse dspReturnAuthorizations::set(const ParameterList &pParams)
 {
   XWidget::set(pParams);
   QVariant param;
-  bool     valid;
 
   return NoError;
 }

--- a/guiclient/displays/dspSalesHistory.cpp
+++ b/guiclient/displays/dspSalesHistory.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -18,6 +18,7 @@
 
 #include "parameterwidget.h"
 #include "salesHistoryInformation.h"
+#include "xtreewidget.h"
 
 dspSalesHistory::dspSalesHistory(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspSalesHistory", fl)

--- a/guiclient/displays/dspSalesOrderStatus.cpp
+++ b/guiclient/displays/dspSalesOrderStatus.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -15,6 +15,7 @@
 #include "errorReporter.h"
 #include "inputManager.h"
 #include "salesOrderList.h"
+#include "xtreewidget.h"
 
 dspSalesOrderStatus::dspSalesOrderStatus(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspSalesOrderStatus", fl)
@@ -43,7 +44,6 @@ dspSalesOrderStatus::dspSalesOrderStatus(QWidget* parent, const char*, Qt::Windo
   list()->addColumn(tr("Close Date"),          _dateColumn, Qt::AlignLeft,   true,  "closedate"  );
   list()->addColumn(tr("Close User"),          _itemColumn, Qt::AlignLeft,   true,  "closeuser"  );
   list()->addColumn(tr("Child Ord. #/Status"), _itemColumn, Qt::AlignCenter, true,  "childinfo" );
-
 }
 
 void dspSalesOrderStatus::languageChange()

--- a/guiclient/displays/dspSingleLevelBOM.cpp
+++ b/guiclient/displays/dspSingleLevelBOM.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -11,6 +11,7 @@
 #include "dspSingleLevelBOM.h"
 
 #include <QVariant>
+#include "xtreewidget.h"
 
 dspSingleLevelBOM::dspSingleLevelBOM(QWidget* parent, const char*, Qt::WindowFlags fl)
   : dspBOMBase(parent, "dspSingleLevelBOM", fl)

--- a/guiclient/displays/dspSlowMovingInventoryByClassCode.cpp
+++ b/guiclient/displays/dspSlowMovingInventoryByClassCode.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -19,12 +19,12 @@
 #include <openreports.h>
 #include <parameter.h>
 
-#include "guiclient.h"
 #include "adjustmentTrans.h"
 #include "enterMiscCount.h"
 #include "transferTrans.h"
 #include "createCountTagsByItem.h"
 #include "mqlutil.h"
+#include "xtreewidget.h"
 
 dspSlowMovingInventoryByClassCode::dspSlowMovingInventoryByClassCode(QWidget* parent, const char*, Qt::WindowFlags fl)
     : display(parent, "dspSlowMovingInventoryByClassCode", fl)

--- a/guiclient/displays/dspSubstituteAvailabilityByItem.cpp
+++ b/guiclient/displays/dspSubstituteAvailabilityByItem.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -20,6 +20,7 @@
 
 #include "dspAllocations.h"
 #include "dspOrders.h"
+#include "xtreewidget.h"
 
 dspSubstituteAvailabilityByItem::dspSubstituteAvailabilityByItem(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspSubstituteAvailabilityByItem", fl)

--- a/guiclient/displays/dspSummarizedBOM.cpp
+++ b/guiclient/displays/dspSummarizedBOM.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -11,6 +11,7 @@
 #include "dspSummarizedBOM.h"
 
 #include <QVariant>
+#include "xtreewidget.h"
 
 dspSummarizedBOM::dspSummarizedBOM(QWidget* parent, const char*, Qt::WindowFlags fl)
   : dspBOMBase(parent, "dspSummarizedBOM", fl)

--- a/guiclient/displays/dspUninvoicedReceivings.cpp
+++ b/guiclient/displays/dspUninvoicedReceivings.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -18,6 +18,7 @@
 #include "poLiabilityDistrib.h"
 #include "postPoReturnCreditMemo.h"
 #include "errorReporter.h"
+#include "xtreewidget.h"
 
 dspUninvoicedReceivings::dspUninvoicedReceivings(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspUninvoicedReceivings", fl)

--- a/guiclient/displays/dspValidLocationsByItem.cpp
+++ b/guiclient/displays/dspValidLocationsByItem.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -13,6 +13,7 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QVariant>
+#include "xtreewidget.h"
 
 dspValidLocationsByItem::dspValidLocationsByItem(QWidget* parent, const char*, Qt::WindowFlags fl)
     : display(parent, "dspValidLocationsByItem", fl)
@@ -28,7 +29,6 @@ dspValidLocationsByItem::dspValidLocationsByItem(QWidget* parent, const char*, Q
   list()->addColumn(tr("Description"), -1,           Qt::AlignLeft,   true,  "locationdescrip"   );
   list()->addColumn(tr("Restricted"),  _orderColumn, Qt::AlignCenter, true,  "location_restrict"  );
   list()->addColumn(tr("Netable"),     _orderColumn, Qt::AlignCenter, true,  "location_netable" );
-
 }
 
 void dspValidLocationsByItem::languageChange()

--- a/guiclient/displays/dspWoMaterialsByItem.cpp
+++ b/guiclient/displays/dspWoMaterialsByItem.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -13,8 +13,8 @@
 #include <QVariant>
 #include <QMessageBox>
 
-#include "guiclient.h"
 #include "inputManager.h"
+#include "xtreewidget.h"
 
 dspWoMaterialsByItem::dspWoMaterialsByItem(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspWoMaterialsByItem", fl)

--- a/guiclient/displays/dspWoMaterialsByWorkOrder.cpp
+++ b/guiclient/displays/dspWoMaterialsByWorkOrder.cpp
@@ -17,6 +17,7 @@
 
 #include "inputManager.h"
 #include "woMaterialItem.h"
+#include "xtreewidget.h"
 
 dspWoMaterialsByWorkOrder::dspWoMaterialsByWorkOrder(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspWoMaterialsByWorkOrder", fl)

--- a/guiclient/group.cpp
+++ b/guiclient/group.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -10,6 +10,7 @@
 
 #include "group.h"
 
+#include <QMenu>
 #include <QMessageBox>
 #include <QSqlError>
 #include <QVariant>

--- a/guiclient/guiclient.cpp
+++ b/guiclient/guiclient.cpp
@@ -418,7 +418,9 @@ GUIClient::GUIClient(const QString &pDatabaseURL, const QString &pUsername)
 
   connect(_privileges, SIGNAL(loaded()), this, SLOT(initMenuBar()));
 
-  VirtualClusterLineEdit::_guiClientInterface = new xTupleGuiClientInterface(this);
+  ScriptableWidget::_guiClientInterface = new xTupleGuiClientInterface(this);
+  // the following can be removed when they all inherit from ScriptableWidget
+  VirtualClusterLineEdit::_guiClientInterface = ScriptableWidget::_guiClientInterface;
   Documents::_guiClientInterface = VirtualClusterLineEdit::_guiClientInterface;
   MenuButton::_guiClientInterface =  VirtualClusterLineEdit::_guiClientInterface;
   XTreeWidget::_guiClientInterface = VirtualClusterLineEdit::_guiClientInterface;

--- a/guiclient/issueToShipping.cpp
+++ b/guiclient/issueToShipping.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -11,6 +11,7 @@
 
 #include "issueToShipping.h"
 
+#include <QMenu>
 #include <QSqlError>
 #include <QVariant>
 

--- a/guiclient/printLabelsBySo.cpp
+++ b/guiclient/printLabelsBySo.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -10,8 +10,10 @@
 
 #include "printLabelsBySo.h"
 
-#include <QVariant>
 #include <QMessageBox>
+#include <QPushButton>
+#include <QVariant>
+
 #include <openreports.h>
 #include <parameter.h>
 #include "guiclient.h"

--- a/guiclient/scriptablePrivate.cpp
+++ b/guiclient/scriptablePrivate.cpp
@@ -10,7 +10,6 @@
 
 #include "scriptablePrivate.h"
 
-#include <QDebug>
 #include <QWidget>
 #include <QScriptEngine>
 #include <QScriptEngineDebugger>
@@ -20,14 +19,24 @@
 #include "qeventproto.h"
 #include "parameterlistsetup.h"
 
-ScriptablePrivate::ScriptablePrivate(QWidget* parent)
-  : ScriptableWidget(parent)
+ScriptablePrivate::ScriptablePrivate(QWidget *parent, QWidget *self)
+  : ScriptableWidget(self),
+    _showMe(0),
+    _rememberPos(0),
+    _rememberSize(0),
+    _shown(false)
 {
   ScriptToolbox::setLastWindow(parent);
 }
 
 ScriptablePrivate::~ScriptablePrivate()
 {
+  if(_showMe)
+    delete _showMe;
+  if(_rememberPos)
+    delete _rememberPos;
+  if(_rememberSize)
+    delete _rememberSize;
 }
 
 QScriptEngine *ScriptablePrivate::engine()
@@ -39,10 +48,11 @@ QScriptEngine *ScriptablePrivate::engine()
   // mywindow is required for backwards compatibility.
   // scriptablewidget creates mywidget.
   engine->globalObject().setProperty("mywindow", mywidget);
+
   // mydialog is required for backwards compatibility.
-  // we had initially had problems scripting on [qx]dialogs when we first
-  // started scripting. i don't know if these remain. gjm
-  if (_object->inherits("QDialog"))
+  // we had problems when we first started scripting [qx]dialogs.
+  // i don't know if these remain. gjm
+  if (dynamic_cast<QDialog*>(this))
   {
     engine->globalObject().setProperty("mydialog", mywidget);
   }

--- a/guiclient/scriptablePrivate.h
+++ b/guiclient/scriptablePrivate.h
@@ -24,13 +24,26 @@ class QWidget;
 class ScriptablePrivate : public ScriptableWidget
 {
   public:
-    ScriptablePrivate(QWidget* parent);
+    ScriptablePrivate(QWidget* parent, QWidget *self = 0);
     virtual ~ScriptablePrivate();
 
     virtual QScriptEngine   *engine();
     virtual enum SetResponse callSet(const ParameterList &);
     virtual void             callShowEvent(QEvent*);
     virtual void             callCloseEvent(QEvent*);
+    virtual ParameterList    get() const = 0;
+
+    QAction      *_showMe;
+    ParameterList _lastSetParams;
+    QAction      *_rememberPos;
+    QAction      *_rememberSize;
+    bool          _shown;
+
+  //public slots:
+    virtual enum SetResponse set(const ParameterList &) = 0;
+
+  protected: //protected slots:
+    virtual enum SetResponse postSet() = 0;
 
 };
 

--- a/guiclient/taxAuthorities.cpp
+++ b/guiclient/taxAuthorities.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -10,6 +10,7 @@
 
 #include "taxAuthorities.h"
 
+#include <QMenu>
 #include <QMessageBox>
 #include <QSqlError>
 
@@ -18,6 +19,7 @@
 #include "errorReporter.h"
 #include "parameterwidget.h"
 #include "taxAuthority.h"
+#include "xtreewidget.h"
 
 taxAuthorities::taxAuthorities(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "taxAuthorities", fl)

--- a/guiclient/xdialog.cpp
+++ b/guiclient/xdialog.cpp
@@ -98,9 +98,9 @@ void XDialog::closeEvent(QCloseEvent * event)
     QDialog::closeEvent(event);
   }
   
-  #ifdef Q_OS_MAC
-    omfgThis->removeFromMacDockMenu(this);
-  #endif
+#ifdef Q_OS_MAC
+  omfgThis->removeFromMacDockMenu(this);
+#endif
 }
 
 void XDialog::showEvent(QShowEvent *event)
@@ -178,6 +178,11 @@ enum SetResponse XDialog::set(const ParameterList & pParams)
   return NoError;
 }
 
+void XDialog::sDbConnectionLost()
+{
+  _private->sDbConnectionLost();
+}
+
 enum SetResponse XDialog::postSet()
 {
   return _private->callSet(_lastSetParams);
@@ -190,10 +195,10 @@ ParameterList XDialog::get() const
 
 int XDialog::exec()
 {
-	#ifdef Q_OS_MAC
-		omfgThis->updateMacDockMenu(this);
-	#endif
+#ifdef Q_OS_MAC
+  omfgThis->updateMacDockMenu(this);
+#endif
 
-	return QDialog::exec();
+  return QDialog::exec();
 }
 

--- a/guiclient/xdialog.h
+++ b/guiclient/xdialog.h
@@ -32,6 +32,7 @@ class XDialog : public QDialog
     virtual enum SetResponse set(const ParameterList &);
     virtual void setRememberPos(bool);
     virtual void setRememberSize(bool);
+    virtual void sDbConnectionLost();
     int exec();
 
   protected:

--- a/guiclient/xdialog.h
+++ b/guiclient/xdialog.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -14,10 +14,11 @@
 
 #include <parameter.h>
 #include <guiclient.h>
+#include "scriptablePrivate.h"
 
 class XDialogPrivate;
 
-class XDialog : public QDialog
+class XDialog : public QDialog, protected ScriptablePrivate
 {
   Q_OBJECT
 
@@ -25,14 +26,12 @@ class XDialog : public QDialog
     XDialog(QWidget * parent = 0, Qt::WindowFlags flags = 0);
     XDialog(QWidget * parent, const char * name, bool modal = false, Qt::WindowFlags flags = 0);
     virtual ~XDialog();
-
     Q_INVOKABLE virtual ParameterList get() const;
 
   public slots:
     virtual enum SetResponse set(const ParameterList &);
     virtual void setRememberPos(bool);
     virtual void setRememberSize(bool);
-    virtual void sDbConnectionLost();
     int exec();
 
   protected:
@@ -46,9 +45,6 @@ class XDialog : public QDialog
   private:
     friend class XDialogPrivate;
     XDialogPrivate *_private;
-
-    ParameterList _lastSetParams;
-    void loadScriptEngine();
 };
 
 #endif // __XDIALOG_H__

--- a/guiclient/xmainwindow.cpp
+++ b/guiclient/xmainwindow.cpp
@@ -102,6 +102,11 @@ enum SetResponse XMainWindow::set(const ParameterList &pParams)
   return NoError;
 }
 
+void XMainWindow::sDbConnectionLost()
+{
+  _private->sDbConnectionLost();
+}
+
 enum SetResponse XMainWindow::postSet()
 {
   return _private->callSet(_lastSetParams);

--- a/guiclient/xmainwindow.h
+++ b/guiclient/xmainwindow.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -14,12 +14,12 @@
 
 #include <parameter.h>
 
-#include "guiclient.h"
+#include "scriptablePrivate.h"
 
 class QScriptEngine;
 class XMainWindowPrivate;
 
-class XMainWindow : public QMainWindow
+class XMainWindow : public QMainWindow, protected ScriptablePrivate
 {
   Q_OBJECT
 
@@ -38,7 +38,6 @@ class XMainWindow : public QMainWindow
 
   public slots:
     virtual enum SetResponse set(const ParameterList &);
-    virtual void             sDbConnectionLost();
 
   protected:
     virtual void closeEvent(QCloseEvent *);
@@ -54,9 +53,6 @@ class XMainWindow : public QMainWindow
     friend class ScriptToolbox;
     XMainWindowPrivate *_private;
     friend QScriptEngine *engine(XMainWindow*);
-
-    ParameterList _lastSetParams;
-    void loadScriptEngine();
 
     bool _forceFloat;
 

--- a/guiclient/xmainwindow.h
+++ b/guiclient/xmainwindow.h
@@ -38,6 +38,7 @@ class XMainWindow : public QMainWindow
 
   public slots:
     virtual enum SetResponse set(const ParameterList &);
+    virtual void             sDbConnectionLost();
 
   protected:
     virtual void closeEvent(QCloseEvent *);

--- a/guiclient/xwidget.cpp
+++ b/guiclient/xwidget.cpp
@@ -185,6 +185,11 @@ enum SetResponse XWidget::set( const ParameterList & pParams )
   return NoError;
 }
 
+void XWidget::sDbConnectionLost()
+{
+  _private->sDbConnectionLost();
+}
+
 enum SetResponse XWidget::postSet()
 {
   return _private->callSet(_lastSetParams);

--- a/guiclient/xwidget.cpp
+++ b/guiclient/xwidget.cpp
@@ -23,26 +23,23 @@
 #include "xcheckbox.h"
 #include "xtsettings.h"
 #include "guiclient.h"
-#include "scriptablePrivate.h"
 #include "shortcuts.h"
 
 #define DEBUG false
 
-class XWidgetPrivate : public ScriptablePrivate
+// Obsolete now?
+class XWidgetPrivate
 {
   friend class XWidget;
 
   public:
     XWidgetPrivate(XWidget *parent);
     virtual ~XWidgetPrivate();
-
-    bool _shown;
 };
 
 XWidgetPrivate::XWidgetPrivate(XWidget *parent)
-  : ScriptablePrivate(parent)
 {
-  _shown = false;
+  Q_UNUSED(parent);
 }
 
 XWidgetPrivate::~XWidgetPrivate()
@@ -52,7 +49,9 @@ XWidgetPrivate::~XWidgetPrivate()
 XWidget::XWidget(QWidget *parent, Qt::WindowFlags flags)
   : QWidget(parent,
             ((flags & (Qt::Dialog | Qt::Window)) && parent && parent->isModal()) ? (flags | Qt::Dialog)
-                  : flags )
+                  : flags ),
+    ScriptablePrivate(parent, this),
+    _private(0)
 {
   if(parent && parent->isModal() && (flags & (Qt::Dialog | Qt::Window)))
   {
@@ -60,39 +59,36 @@ XWidget::XWidget(QWidget *parent, Qt::WindowFlags flags)
   }
   if(!parent || !parent->isModal())
     setParent(omfgThis);
-
-  _private = new XWidgetPrivate(this);
 }
 
 XWidget::XWidget(QWidget * parent, const char * name, Qt::WindowFlags flags)
   : QWidget(parent,
             ((flags & (Qt::Dialog | Qt::Window)) && parent && parent->isModal()) ? (flags | Qt::Dialog)
-                  : flags )
+                  : flags ),
+    ScriptablePrivate(parent, this),
+    _private(0)
 {
   if(parent && parent->isModal() && (flags & (Qt::Dialog | Qt::Window)))
   {
     setWindowModality(Qt::ApplicationModal);
-    //setWindowFlags(windowFlags() | Qt::Dialog);
   }
 
   if(name)
     setObjectName(name);
   if(!parent || !parent->isModal())
     setParent(omfgThis);
-
-  _private = new XWidgetPrivate(this);
 }
 
 XWidget::~XWidget()
 {
-  if(_private)
+  if (_private)
     delete _private;
 }
 
 void XWidget::closeEvent(QCloseEvent *event)
 {
   event->accept(); // we have no reason not to accept and let the script change it if needed
-  _private->callCloseEvent(event);
+  callCloseEvent(event);
 
   if(event->isAccepted())
   {
@@ -109,9 +105,9 @@ void XWidget::closeEvent(QCloseEvent *event)
 
 void XWidget::showEvent(QShowEvent *event)
 {
-  if(!_private->_shown)
+  if (! _shown)
   {
-    _private->_shown = true;
+    _shown = true;
     if (windowFlags() & (Qt::Window | Qt::Dialog))
     {
       QRect availableGeometry = QApplication::desktop()->availableGeometry();
@@ -161,7 +157,7 @@ void XWidget::showEvent(QShowEvent *event)
       }
     }
 
-    _private->loadScriptEngine();
+    loadScriptEngine();
 
     QList<XCheckBox*> allxcb = findChildren<XCheckBox*>();
     for (int i = 0; i < allxcb.size(); ++i)
@@ -170,39 +166,24 @@ void XWidget::showEvent(QShowEvent *event)
     shortcuts::setStandardKeys(this);
   }
 
-  _private->callShowEvent(event);
+  callShowEvent(event);
   QWidget::showEvent(event);
 }
 
-enum SetResponse XWidget::set( const ParameterList & pParams )
+enum SetResponse XWidget::set(const ParameterList & pParams)
 {
   _lastSetParams = pParams;
-
-  _private->loadScriptEngine();
-
+  loadScriptEngine();
   QTimer::singleShot(0, this, SLOT(postSet()));
-
   return NoError;
-}
-
-void XWidget::sDbConnectionLost()
-{
-  _private->sDbConnectionLost();
 }
 
 enum SetResponse XWidget::postSet()
 {
-  return _private->callSet(_lastSetParams);
+  return callSet(_lastSetParams);
 }
 
 ParameterList XWidget::get() const
 {
   return _lastSetParams;
 }
-
-QScriptEngine *XWidget::engine()
-{
-  _private->loadScriptEngine();
-  return _private->_engine;
-}
- 

--- a/guiclient/xwidget.h
+++ b/guiclient/xwidget.h
@@ -31,6 +31,7 @@ class XWidget : public QWidget
 
   public slots:
     virtual enum SetResponse set(const ParameterList &);
+    virtual void sDbConnectionLost();
 
   protected:
     void closeEvent(QCloseEvent * event);
@@ -45,7 +46,6 @@ class XWidget : public QWidget
     XWidgetPrivate *_private;
 
     ParameterList _lastSetParams;
-    void loadScriptEngine();
 };
 
 #endif // __XWIDGET_H__

--- a/guiclient/xwidget.h
+++ b/guiclient/xwidget.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -14,11 +14,12 @@
 
 #include <parameter.h>
 #include <guiclient.h>
+#include "scriptablePrivate.h"
 
 class QScriptEngine;
 class XWidgetPrivate;
 
-class XWidget : public QWidget
+class XWidget : public QWidget, protected ScriptablePrivate
 {
   Q_OBJECT
 
@@ -26,17 +27,14 @@ class XWidget : public QWidget
     XWidget(QWidget * parent = 0, Qt::WindowFlags flags = 0);
     XWidget(QWidget * parent, const char * name, Qt::WindowFlags flags = 0);
     ~XWidget();
-
     Q_INVOKABLE virtual ParameterList get() const;
 
   public slots:
     virtual enum SetResponse set(const ParameterList &);
-    virtual void sDbConnectionLost();
 
   protected:
     void closeEvent(QCloseEvent * event);
     void showEvent(QShowEvent * event);
-    QScriptEngine *engine();
 
   protected slots:
     virtual enum SetResponse postSet();
@@ -44,8 +42,6 @@ class XWidget : public QWidget
   private:
     friend class XWidgetPrivate;
     XWidgetPrivate *_private;
-
-    ParameterList _lastSetParams;
 };
 
 #endif // __XWIDGET_H__

--- a/widgets/addressCluster.cpp
+++ b/widgets/addressCluster.cpp
@@ -13,6 +13,7 @@
 #include <QGridLayout>
 #include <QMessageBox>
 #include <QSqlError>
+#include <QPushButton>
 #include <QtScript>
 
 #include <metasql.h>
@@ -20,142 +21,159 @@
 
 #include "errorReporter.h"
 #include "xcheckbox.h"
+#include "xtreewidget.h"
 
 #define DEBUG false
 
 void AddressCluster::init()
 {
-    _list = new QPushButton(tr("..."), this);
-    _list->setObjectName("_list");
-    _list->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+  _list = new QPushButton(tr("..."), this);
+  _list->setObjectName("_list");
+  _list->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
 #ifndef Q_OS_MAC
-    _list->setMaximumWidth(25);
+  _list->setMaximumWidth(25);
 #else
-    _list->setMinimumWidth(60);
-    _list->setMinimumHeight(32);
+  _list->setMinimumWidth(60);
+  _list->setMinimumHeight(32);
 #endif
 
-    _titleSingular = tr("Address");
-    _titlePlural   = tr("Addresses");
-    _query = "SELECT * FROM address ";
-    _searchAcctId = -1;
+  _titleSingular = tr("Address");
+  _titlePlural   = tr("Addresses");
+  _query = "SELECT * FROM address ";
+  _searchAcctId = -1;
 
-    // handle differences between VirtualCluster and AddressCluster
-    _grid->removeWidget(_label);
-    _grid->removeWidget(_description);
-    delete _description;
-    _description = 0;
+  // handle differences between VirtualCluster and AddressCluster
+  _grid->removeWidget(_label);
+  _grid->removeWidget(_description);
+  delete _description;
+  _description = 0;
 
-    _addrChange    = new XLineEdit(this);
-    _number        = new XLineEdit(this);
-    _addrLit       = new QLabel(tr("Street\nAddress:"), this);
-    _addr1         = new XLineEdit(this);
-    _addr2         = new XLineEdit(this);
-    _addr3         = new XLineEdit(this);
-    _cityLit       = new QLabel(tr("City:"), this);
-    _city          = new XLineEdit(this);
-    _stateLit      = new QLabel(tr("State:"));
-    _state         = new XComboBox(this, "_state");
-    _postalcodeLit = new QLabel(tr("Postal:"));
-    _postalcode    = new XLineEdit(this);
-    _countryLit    = new QLabel(tr("Country:"));
-    _country       = new XComboBox(this, "_country");
-    _active        = new QCheckBox(tr("Active"), this);
-    _mapper        = new XDataWidgetMapper(this);
+  _addrChange    = new XLineEdit(this);
+  _number        = new XLineEdit(this);
+  _addrLit       = new QLabel(tr("Street\nAddress:"), this);
+  _addr1         = new XLineEdit(this);
+  _addr2         = new XLineEdit(this);
+  _addr3         = new XLineEdit(this);
+  _cityLit       = new QLabel(tr("City:"), this);
+  _city          = new XLineEdit(this);
+  _stateLit      = new QLabel(tr("State:"));
+  _state         = new XComboBox(this, "_state");
+  _postalcodeLit = new QLabel(tr("Postal:"));
+  _postalcode    = new XLineEdit(this);
+  _countryLit    = new QLabel(tr("Country:"));
+  _country       = new XComboBox(this, "_country");
+  _active        = new QCheckBox(tr("Active"), this);
+  _mapper        = new XDataWidgetMapper(this);
 
-    _addrChange->hide();
-#if defined Q_OS_MAC   
-    _city->setMinimumWidth(110);
+  _addrChange->setObjectName("_addrChange");
+  _number->setObjectName("_number");
+  _addrLit->setObjectName("_addrLit");
+  _addr1->setObjectName("_addr1");
+  _addr2->setObjectName("_addr2");
+  _addr3->setObjectName("_addr3");
+  _cityLit->setObjectName("_cityLit");
+  _city->setObjectName("_city");
+  _stateLit->setObjectName("_stateLit");
+  _postalcodeLit->setObjectName("_postalcodeLit");
+  _postalcode->setObjectName("_postalcode");
+  _countryLit->setObjectName("_countryLit");
+  _active->setObjectName("_active");
+  _mapper->setObjectName("_mapper");
+
+  _addrChange->hide();
+#if defined Q_OS_MAC
+  _city->setMinimumWidth(110);
 #else
-    _city->setMinimumWidth(85);
+  _city->setMinimumWidth(85);
 #endif
-    if (! DEBUG)
-      _number->hide();
-    _addrLit->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    _cityLit->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    _stateLit->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    _state->setEditable(true);
-    _state->setAllowNull(true);
-    _country->setMaximumWidth(250);
-    _country->setEditable(! (_x_metrics &&
-                             _x_metrics->boolean("StrictAddressCountry")));
-    if (DEBUG)
-      qDebug("%s::_country.isEditable() = %d",
-             (objectName().isEmpty() ? "AddressCluster":qPrintable(objectName())),
-             _country->isEditable());
+  if (! DEBUG)
+    _number->hide();
+  _addrLit->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+  _cityLit->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+  _stateLit->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+  _state->setEditable(true);
+  _state->setAllowNull(true);
+  _state->setMaximumWidth(250);
+  _country->setMaximumWidth(250);
+  _country->setEditable(! (_x_metrics &&
+                           _x_metrics->boolean("StrictAddressCountry")));
+  if (DEBUG)
+    qDebug("%s::_country.isEditable() = %d",
+           (objectName().isEmpty() ? "AddressCluster":qPrintable(objectName())),
+           _country->isEditable());
 
-    _postalcodeLit->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    _countryLit->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+  _postalcodeLit->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+  _countryLit->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
 
-    _grid->setMargin(0);
-    _grid->setSpacing(2);
-    _grid->addWidget(_label,         0, 0, 1, -1);
-    _grid->addWidget(_addrLit,       1, 0, 3, 1);
-    _grid->addWidget(_addr1,         1, 1, 1, -1);
-    _grid->addWidget(_addr2,         2, 1, 1, -1);
-    _grid->addWidget(_addr3,         3, 1, 1, -1);
-    _grid->addWidget(_cityLit,       5, 0);
-    _grid->addWidget(_city,          5, 1);
-    _grid->addWidget(_stateLit,      5, 2);
-    _grid->addWidget(_state,         5, 3);
-    _grid->addWidget(_postalcodeLit, 5, 4);
-    _grid->addWidget(_postalcode,    5, 5, 1, 2);
-    _grid->addWidget(_countryLit,    4, 0);
-    _grid->addWidget(_country,       4, 1, 1, 3);
-    _grid->addWidget(_active,        4, 4);
+  _grid->setMargin(0);
+  _grid->setSpacing(2);
+  _grid->addWidget(_label,         0, 0, 1, -1);
+  _grid->addWidget(_addrLit,       1, 0, 3, 1);
+  _grid->addWidget(_addr1,         1, 1, 1, -1);
+  _grid->addWidget(_addr2,         2, 1, 1, -1);
+  _grid->addWidget(_addr3,         3, 1, 1, -1);
+  _grid->addWidget(_cityLit,       5, 0);
+  _grid->addWidget(_city,          5, 1);
+  _grid->addWidget(_stateLit,      5, 2);
+  _grid->addWidget(_state,         5, 3);
+  _grid->addWidget(_postalcodeLit, 5, 4);
+  _grid->addWidget(_postalcode,    5, 5, 1, 2);
+  _grid->addWidget(_countryLit,    4, 0);
+  _grid->addWidget(_country,       4, 1, 1, 3);
+  _grid->addWidget(_active,        4, 4);
 
-    QHBoxLayout* hbox = new QHBoxLayout;
-    hbox->addWidget(_list);
-    _grid->addLayout(hbox, 4, 5, 1, -1, Qt::AlignRight);
+  QHBoxLayout* hbox = new QHBoxLayout;
+  hbox->addWidget(_list);
+  _grid->addLayout(hbox, 4, 5, 1, -1, Qt::AlignRight);
 
-    _grid->setColumnStretch(0, 0);
-    _grid->setColumnStretch(1, 3);
-    _grid->setColumnStretch(2, 0);
-    _grid->setColumnStretch(3, 1);
-    _grid->setColumnStretch(4, 0);
-    _grid->setColumnStretch(5, 2);
+  _grid->setColumnStretch(0, 0);
+  _grid->setColumnStretch(1, 3);
+  _grid->setColumnStretch(2, 0);
+  _grid->setColumnStretch(3, 1);
+  _grid->setColumnStretch(4, 0);
+  _grid->setColumnStretch(5, 2);
 
 #if defined Q_OS_MAC
-    setMinimumSize(_grid->columnCount() * 60, 132);
+  setMinimumSize(_grid->columnCount() * 60, 132);
 #endif
 
-    connect(_list,      SIGNAL(clicked()), this, SLOT(sEllipses()));
-    connect(_addr1,     SIGNAL(textChanged(const QString&)), this, SIGNAL(changed()));
-    connect(_addr2,     SIGNAL(textChanged(const QString&)), this, SIGNAL(changed()));
-    connect(_addr3,     SIGNAL(textChanged(const QString&)), this, SIGNAL(changed()));
-    connect(_city,      SIGNAL(textChanged(const QString&)), this, SIGNAL(changed()));
-    connect(_state, SIGNAL(editTextChanged(const QString&)), this, SIGNAL(changed()));
-    connect(_state,                      SIGNAL(newID(int)), this, SIGNAL(changed()));
-    connect(_postalcode,SIGNAL(textChanged(const QString&)), this, SIGNAL(changed()));
-    connect(_country,SIGNAL(editTextChanged(const QString&)),this, SLOT(setCountry(const QString&)));
-    connect(_country,                    SIGNAL(newID(int)), this, SIGNAL(changed()));
-    connect(_country,                    SIGNAL(newID(int)), this, SLOT(populateStateComboBox()));
+  connect(_list,      SIGNAL(clicked()), this, SLOT(sEllipses()));
+  connect(_addr1,     SIGNAL(textChanged(const QString&)), this, SIGNAL(changed()));
+  connect(_addr2,     SIGNAL(textChanged(const QString&)), this, SIGNAL(changed()));
+  connect(_addr3,     SIGNAL(textChanged(const QString&)), this, SIGNAL(changed()));
+  connect(_city,      SIGNAL(textChanged(const QString&)), this, SIGNAL(changed()));
+  connect(_state, SIGNAL(editTextChanged(const QString&)), this, SIGNAL(changed()));
+  connect(_state,                      SIGNAL(newID(int)), this, SIGNAL(changed()));
+  connect(_postalcode,SIGNAL(textChanged(const QString&)), this, SIGNAL(changed()));
+  connect(_country,SIGNAL(editTextChanged(const QString&)),this, SLOT(setCountry(const QString&)));
+  connect(_country,                    SIGNAL(newID(int)), this, SIGNAL(changed()));
+  connect(_country,                    SIGNAL(newID(int)), this, SLOT(populateStateComboBox()));
 
-    connect(_addr1, SIGNAL(requestList()), this, SLOT(sList()));
-    connect(_addr2, SIGNAL(requestList()), this, SLOT(sList()));
-    connect(_addr3, SIGNAL(requestList()), this, SLOT(sList()));
-    connect(_city, SIGNAL(requestList()), this, SLOT(sList()));
-    connect(_postalcode, SIGNAL(requestList()), this, SLOT(sList()));
-    connect(_addr1, SIGNAL(requestSearch()), this, SLOT(sSearch()));
-    connect(_addr2, SIGNAL(requestSearch()), this, SLOT(sSearch()));
-    connect(_addr3, SIGNAL(requestSearch()), this, SLOT(sSearch()));
-    connect(_city,  SIGNAL(requestSearch()), this, SLOT(sSearch()));
-    connect(_postalcode,  SIGNAL(requestSearch()), this, SLOT(sSearch()));
+  connect(_addr1, SIGNAL(requestList()), this, SLOT(sList()));
+  connect(_addr2, SIGNAL(requestList()), this, SLOT(sList()));
+  connect(_addr3, SIGNAL(requestList()), this, SLOT(sList()));
+  connect(_city, SIGNAL(requestList()), this, SLOT(sList()));
+  connect(_postalcode, SIGNAL(requestList()), this, SLOT(sList()));
+  connect(_addr1, SIGNAL(requestSearch()), this, SLOT(sSearch()));
+  connect(_addr2, SIGNAL(requestSearch()), this, SLOT(sSearch()));
+  connect(_addr3, SIGNAL(requestSearch()), this, SLOT(sSearch()));
+  connect(_city,  SIGNAL(requestSearch()), this, SLOT(sSearch()));
+  connect(_postalcode,  SIGNAL(requestSearch()), this, SLOT(sSearch()));
 
-    connect(_addr1,     SIGNAL(textChanged(QString)), this, SLOT(emitAddressChanged()));
-    connect(_addr2,     SIGNAL(textChanged(QString)), this, SLOT(emitAddressChanged()));
-    connect(_addr3,     SIGNAL(textChanged(QString)), this, SLOT(emitAddressChanged()));
-    connect(_city,      SIGNAL(textChanged(QString)), this, SLOT(emitAddressChanged()));
-    connect(_postalcode,SIGNAL(textChanged(QString)), this, SLOT(emitAddressChanged()));
+  connect(_addr1,     SIGNAL(textChanged(QString)), this, SLOT(emitAddressChanged()));
+  connect(_addr2,     SIGNAL(textChanged(QString)), this, SLOT(emitAddressChanged()));
+  connect(_addr3,     SIGNAL(textChanged(QString)), this, SLOT(emitAddressChanged()));
+  connect(_city,      SIGNAL(textChanged(QString)), this, SLOT(emitAddressChanged()));
+  connect(_postalcode,SIGNAL(textChanged(QString)), this, SLOT(emitAddressChanged()));
 
-    setFocusProxy(_addr1);
-    setFocusPolicy(Qt::StrongFocus);
-    setLabel("");
-    setActiveVisible(false);
-    silentSetId(-1);
-    _list->show();
-    _mode = Edit;
+  setFocusProxy(_addr1);
+  setFocusPolicy(Qt::StrongFocus);
+  setLabel("");
+  setActiveVisible(false);
+  silentSetId(-1);
+  _list->show();
+  _mode = Edit;
 }
 
 AddressCluster::AddressCluster(QWidget* pParent, const char* pName)
@@ -246,7 +264,7 @@ void AddressCluster::populateCountryComboBox()
 
   _country->clear();
   XSqlQuery country;
-  country.prepare("SELECT -1, '','' AS country_name " 
+  country.prepare("SELECT -1, '','' AS country_name "
                   "UNION "
                   "SELECT country_id, country_name, country_name "
                   "FROM country ORDER BY country_name;");
@@ -273,7 +291,7 @@ void AddressCluster::setId(const int pId, const QString&)
   if (pId == _id)
     return;
   silentSetId(pId);
-  emit newId(pId);  
+  emit newId(pId);
 }
 
 void AddressCluster::silentSetId(const int pId)
@@ -319,7 +337,7 @@ void AddressCluster::silentSetId(const int pId)
            _mapper->model()->setData(_mapper->model()->index(_mapper->currentIndex(),_mapper->mappedSection(_city)), _city->text());
            _mapper->model()->setData(_mapper->model()->index(_mapper->currentIndex(),_mapper->mappedSection(_state)), _state->currentText());
            _mapper->model()->setData(_mapper->model()->index(_mapper->currentIndex(),_mapper->mappedSection(_postalcode)), _postalcode->text());
-           _mapper->model()->setData(_mapper->model()->index(_mapper->currentIndex(),_mapper->mappedSection(_country)), _country->currentText());    
+           _mapper->model()->setData(_mapper->model()->index(_mapper->currentIndex(),_mapper->mappedSection(_country)), _country->currentText());
         }
 
         c_number     = _number->text();
@@ -431,7 +449,7 @@ void AddressCluster::clear()
   _active->setChecked(c_active);
   _selected = false;
 }
-   
+
 void AddressCluster::setDataWidgetMap(XDataWidgetMapper* m)
 {
   m->addMapping(_addrChange , _fieldNameAddrChange,   "text", "defaultText");
@@ -448,13 +466,13 @@ void AddressCluster::setDataWidgetMap(XDataWidgetMapper* m)
   _country->setDataWidgetMap(m);
   _mapper=m;
 }
-   
+
 /*
    return +N addr_id if save is successful or if found another addr with the same info
    return  0 if there is no address to save
    return -1 if there was an error
    return -2 if there are N contacts sharing this address
-  
+
  */
 int AddressCluster::save(enum SaveFlags flag)
 {
@@ -479,10 +497,10 @@ int AddressCluster::save(enum SaveFlags flag)
                              "before saving."));
     return -3;
   }
-  
+
   XSqlQuery datamodQ;
-  datamodQ.prepare("SELECT saveAddr(:addr_id,:addr_number,:addr1,:addr2,:addr3," 
-		   ":city,:state,:postalcode,:country,:active,:notes,:flag) AS result;");
+  datamodQ.prepare("SELECT saveAddr(:addr_id,:addr_number,:addr1,:addr2,:addr3,"
+                   ":city,:state,:postalcode,:country,:active,:notes,:flag) AS result;");
   datamodQ.bindValue(":addr_id", id());
   if (!_number->text().isEmpty())
     datamodQ.bindValue(":addr_number", _number->text());
@@ -503,7 +521,7 @@ int AddressCluster::save(enum SaveFlags flag)
     datamodQ.bindValue(":flag", QString("CHANGEONE"));
   else
     return -1;
-    
+
   datamodQ.exec();
   if (datamodQ.first())
   {
@@ -539,7 +557,7 @@ void AddressCluster::check()
     tx.exec("ROLLBACK;");
     if (result == -2)
     {
-      int answer = 2;	// Cancel
+      int answer = 2; // Cancel
       answer = QMessageBox::question(this, tr("Question Saving Address"),
                   tr("<p>There are multiple Contacts sharing this Address.</p>"
                      "<p>What would you like to do?</p>"),
@@ -552,7 +570,7 @@ void AddressCluster::check()
          _addrChange->setText("CHANGEALL");
        // Make sure the mapper is aware of this change
        if (_mapper->model()->data(_mapper->model()->index(_mapper->currentIndex(),_mapper->mappedSection(_addrChange))).toString() != _addrChange->text())
-         _mapper->model()->setData(_mapper->model()->index(_mapper->currentIndex(),_mapper->mappedSection(_addrChange)), _addrChange->text());     
+         _mapper->model()->setData(_mapper->model()->index(_mapper->currentIndex(),_mapper->mappedSection(_addrChange)), _addrChange->text());
     }
     else if (result < 0)
     {
@@ -661,7 +679,7 @@ void AddressCluster::setAddrChange(QString p)
   if (_mapper->model() &&
       _mapper->model()->data(_mapper->model()->index(_mapper->currentIndex(),_mapper->mappedSection(_addrChange))).toString() != _addrChange->text())
     _mapper->model()->setData(_mapper->model()->index(_mapper->currentIndex(),_mapper->mappedSection(_addrChange)), _addrChange->text());
-  
+
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/widgets/addresscluster.h
+++ b/widgets/addresscluster.h
@@ -12,7 +12,6 @@
 #define addressCluster_h
 
 #include "widgets.h"
-#include "scriptablewidget.h"
 #include "virtualCluster.h"
 #include "xcheckbox.h"
 #include "xcombobox.h"

--- a/widgets/crmCluster.cpp
+++ b/widgets/crmCluster.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -9,8 +9,14 @@
  */
 
 #include "crmcluster.h"
+
+#include <QCompleter>
+#include <QMenu>
 #include <QMessageBox>
 #include <QSqlError>
+#include <QSqlQueryModel>
+
+#include "xsqlquery.h"
 
 #define DEBUG false
 

--- a/widgets/crmacctCluster.cpp
+++ b/widgets/crmacctCluster.cpp
@@ -8,6 +8,9 @@
  * to be bound by its terms.
  */
 
+#include <QDialogButtonBox>
+#include <QGridLayout>
+#include <QLabel>
 #include <QtScript>
 
 #include <metasql.h>
@@ -16,6 +19,7 @@
 #include "custcluster.h"
 #include "errorReporter.h"
 #include "xcombobox.h"
+#include "xtreewidget.h"
 
 /* _listAndSearchQueryString is, as you may have guessed, shared by the
    CRMAcctList and CRMAcctSearch classes. It's a big 'un and has a couple

--- a/widgets/custCluster.cpp
+++ b/widgets/custCluster.cpp
@@ -10,9 +10,11 @@
 
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QMenu>
 #include <QMessageBox>
 #include <QPushButton>
 #include <QSqlError>
+#include <QSqlQueryModel>
 #include <QVBoxLayout>
 #include <QtScript>
 

--- a/widgets/deptCluster.cpp
+++ b/widgets/deptCluster.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -9,6 +9,8 @@
  */
 
 #include "deptcluster.h"
+
+#include <QLabel>
 
 DeptCluster::DeptCluster(QWidget* pParent, const char* pName) :
     VirtualCluster(pParent, pName)

--- a/widgets/empcluster.cpp
+++ b/widgets/empcluster.cpp
@@ -10,6 +10,12 @@
 
 #include "empcluster.h"
 
+#include <QLabel>
+#include <QtScript>
+
+#include "xcheckbox.h"
+#include "xtreewidget.h"
+
 EmpCluster::EmpCluster(QWidget* pParent, const char* pName) :
     VirtualCluster(pParent, pName)
 {

--- a/widgets/empgroupcluster.cpp
+++ b/widgets/empgroupcluster.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -9,6 +9,11 @@
  */
 
 #include "empgroupcluster.h"
+
+#include <QLabel>
+
+#include "xcheckbox.h"
+#include "xtreewidget.h"
 
 EmpGroupCluster::EmpGroupCluster(QWidget* pParent, const char* pName) :
     VirtualCluster(pParent, pName)

--- a/widgets/glCluster.cpp
+++ b/widgets/glCluster.cpp
@@ -8,13 +8,18 @@
  * to be bound by its terms.
  */
 
+#include "glcluster.h"
+
 #include <QHBoxLayout>
+#include <QLabel>
 #include <QMessageBox>
+#include <QSqlQueryModel>
 #include <QtScript>
 
 #include <metasql.h>
 
-#include "glcluster.h"
+#include "xcheckbox.h"
+#include "xtreewidget.h"
 
 static QString _listAndSearchQueryString(
   "SELECT accnt_id, accnt_number, accnt_descrip, accnt_comments, accnt_profit,"

--- a/widgets/glcluster.h
+++ b/widgets/glcluster.h
@@ -16,6 +16,9 @@
 #include "projectcluster.h"
 #include <QComboBox>
 
+class QHBoxLayout;
+class XCheckBox;
+
 class XTUPLEWIDGETS_EXPORT accountList : public VirtualList
 {
     Q_OBJECT

--- a/widgets/imagecluster.cpp
+++ b/widgets/imagecluster.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -10,10 +10,16 @@
 
 #include "imagecluster.h"
 
+#include <QGridLayout>
+#include <QLabel>
 #include <QPixmap>
 #include <QScrollArea>
 
 #include <quuencode.h>
+#include <xsqlquery.h>
+
+#include "xcheckbox.h"
+#include "xtreewidget.h"
 
 #define DEBUG   false
 

--- a/widgets/itemCluster.cpp
+++ b/widgets/itemCluster.cpp
@@ -9,15 +9,24 @@
  */
 
 #include <QApplication>
+#include <QCompleter>
+#include <QGridLayout>
+#include <QLabel>
+#include <QMenu>
 #include <QMessageBox>
 #include <QSqlRecord>
 #include <QStandardItemEditorCreator>
+#include <QTreeView>
+#include <QVBoxLayout>
 #include <QtScript>
 
 #include <xsqlquery.h>
 
+#include "guiclientinterface.h"
 #include "itemcluster.h"
 #include "itemAliasList.h"
+#include "xcheckbox.h"
+#include "xtreewidget.h"
 #include "xsqltablemodel.h"
 
 #define DEBUG false

--- a/widgets/itemcluster.h
+++ b/widgets/itemcluster.h
@@ -20,13 +20,9 @@
 
 #include "virtualCluster.h"
 
-class ParameterList;
-
-class QPushButton;
+class QCheckBox;
 class QLabel;
-class QDragEnterEvent;
-class QDropEvent;
-class QMouseEvent;
+
 class ItemLineEditDelegate;
 class itemList;
 class itemSearch;

--- a/widgets/itemgroupcluster.cpp
+++ b/widgets/itemgroupcluster.cpp
@@ -10,6 +10,12 @@
 
 #include "itemgroupcluster.h"
 
+#include <QLabel>
+#include <QtScript>
+
+#include "xcheckbox.h"
+#include "xtreewidget.h"
+
 ItemGroupCluster::ItemGroupCluster(QWidget* pParent, const char* pName) :
     VirtualCluster(pParent, pName)
 {

--- a/widgets/lotserialCluster.cpp
+++ b/widgets/lotserialCluster.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -14,6 +14,7 @@
 #include <QSqlError>
 
 #include "xsqlquery.h"
+#include "xtreewidget.h"
 
 LotserialList::LotserialList(QWidget* pParent, Qt::WindowFlags flags)
   : VirtualList(pParent, flags)

--- a/widgets/ordercluster.cpp
+++ b/widgets/ordercluster.cpp
@@ -8,13 +8,17 @@
  * to be bound by its terms.
  */
 
+#include <QGridLayout>
+#include <QLabel>
 #include <QMessageBox>
 #include <QSqlError>
 #include <QtScript>
 
-#include "ordercluster.h"
 #include "errorReporter.h"
+#include "ordercluster.h"
 #include "xsqlquery.h"
+#include "xcheckbox.h"
+#include "xtreewidget.h"
 
 #define DEBUG false
 

--- a/widgets/ordercluster.h
+++ b/widgets/ordercluster.h
@@ -16,7 +16,10 @@
 #include "parameter.h"
 #include "virtualCluster.h"
 
+class QLabel;
+class QGridLayout;
 class QScriptEngine;
+class XTreeWidgetItem;
 
 class XTUPLEWIDGETS_EXPORT OrderLineEdit : public VirtualClusterLineEdit
 {

--- a/widgets/plCluster.cpp
+++ b/widgets/plCluster.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -9,9 +9,8 @@
  */
 
 #include <QLabel>
-//#include <QLineEdit>
-//#include <QPushButton>
 #include <QHBoxLayout>
+#include <QSqlQueryModel>
 #include <QVBoxLayout>
 
 #include <xsqlquery.h>

--- a/widgets/projectCluster.cpp
+++ b/widgets/projectCluster.cpp
@@ -10,6 +10,7 @@
 
 #include "projectcluster.h"
 
+#include <QLabel>
 #include <QtScript>
 
 #include "projectCopy.h"

--- a/widgets/quotecluster.cpp
+++ b/widgets/quotecluster.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -14,6 +14,7 @@
 #include "quotecluster.h"
 
 #include <metasql.h>
+#include "xtreewidget.h"
 
 QuoteList::QuoteList(QWidget *pParent, Qt::WindowFlags flags)
   : VirtualList(pParent, flags)

--- a/widgets/racluster.cpp
+++ b/widgets/racluster.cpp
@@ -8,6 +8,9 @@
  * to be bound by its terms.
  */
 
+#include "racluster.h"
+
+#include <QIntValidator>
 #include <QMessageBox>
 #include <QSqlError>
 #include <QtScript>
@@ -15,9 +18,7 @@
 #include <metasql.h>
 
 #include "xsqlquery.h"
-
-
-#include "racluster.h"
+#include "xtreewidget.h"
 
 RaCluster::RaCluster(QWidget *pParent, const char *pName) :
   VirtualCluster(pParent, pName)

--- a/widgets/revisionCluster.cpp
+++ b/widgets/revisionCluster.cpp
@@ -10,6 +10,7 @@
 
 #include "revisioncluster.h"
 
+#include <QMenu>
 #include <QMessageBox>
 #include <QSqlError>
 #include <QtScript>

--- a/widgets/scriptablewidget.cpp
+++ b/widgets/scriptablewidget.cpp
@@ -15,14 +15,24 @@
 #include <QScriptEngine>
 #include <QScriptEngineDebugger>
 #include <QScriptValue>
+#include <QSqlDatabase>
+#include <QSqlDriver>
 
+#include "guiclientinterface.h"
 #include "include.h"
 #include "qtsetup.h"
 #include "widgets.h"
 #include "xsqlquery.h"
 
+#define DEBUG true
+
 // _object lets us work with the widget we want to script without deriving
 // ScriptableWidget from QObject, which would cause multiple inheritance headaches
+
+QString ScriptableWidget::_tablesToWatch("pkghead script pkgscript");
+GuiClientInterface                  *ScriptableWidget::_guiClientInterface = 0;
+QHash<int, QPair<QString, QString> > ScriptableWidget::_cacheScriptsById;
+QHash<QString, QList<int> >          ScriptableWidget::_cacheIdsByName;
 
 ScriptableWidget::ScriptableWidget(QObject* object)
   : _debugger(0),
@@ -30,6 +40,19 @@ ScriptableWidget::ScriptableWidget(QObject* object)
     _object(object),
     _scriptLoaded(false)
 {
+  QSqlDatabase db = QSqlDatabase::database();
+  foreach (QString tableName, _tablesToWatch.split(" "))
+  {
+    if (! db.driver()->subscribedToNotifications().contains(tableName))
+    {
+      db.driver()->subscribeToNotification(tableName);
+      QObject::connect(db.driver(), SIGNAL(notification(const QString&)),
+                       _object,     SLOT(sNotified(const QString&)));
+    }
+  }
+  if (ScriptableWidget::_guiClientInterface)
+    QObject::connect(ScriptableWidget::_guiClientInterface, SIGNAL(dbConnectionLost()),
+                     _object, SLOT(sDbConnectionLost()), Qt::UniqueConnection);
 }
 
 ScriptableWidget::~ScriptableWidget()
@@ -64,29 +87,46 @@ void ScriptableWidget::loadScript(const QStringList &list)
     return;
   }
   qDebug() << "Looking for scripts" << list;
+  QString widgetName = list.last();
 
-  // make one query to get all relevant scripts, using a JSON object
-  // to enforce load order: key = order, value = name
-  QStringList pair;
-  for (int i = 0; i < list.length(); i++)
+  // assume a coherent cache has the whole list if it has the last
+  if (! _cacheIdsByName.contains(widgetName))
   {
-    pair.append(QString("\"%1\": \"%2\"").arg(i).arg(list.at(i)));
+    _cacheIdsByName.insert(widgetName, QList<int>());
+
+    // make one query to get all relevant scripts, using a JSON object
+    // to enforce load order: key = order, value = name
+    QStringList pair;
+    for (int i = 0; i < list.length(); i++)
+    {
+      pair.append(QString("\"%1\": \"%2\"").arg(i).arg(list.at(i)));
+    }
+
+    XSqlQuery q;
+    q.prepare("WITH jsonlist AS (SELECT *"
+              "                    FROM json_each_text(:jsonlist))"
+              "SELECT script_id, script_name, script_source"
+              "  FROM script"
+              "  JOIN jsonlist ON script_name = value"
+              " WHERE script_enabled"
+              " ORDER BY key, script_order;");
+    q.bindValue(":jsonlist", "{" + pair.join(", ") + "}");
+    q.exec();
+    while (q.next())
+    {
+      _cacheScriptsById.insert(q.value("script_id").toInt(),
+                               qMakePair(q.value("script_name").toString(),
+                                         q.value("script_source").toString()));
+      _cacheIdsByName[widgetName].append(q.value("script_id").toInt());
+    }
+    if (DEBUG) qDebug() << _cacheIdsByName[widgetName];
   }
 
-  XSqlQuery scriptq;
-  scriptq.prepare("WITH jsonlist AS (SELECT *"
-                  "                    FROM json_each_text(:jsonlist))"
-                  "SELECT script_name, script_source"
-                  "  FROM script"
-                  "  JOIN jsonlist ON script_name = value"
-                  " WHERE script_enabled"
-                  " ORDER BY key, script_order;");
-  scriptq.bindValue(":jsonlist", "{" + pair.join(", ") + "}");
-  scriptq.exec();
-  while (scriptq.next())
+  foreach(int id, _cacheIdsByName[widgetName])
   {
-    QScriptValue result = engine()->evaluate(scriptq.value("script_source").toString(),
-                                             scriptq.value("script_name").toString());
+    QPair<QString, QString> script = _cacheScriptsById.value(id);
+    if (DEBUG) qDebug() << "evaluating" << id << script.first;
+    QScriptValue result = engine()->evaluate(script.second, script.first);
     if (engine()->hasUncaughtException())
     {
       qDebug() << "uncaught exception at line"
@@ -130,4 +170,17 @@ void ScriptableWidget::loadScriptEngine()
 
   scriptList.removeDuplicates();
   loadScript(scriptList);
+}
+
+void ScriptableWidget::sDbConnectionLost()
+{
+  sNotified("");
+}
+
+void ScriptableWidget::sNotified(const QString &pNotification)
+{
+  if (DEBUG) qDebug() << "sNotified() entered" << pNotification;
+  Q_UNUSED(pNotification);
+  _cacheScriptsById.clear();
+  _cacheIdsByName.clear();
 }

--- a/widgets/scriptablewidget.h
+++ b/widgets/scriptablewidget.h
@@ -18,11 +18,15 @@
 class QScriptEngine;
 class QScriptEngineDebugger;
 
+class GuiClientInterface;
+
 class ScriptableWidget
 {
   public:
     ScriptableWidget(QObject *object);
     virtual ~ScriptableWidget();
+
+    static GuiClientInterface *_guiClientInterface;
 
     virtual QScriptEngine *engine();
     virtual void           loadScript(const QStringList &list);
@@ -34,6 +38,14 @@ class ScriptableWidget
     QScriptEngine         *_engine;
     QObject               *_object;
     bool                   _scriptLoaded;
+
+    static QString _tablesToWatch;
+    static QHash<int, QPair<QString, QString> > _cacheScriptsById;
+    static QHash<QString, QList<int> >          _cacheIdsByName;
+
+  protected slots:
+    virtual void sDbConnectionLost();
+    virtual void sNotified(const QString &pNotification);
 };
 
 #endif

--- a/widgets/scriptablewidget.h
+++ b/widgets/scriptablewidget.h
@@ -19,11 +19,12 @@ class QScriptEngine;
 class QScriptEngineDebugger;
 
 class GuiClientInterface;
+class ScriptCache;
 
 class ScriptableWidget
 {
   public:
-    ScriptableWidget(QObject *object);
+    ScriptableWidget(QWidget *self = 0);
     virtual ~ScriptableWidget();
 
     static GuiClientInterface *_guiClientInterface;
@@ -34,18 +35,11 @@ class ScriptableWidget
     virtual void           loadScriptEngine();
 
   protected:
+    static ScriptCache    *_cache;
     QScriptEngineDebugger *_debugger;
     QScriptEngine         *_engine;
-    QObject               *_object;
     bool                   _scriptLoaded;
-
-    static QString _tablesToWatch;
-    static QHash<int, QPair<QString, QString> > _cacheScriptsById;
-    static QHash<QString, QList<int> >          _cacheIdsByName;
-
-  protected slots:
-    virtual void sDbConnectionLost();
-    virtual void sNotified(const QString &pNotification);
+    QWidget               *_self;
 };
 
 #endif

--- a/widgets/scriptcache.cpp
+++ b/widgets/scriptcache.cpp
@@ -1,0 +1,52 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which (including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#include "scriptcache.h"
+
+#include <QSqlDatabase>
+#include <QSqlDriver>
+
+ScriptCache::ScriptCache(QObject *parent)
+  : QObject(parent)
+{
+  _tablesToWatch << "pkghead" << "script" << "pkgscript";
+
+  QSqlDatabase db = QSqlDatabase::database();
+  foreach (QString tableName, _tablesToWatch)
+  {
+    if (! db.driver()->subscribedToNotifications().contains(tableName))
+      db.driver()->subscribeToNotification(tableName);
+  }
+  QObject::connect(db.driver(), SIGNAL(notification(const QString&)), this, SLOT(sNotified(const QString &)));
+  if (parent)
+    connect(parent, SIGNAL(dbConnectionLost()), this, SLOT(sDbConnectionLost()));
+}
+
+ScriptCache::~ScriptCache()
+{
+  clear();
+}
+
+void ScriptCache::clear()
+{
+  _scriptsById.clear();
+  _idsByName.clear();
+}
+
+void ScriptCache::sDbConnectionLost()
+{
+  clear();
+}
+
+void ScriptCache::sNotified(const QString &pNotification)
+{
+  if (_tablesToWatch.contains(pNotification))
+    clear();
+}

--- a/widgets/scriptcache.h
+++ b/widgets/scriptcache.h
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which (including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#include <QDebug>
+#include <QWidget>
+#include <QScriptEngine>
+#include <QScriptEngineDebugger>
+#include <QScriptValue>
+#include <QSqlDatabase>
+#include <QSqlDriver>
+
+#include "guiclientinterface.h"
+#include "include.h"
+#include "qtsetup.h"
+#include "widgets.h"
+#include "xsqlquery.h"
+
+class ScriptCache : public QObject
+{
+  Q_OBJECT
+
+  public:
+    ScriptCache(QObject *parent = 0);
+    virtual ~ScriptCache();
+
+    QHash<int, QPair<QString, QString> > _scriptsById;
+    QHash<QString, QList<int> >          _idsByName;
+    QStringList                          _tablesToWatch;
+
+  public slots:
+    virtual void clear();
+    virtual void sDbConnectionLost();
+    virtual void sNotified(const QString &pNotification);
+};

--- a/widgets/shipmentCluster.cpp
+++ b/widgets/shipmentCluster.cpp
@@ -13,6 +13,9 @@
 #include <QMessageBox>
 #include <QtScript>
 
+#include "xcheckbox.h"
+#include "xtreewidget.h"
+
 ShipmentCluster::ShipmentCluster(QWidget* pParent, const char* pName) :
     VirtualCluster(pParent, pName)
 {

--- a/widgets/shiptoCluster.cpp
+++ b/widgets/shiptoCluster.cpp
@@ -1,12 +1,14 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
  * to be bound by its terms.
  */
+
+#include "shiptocluster.h"
 
 #include <QLabel>
 #include <QPushButton>
@@ -18,7 +20,8 @@
 #include <parameter.h>
 #include <xsqlquery.h>
 
-#include "shiptocluster.h"
+#include "guiclientinterface.h"
+#include "xtreewidget.h"
 
 ShiptoEdit::ShiptoEdit(QWidget *pParent, const char *pName) :
    VirtualClusterLineEdit(pParent, "shiptoinfo", "shipto_id", "shipto_num", "shipto_name", "addr_line1", " (false) ", pName, "shipto_active")

--- a/widgets/usernameCluster.cpp
+++ b/widgets/usernameCluster.cpp
@@ -8,16 +8,18 @@
  * to be bound by its terms.
  */
 
-#include <QPushButton>
-#include <QLabel>
+#include "usernamecluster.h"
+
 #include <QHBoxLayout>
+#include <QLabel>
+#include <QMenu>
+#include <QPushButton>
 #include <QtScript>
 
 #include <parameter.h>
 #include <xsqlquery.h>
 
-#include "usernamecluster.h"
-#include "format.h"
+#include "xtreewidget.h"
 
 UsernameLineEdit::UsernameLineEdit(QWidget* pParent, const char* pName) :
     VirtualClusterLineEdit(pParent, "usr", "usr_id", "usr_username", "usr_propername", 0, 0, pName)

--- a/widgets/vendorcluster.cpp
+++ b/widgets/vendorcluster.cpp
@@ -1,19 +1,18 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2016 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
  * to be bound by its terms.
  */
 
-#include <QHBoxLayout>
 #include <QLabel>
-#include <QMessageBox>
+#include <QMenu>
 #include <QPushButton>
 #include <QSqlError>
-#include <QVBoxLayout>
+#include <QSqlQueryModel>
 
 #include <metasql.h>
 #include <parameter.h>

--- a/widgets/virtualCluster.h
+++ b/widgets/virtualCluster.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -11,38 +11,37 @@
 #ifndef virtCluster_h
 #define virtCluster_h
 
-#include "widgets.h"
-#include "guiclientinterface.h"
 #include "parameter.h"
+#include "scriptablewidget.h"
+#include "widgets.h"
 #include "xlineedit.h"
-#include "xtextedit.h"
-#include "xtreewidget.h"
-#include "xcheckbox.h"
-#include "xdatawidgetmapper.h"
 
-#include <QSqlQueryModel>
-#include <QAction>
-#include <QDialogButtonBox>
-#include <QCheckBox>
-#include <QCompleter>
 #include <QDialog>
-#include <QHBoxLayout>
-#include <QLabel>
-#include <QMenu>
-#include <QPushButton>
-#include <QSqlQueryModel>
-#include <QVBoxLayout>
+#include <QSqlQuery>
 #include <QWidget>
 
+class GuiClientInterface;
+class QAction;
+class QCompleter;
+class QDialogButtonBox;
 class QGridLayout;
+class QLabel;
+class QMenu;
+class QPushButton;
+class QSpacerItem;
+class QSqlQueryModel;
+class QVBoxLayout;
 class VirtualClusterLineEdit;
+class XCheckBox;
+class XDataWidgetMapper;
+class XTreeWidget;
 
 #define ID              1
 #define NUMBER          2
 #define DESCRIPTION     3
 #define ACTIVE          4
 
-class XTUPLEWIDGETS_EXPORT VirtualList : public QDialog
+class XTUPLEWIDGETS_EXPORT VirtualList : public QDialog, public ScriptableWidget
 {
     Q_OBJECT
 
@@ -60,7 +59,7 @@ class XTUPLEWIDGETS_EXPORT VirtualList : public QDialog
 
     protected:
         virtual void init();
-        void showEvent(QShowEvent *);
+        virtual void showEvent(QShowEvent *);
 
         VirtualClusterLineEdit* _parent;
         QVBoxLayout* _dialogLyt;
@@ -73,7 +72,7 @@ class XTUPLEWIDGETS_EXPORT VirtualList : public QDialog
         int          _id;
 };
 
-class XTUPLEWIDGETS_EXPORT VirtualSearch : public QDialog
+class XTUPLEWIDGETS_EXPORT VirtualSearch : public QDialog, public ScriptableWidget
 {
     Q_OBJECT
 
@@ -91,6 +90,8 @@ class XTUPLEWIDGETS_EXPORT VirtualSearch : public QDialog
         virtual void sSelect();
 
     protected:
+        virtual void showEvent(QShowEvent *);
+
         VirtualClusterLineEdit* _parent;
         QVBoxLayout* _dialogLyt;
         int  _id;
@@ -111,7 +112,7 @@ class XTUPLEWIDGETS_EXPORT VirtualSearch : public QDialog
         QLayout*     buttonsLyt;
 };
 
-class XTUPLEWIDGETS_EXPORT VirtualInfo : public QDialog
+class XTUPLEWIDGETS_EXPORT VirtualInfo : public QDialog, public ScriptableWidget
 {
     Q_OBJECT
 
@@ -124,6 +125,8 @@ class XTUPLEWIDGETS_EXPORT VirtualInfo : public QDialog
         virtual void sPopulate();
 
     protected:
+        virtual void showEvent(QShowEvent *);
+
         VirtualClusterLineEdit* _parent;
         QLabel*         _titleLit;
         QLabel*         _numberLit;
@@ -300,7 +303,7 @@ class XTUPLEWIDGETS_EXPORT VirtualClusterLineEdit : public XLineEdit
 
 */
 
-class XTUPLEWIDGETS_EXPORT VirtualCluster : public QWidget
+class XTUPLEWIDGETS_EXPORT VirtualCluster : public QWidget, public ScriptableWidget
 {
     Q_OBJECT
 
@@ -320,17 +323,17 @@ class XTUPLEWIDGETS_EXPORT VirtualCluster : public QWidget
         VirtualCluster(QWidget*, const char* = 0);
         VirtualCluster(QWidget*, VirtualClusterLineEdit* = 0, const char* = 0);
 
-        Q_INVOKABLE inline virtual int     id()             const { return _number->id(); }
-                    inline virtual QString label()          const { return _label->text(); }
-                    inline virtual QString number()         const { return _number->text(); }
-        Q_INVOKABLE inline virtual QString description()    const { return _description->text(); }
-        Q_INVOKABLE inline virtual bool    isValid()        const { return _number->isValid(); }
-        Q_INVOKABLE        virtual QString name()           const { return _name->text(); }
-        Q_INVOKABLE inline virtual bool    isStrict()       const { return _number->isStrict(); }
-                    inline virtual bool    readOnly()       const { return _readOnly; }
-                           virtual QString defaultNumber()  const { return _default; }
-                    inline virtual QString fieldName()      const { return _fieldName; }
-        Q_INVOKABLE inline virtual QString extraClause()    const { return _number->extraClause(); }
+        Q_INVOKABLE virtual int     id()             const;
+                    virtual QString label()          const;
+                    virtual QString number()         const;
+        Q_INVOKABLE virtual QString description()    const;
+        Q_INVOKABLE virtual bool    isValid()        const;
+        Q_INVOKABLE virtual QString name()           const;
+        Q_INVOKABLE virtual bool    isStrict()       const;
+                    virtual bool    readOnly()       const;
+                    virtual QString defaultNumber()  const;
+                    virtual QString fieldName()      const;
+        Q_INVOKABLE virtual QString extraClause()    const;
 
         virtual Qt::Orientation orientation();
         virtual void setOrientation(Qt::Orientation orientation);
@@ -346,15 +349,15 @@ class XTUPLEWIDGETS_EXPORT VirtualCluster : public QWidget
 
     public slots:
         // most of the heavy lifting is done by VirtualClusterLineEdit _number
-        virtual void clearExtraClause()                { _number->clearExtraClause(); }
-        virtual void setDefaultNumber(const QString& p){ _default=p;}
-        virtual void setDescription(const QString& p)  { _description->setText(p); }
-        virtual void setExtraClause(const QString& p, const QString& = QString::null)  { _number->setExtraClause(p); }
-        virtual void setFieldName(QString p)           { _fieldName = p; }
-        virtual void setId(const int p, const QString& = QString::null)                { _number->setId(p); }
-        virtual void setName(int, const QString& p)    { _name->setText(p); }
-        virtual void setNumber(const int p)            { _number->setNumber(QString::number(p)); }
-        virtual void setNumber(QString p)              { _number->setNumber(p); }
+        virtual void clearExtraClause();
+        virtual void setDefaultNumber(const QString& p);
+        virtual void setDescription(const QString& p);
+        virtual void setExtraClause(const QString& p, const QString& = QString::null);
+        virtual void setFieldName(QString p);
+        virtual void setId(const int p, const QString& = QString::null);
+        virtual void setName(int, const QString& p);
+        virtual void setNumber(const int p);
+        virtual void setNumber(QString p);
 
         virtual void clear();
         virtual void setDataWidgetMap(XDataWidgetMapper* m);
@@ -377,6 +380,7 @@ class XTUPLEWIDGETS_EXPORT VirtualCluster : public QWidget
 
     protected:
         virtual void addNumberWidget(VirtualClusterLineEdit* pNumberWidget);
+        virtual void showEvent(QShowEvent* e);
 
         QGridLayout*            _grid;
         QLabel*                 _label;

--- a/widgets/widgets.pro
+++ b/widgets/widgets.pro
@@ -116,6 +116,7 @@ HEADERS += plugins/addressclusterplugin.h \
 
 SOURCES += widgets.cpp \
     scriptablewidget.cpp                \
+    scriptcache.cpp                     \
     addressCluster.cpp \
     alarmMaint.cpp \
     alarms.cpp \
@@ -211,6 +212,7 @@ SOURCES += widgets.cpp \
 
 HEADERS += widgets.h \
     scriptablewidget.h          \
+    scriptcache.h               \
     xtupleplugin.h \
     guiclientinterface.h \
     addresscluster.h \

--- a/widgets/woCluster.cpp
+++ b/widgets/woCluster.cpp
@@ -8,24 +8,25 @@
  * to be bound by its terms.
  */
 
+#include "wocluster.h"
+
+#include <QCompleter>
 #include <QHBoxLayout>
 #include <QLabel>
-#include <QLayout>
-#include <QPushButton>
+#include <QMessageBox>
+#include <QSqlQueryModel>
 #include <QVBoxLayout>
 #include <QtScript>
 
 #include <parameter.h>
 #include <xsqlquery.h>
-#include <QMessageBox>
 
+#include "format.h"
 #include "warehousegroup.h"
+#include "xcheckbox.h"
 #include "xcombobox.h"
 #include "xlineedit.h"
-
-#include "wocluster.h"
-
-#include "../common/format.h"
+#include "xtreewidget.h"
 
 WoLineEdit::WoLineEdit(QWidget *pParent, const char *pName) :
     VirtualClusterLineEdit(pParent, "wo", "wo_id", "formatWoNumber(wo_id)", "item_number", "(item_descrip1 || ' ' || item_descrip2) ", 0, pName)


### PR DESCRIPTION
Add scriptability to VirtualCluster, its subclasses including the AddressCluster, and the Info, Search, and List windows. Most of the file changes below are consequence of moving code from the VirtualCluster header file to the source file and reducing the number of includes (widgets/Makefile dropped about 20% in size).