### PR TITLE
Support for Sales Order (line item) > Return Stock sans locking

### DIFF
--- a/common/storedProcErrorLookup.cpp
+++ b/common/storedProcErrorLookup.cpp
@@ -1432,6 +1432,8 @@ const struct {
 			       "you may Return this Shipment."),
 								0, "" },
 
+  { "returnShipmentTransaction", -1, QT_TRANSLATE_NOOP("storedProcErrorLookup", "Missing Cost Category for itemsite"), 0, "" },
+  { "returnShipmentTransaction", -2, QT_TRANSLATE_NOOP("storedProcErrorLookup", "Missing Cost Category for itemsite"), 0, "" },
   { "returnShipmentTransaction",
 			-5, QT_TRANSLATE_NOOP("storedProcErrorLookup", "Either a Cost Category for the Items you are "
 			       "trying to Return is not configured with a "
@@ -1443,6 +1445,7 @@ const struct {
 			       "Administrator to have this corrected before "
 			       "you may Return this Shipment."),
 								0, "" },
+  { "returnShipmentTransaction", -11, QT_TRANSLATE_NOOP("storedProcErrorLookup", "Can not return shipment for this order type"), 0, "" },
 
   { "reverseapapplication", -1, QT_TRANSLATE_NOOP("storedProcErrorLookup", "The amount paid is less than the applied amount."),
                                 	0, "" },

--- a/guiclient/maintainShipping.cpp
+++ b/guiclient/maintainShipping.cpp
@@ -205,6 +205,8 @@ void maintainShipping::sViewOrder()
   {
     return;
   }
+
+  sFillList();
 }
 
 void maintainShipping::sPrintShippingForm()

--- a/guiclient/maintainShipping.cpp
+++ b/guiclient/maintainShipping.cpp
@@ -183,6 +183,8 @@ void maintainShipping::sReturnAllOrderStock()
                          maintainReturnAllOrderStock, __FILE__, __LINE__);
     return;
   }
+
+  sFillList();
 }
 
 void maintainShipping::sViewOrder()
@@ -205,8 +207,6 @@ void maintainShipping::sViewOrder()
   {
     return;
   }
-
-  sFillList();
 }
 
 void maintainShipping::sPrintShippingForm()
@@ -244,6 +244,8 @@ void maintainShipping::sReturnAllLineStock()
                          maintainReturnAllLineStock, __FILE__, __LINE__);
     return;
   }
+
+  sFillList();
 }
 
 void maintainShipping::sViewLine()
@@ -271,40 +273,17 @@ void maintainShipping::sViewLine()
 void maintainShipping::sReturnAllStock()
 {
   XSqlQuery maintainReturnAllStock;
-  XSqlQuery rollback;
-  rollback.prepare("ROLLBACK;");
-
-  maintainReturnAllStock.exec("BEGIN");
   maintainReturnAllStock.prepare("SELECT returnShipmentTransaction(:ship_id) AS result;");
   maintainReturnAllStock.bindValue(":ship_id", _ship->altId());
   maintainReturnAllStock.exec();
-  if (maintainReturnAllStock.first())
+  if (maintainReturnAllStock.lastError().type() != QSqlError::NoError)
   {
-    int result = maintainReturnAllStock.value("result").toInt();
-    if (maintainReturnAllStock.value("result").toInt() < 0)
-    {
-      rollback.exec();
-      ErrorReporter::error(QtCriticalMsg, this, tr("Error Retrieving Shipment Information"),
-                             storedProcErrorLookup("returnShipmentTransaction", result),
-                             __FILE__, __LINE__);
-      return;
-    }
-    else if (distributeInventory::SeriesAdjust(result, this) == XDialog::Rejected)
-    {
-      rollback.exec();
-      QMessageBox::information( this, tr("Issue to Shipping"), tr("Return Canceled") );
-      return;
-    }    
-    maintainReturnAllStock.exec("COMMIT;"); 
-    sFillList();
-  }
-  else if (maintainReturnAllStock.lastError().type() != QSqlError::NoError)
-  {
-    rollback.exec();
     ErrorReporter::error(QtCriticalMsg, this, tr("Error Retrieving Shipment Information"),
                          maintainReturnAllStock, __FILE__, __LINE__);
     return;
   }
+
+  sFillList();
 }
 
 void maintainShipping::sFillList()

