### PR TITLE
Resolves issue #29933 - unable to post scrap/expense transactions

### DIFF
--- a/guiclient/expenseTrans.cpp
+++ b/guiclient/expenseTrans.cpp
@@ -26,9 +26,10 @@ expenseTrans::expenseTrans(QWidget* parent, const char* name, Qt::WindowFlags fl
 {
   setupUi(this);
 
-  connect(_post,                 SIGNAL(clicked()), this, SLOT(sPost()));
-  connect(_qty,SIGNAL(textChanged(const QString&)), this, SLOT(sPopulateQty()));
-  connect(_warehouse,           SIGNAL(newID(int)), this, SLOT(sPopulateQOH(int)));
+  connect(_post,          SIGNAL(clicked()), this, SLOT(sPost()));
+  connect(_qty,           SIGNAL(textChanged(const QString&)), this, SLOT(sPopulateQty()));
+  connect(_warehouse,     SIGNAL(newID(int)), this, SLOT(sPopulateQOH()));
+  connect(_item,          SIGNAL(newId(int)), this, SLOT(sPopulateQOH()));
 
   _captive = false;
   _prjid = -1;
@@ -248,9 +249,9 @@ void expenseTrans::sPost()
   }
 }
 
-void expenseTrans::sPopulateQOH(int pWarehousid)
+void expenseTrans::sPopulateQOH()
 {
-  if (_mode != cView)
+  if (_mode != cView && _item->isValid() && _warehouse->isValid())
   {
     XSqlQuery qohq;
     qohq.prepare( "SELECT itemsite_qtyonhand, "
@@ -259,7 +260,7 @@ void expenseTrans::sPopulateQOH(int pWarehousid)
                "WHERE ( (itemsite_item_id=:item_id)"
                " AND (itemsite_warehous_id=:warehous_id) );" );
     qohq.bindValue(":item_id", _item->id());
-    qohq.bindValue(":warehous_id", pWarehousid);
+    qohq.bindValue(":warehous_id", _warehouse->id());
     qohq.exec();
     if (qohq.first())
     {

--- a/guiclient/expenseTrans.h
+++ b/guiclient/expenseTrans.h
@@ -31,7 +31,7 @@ public slots:
     virtual enum SetResponse set( const ParameterList & pParams );
     virtual void setProjectId(int p) { _prjid = p; }
     virtual void sPost();
-    virtual void sPopulateQOH( int pWarehousid );
+    virtual void sPopulateQOH();
     virtual void sPopulateQty();
 
 protected slots:

--- a/guiclient/scrapTrans.h
+++ b/guiclient/scrapTrans.h
@@ -27,7 +27,7 @@ public:
 public slots:
     virtual enum SetResponse set(const ParameterList & pParams );
     virtual void sPost();
-    virtual void sPopulateQOH( int pWarehousid );
+    virtual void sPopulateQOH();
     virtual void sPopulateQty();
 
 protected slots:

--- a/guiclient/transferTrans.cpp
+++ b/guiclient/transferTrans.cpp
@@ -29,7 +29,7 @@ transferTrans::transferTrans(QWidget* parent, const char* name, Qt::WindowFlags 
 //  (void)statusBar();
 
   connect(_item, SIGNAL(newId(int)), this, SLOT(sHandleItem()));
-  connect(_fromWarehouse, SIGNAL(newID(int)), this, SLOT(sPopulateFromQty(int)));
+  connect(_fromWarehouse, SIGNAL(newID(int)), this, SLOT(sPopulateFromQty()));
   connect(_post, SIGNAL(clicked()),                   this, SLOT(sPost()));
   connect(_qty,  SIGNAL(textChanged(const QString&)), this, SLOT(sUpdateQty(const QString&)));
   connect(_toWarehouse, SIGNAL(newID(int)), this, SLOT(sPopulateToQty(int)));
@@ -170,6 +170,8 @@ void transferTrans::sHandleItem()
     _qty->setValidator(omfgThis->transQtyVal());
   else
     _qty->setValidator(new QIntValidator(this));
+
+  sPopulateFromQty();
 }
 
 void transferTrans::sPost()
@@ -273,17 +275,17 @@ void transferTrans::sPost()
   }
 }
 
-void transferTrans::sPopulateFromQty(int pWarehousid)
+void transferTrans::sPopulateFromQty()
 {
   XSqlQuery transferPopulateFromQty;
-  if (_mode != cView)
+  if (_mode != cView && _item->isValid() && _fromWarehouse->isValid())
   {
     transferPopulateFromQty.prepare( "SELECT itemsite_qtyonhand "
                "FROM itemsite "
                "WHERE ( (itemsite_item_id=:item_id)"
                " AND (itemsite_warehous_id=:warehous_id) );" );
     transferPopulateFromQty.bindValue(":item_id", _item->id());
-    transferPopulateFromQty.bindValue(":warehous_id", pWarehousid);
+    transferPopulateFromQty.bindValue(":warehous_id", _fromWarehouse->id());
     transferPopulateFromQty.exec();
     if (transferPopulateFromQty.first())
     {

--- a/guiclient/transferTrans.h
+++ b/guiclient/transferTrans.h
@@ -32,7 +32,7 @@ protected slots:
 
     virtual void sHandleItem();
     virtual void sPost();
-    virtual void sPopulateFromQty( int pWarehousid );
+    virtual void sPopulateFromQty();
     virtual void sPopulateToQty( int pWarehousid );
     virtual void sUpdateQty( const QString & pQty );
 


### PR DESCRIPTION
Before: The Before Qty was not populating unless user "selected" the (already set) WH from the WComboBox. 
After: Added signals to _item so that The Before Qty populates after the ItemCluster value is set.

- expenseTrans
- scrapTrans
- transformTrans