--- a/guiclient/maintainShipping.cpp
+++ b/guiclient/maintainShipping.cpp
@@ -174,36 +174,11 @@ void maintainShipping::sShipOrder()
 void maintainShipping::sReturnAllOrderStock()
 {
   XSqlQuery maintainReturnAllOrderStock;
-  XSqlQuery rollback;
-  rollback.prepare("ROLLBACK;");
-
-  maintainReturnAllOrderStock.exec("BEGIN");
   maintainReturnAllOrderStock.prepare("SELECT returnCompleteShipment(:ship_id) AS result;");
   maintainReturnAllOrderStock.bindValue(":ship_id", _ship->id());
   maintainReturnAllOrderStock.exec();
-  if (maintainReturnAllOrderStock.first())
+  if (maintainReturnAllOrderStock.lastError().type() != QSqlError::NoError)
   {
-    int result = maintainReturnAllOrderStock.value("result").toInt();
-    if (result < 0)
-    {
-      rollback.exec();
-      ErrorReporter::error(QtCriticalMsg, this, tr("Error Retrieving Shipment Information"),
-                             storedProcErrorLookup("returnCompleteShipment", result),
-                             __FILE__, __LINE__);
-      return;
-    }
-    else if (distributeInventory::SeriesAdjust(result, this) == XDialog::Rejected)
-    {
-      rollback.exec();
-      QMessageBox::information( this, tr("Issue to Shipping"), tr("Return Canceled") );
-      return;
-    }
-    maintainReturnAllOrderStock.exec("COMMIT;"); 
-    sFillList();
-  }
-  else if (maintainReturnAllOrderStock.lastError().type() != QSqlError::NoError)
-  {
-    rollback.exec();
     ErrorReporter::error(QtCriticalMsg, this, tr("Error Retrieving Shipment Information"),
                          maintainReturnAllOrderStock, __FILE__, __LINE__);
     return;
@@ -258,36 +233,11 @@ void maintainShipping::sIssueStock()
 void maintainShipping::sReturnAllLineStock()
 {
   XSqlQuery maintainReturnAllLineStock;
-  XSqlQuery rollback;
-  rollback.prepare("ROLLBACK;");
-
-  maintainReturnAllLineStock.exec("BEGIN");
   maintainReturnAllLineStock.prepare("SELECT returnItemShipments(:ship_id) AS result;");
   maintainReturnAllLineStock.bindValue(":ship_id", _ship->altId());
   maintainReturnAllLineStock.exec();
-  if (maintainReturnAllLineStock.first())
+  if (maintainReturnAllLineStock.lastError().type() != QSqlError::NoError)
   {
-    int result = maintainReturnAllLineStock.value("result").toInt();
-    if (maintainReturnAllLineStock.value("result").toInt() < 0)
-    {
-      rollback.exec();
-      ErrorReporter::error(QtCriticalMsg, this, tr("Error Retrieving Shipment Information"),
-                             storedProcErrorLookup("returnItemShipments", result),
-                             __FILE__, __LINE__);
-      return;
-    }
-    else if (distributeInventory::SeriesAdjust(result, this) == XDialog::Rejected)
-    {
-      rollback.exec();
-      QMessageBox::information( this, tr("Issue to Shipping"), tr("Return Canceled") );
-      return;
-    }    
-    maintainReturnAllLineStock.exec("COMMIT;"); 
-    sFillList();
-  }
-  else if (maintainReturnAllLineStock.lastError().type() != QSqlError::NoError)
-  {
-    rollback.exec();
     ErrorReporter::error(QtCriticalMsg, this, tr("Error Retrieving Shipment Information"),
                          maintainReturnAllLineStock, __FILE__, __LINE__);
     return;

--- a/guiclient/salesOrder.cpp
+++ b/guiclient/salesOrder.cpp
@@ -4220,18 +4220,7 @@ void salesOrder::sReturnStock()
   {
     returnSales.bindValue(":soitem_id", ((XTreeWidgetItem *)(selected[i]))->id());
     returnSales.exec();
-    if (returnSales.first())
-    {
-      int result = returnSales.value("result").toInt();
-      if (result < 0)
-      {
-        ErrorReporter::error(QtCriticalMsg, this, tr("Error Retrieving Return Item Information"),
-                               storedProcErrorLookup("returnItemShipments", result),
-                               __FILE__, __LINE__);
-        return;
-      }
-    }
-    else if (returnSales.lastError().type() != QSqlError::NoError)
+    if (returnSales.lastError().type() != QSqlError::NoError)
     {
       ErrorReporter::error(QtCriticalMsg, this, tr("Error Retrieving Return Item Information"),
                            returnSales, __FILE__, __LINE__);

--- a/guiclient/salesOrder.cpp
+++ b/guiclient/salesOrder.cpp
@@ -4213,11 +4213,7 @@ bool salesOrder::okToProcessCC()
 
 void salesOrder::sReturnStock()
 {
-  XSqlQuery rollback;
-  rollback.prepare("ROLLBACK;");
-
   XSqlQuery returnSales;
-  returnSales.exec("BEGIN;"); // because of possible lot, serial, or location distribution cancelations
   returnSales.prepare("SELECT returnItemShipments(:soitem_id) AS result;");
   QList<XTreeWidgetItem *> selected = _soitem->selectedItems();
   for (int i = 0; i < selected.size(); i++)
@@ -4229,32 +4225,21 @@ void salesOrder::sReturnStock()
       int result = returnSales.value("result").toInt();
       if (result < 0)
       {
-        rollback.exec();
         ErrorReporter::error(QtCriticalMsg, this, tr("Error Retrieving Return Item Information"),
                                storedProcErrorLookup("returnItemShipments", result),
                                __FILE__, __LINE__);
         return;
       }
-      if (distributeInventory::SeriesAdjust(returnSales.value("result").toInt(), this) == XDialog::Rejected)
-      {
-        rollback.exec();
-        QMessageBox::information( this, tr("Return Stock"), tr("Transaction Canceled") );
-        return;
-      }
-
     }
     else if (returnSales.lastError().type() != QSqlError::NoError)
     {
-      rollback.exec();
       ErrorReporter::error(QtCriticalMsg, this, tr("Error Retrieving Return Item Information"),
                            returnSales, __FILE__, __LINE__);
       return;
     }
   }
 
-  returnSales.exec("COMMIT;");
-
-    sFillItemList();
+  sFillItemList();
 }
 
 void salesOrder::sIssueStock()
@@ -4557,7 +4542,7 @@ void salesOrder::sIssueLineBalance()
 
       // issueToShipping instead of issueLineBalanceToShipping because we have already calculated the balance
       issueSales.prepare("SELECT issueToShipping('SO', :soitem_id, :qty, :itemlocseries, now(), "
-                         ":invhist_id, TRUE) AS result;");
+                         ":invhist_id, FALSE, TRUE) AS result;");
       issueSales.bindValue(":soitem_id", soitem->id());
       issueSales.bindValue(":qty", balance);
       issueSales.bindValue(":itemlocseries", itemlocSeries);

--- a/guiclient/salesOrder.cpp
+++ b/guiclient/salesOrder.cpp
@@ -4224,7 +4224,7 @@ void salesOrder::sReturnStock()
     {
       ErrorReporter::error(QtCriticalMsg, this, tr("Error Retrieving Return Item Information"),
                            returnSales, __FILE__, __LINE__);
-      return;
+      continue;
     }
   }
 

--- a/guiclient/shippingInformation.cpp
+++ b/guiclient/shippingInformation.cpp
@@ -184,20 +184,10 @@ void shippingInformation::sReturnAllLineStock()
   shippingReturnAllLineStock.bindValue(":ordertype", _order->type());
   shippingReturnAllLineStock.bindValue(":lineitemid", _item->id());
   shippingReturnAllLineStock.exec();
-  if (shippingReturnAllLineStock.first())
+  if (shippingReturnAllLineStock.lastError().type() != QSqlError::NoError)
   {
-    int result = shippingReturnAllLineStock.value("result").toInt();
-    if (result < 0)
-    {
-      ErrorReporter::error(QtCriticalMsg, this, tr("Error Returning Items From Shipment"),
-                             storedProcErrorLookup("returnItemShipments", result),
-                             __FILE__, __LINE__);
-      return;
-    }
-  }
-  else if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Returning Items From Shipment"),
-                                shippingReturnAllLineStock, __FILE__, __LINE__))
-  {
+    ErrorReporter::error(QtCriticalMsg, this, tr("Error Returning Items From Shipment"),
+                                shippingReturnAllLineStock, __FILE__, __LINE__);
     return;
   }
 

--- a/guiclient/transferOrder.cpp
+++ b/guiclient/transferOrder.cpp
@@ -1766,45 +1766,19 @@ void transferOrder::viewTransferOrder( int pId )
 void transferOrder::sReturnStock()
 {
   XSqlQuery transferReturnStock;
-  XSqlQuery rollback;
-  rollback.prepare("ROLLBACK;");
-
-  transferReturnStock.exec("BEGIN;");	// because of possible lot, serial, or location distribution cancelations
   transferReturnStock.prepare("SELECT returnItemShipments('TO', :toitem_id, 0, CURRENT_TIMESTAMP) AS result;");
   QList<XTreeWidgetItem*> selected = _toitem->selectedItems();
   for (int i = 0; i < selected.size(); i++)
   {
     transferReturnStock.bindValue(":toitem_id", ((XTreeWidgetItem*)(selected[i]))->id());
     transferReturnStock.exec();
-    if (transferReturnStock.first())
+  if (transferReturnStock.lastError().type() != QSqlError::NoError)
     {
-      int result = transferReturnStock.value("result").toInt();
-      if (result < 0)
-      {
-        rollback.exec();
-        ErrorReporter::error(QtCriticalMsg, this, tr("Error Retrieving Return Item Information"),
-                               storedProcErrorLookup("returnItemShipments", result),
-                               __FILE__, __LINE__);
-        return;
-      }
-      if (distributeInventory::SeriesAdjust(transferReturnStock.value("result").toInt(), this) == XDialog::Rejected)
-      {
-        rollback.exec();
-        QMessageBox::information( this, tr("Return Stock"), tr("Transaction Canceled") );
-        return;
-      }
-
-    }
-    else if (transferReturnStock.lastError().type() != QSqlError::NoError)
-    {
-      rollback.exec();
       ErrorReporter::error(QtCriticalMsg, this, tr("Error Retrieving Return Item Information"),
                            transferReturnStock, __FILE__, __LINE__);
       return;
     }
   }
-
-  transferReturnStock.exec("COMMIT;");
 
   sFillItemList();
 }

--- a/guiclient/transferOrder.cpp
+++ b/guiclient/transferOrder.cpp
@@ -1776,7 +1776,7 @@ void transferOrder::sReturnStock()
     {
       ErrorReporter::error(QtCriticalMsg, this, tr("Error Retrieving Return Item Information"),
                            transferReturnStock, __FILE__, __LINE__);
-      return;
+      continue;
     }
   }
 


### PR DESCRIPTION
https://github.com/xtuple/xtuple/pull/3015

In qt-client, all calls to returnItemShipments are wrapped in a transaction, followed by distributeInventory::SeriesAdjust. I propose that the sole purpose of this was to call postItemlocSeries https://github.com/xtuple/qt-client/blob/4_10_x/guiclient/distributeInventory.cpp#L355. Any and all distribution detail occurs entirely in the database because all nested functions of returnItemShipments that call postInvTrans always pass the invhist_id. 

~~I added postItemlocSeries to returnItemShipments (pr linked above).~~ I added postItemlocSeries to postInvTrans https://github.com/xtuple/xtuple/pull/3015/files#diff-986ae11ec8bee1fa06e1ef93bf5affeaR245. This pr removes the transaction blocks from the return stock methods in:
- issueToShipping.cpp
- maintainShipping.cpp
- shippingInformation.cpp
- transferOrder.cpp
- salesOrder.cpp

*TODO for future pr:* The following files should have the postItemlocSeries call removed as it's now handled in postInvTrans anytime invhist_id is sent.
- https://github.com/xtuple/qt-client/blob/4_10_x/guiclient/enterPoReceipt.cpp#L362
- https://github.com/xtuple/qt-client/blob/4_10_x/guiclient/enterPoReceipt.cpp#L412
- https://github.com/xtuple/qt-client/blob/4_10_x/guiclient/postProduction.cpp#L338
- https://github.com/xtuple/qt-client/blob/4_10_x/guiclient/postProduction.cpp#L373
- https://github.com/xtuple/qt-client/blob/4_10_x/guiclient/scrapWoMaterialFromWIP.cpp#L249
- https://github.com/xtuple/qt-client/blob/4_10_x/guiclient/unpostedPoReceipts.cpp#L319