### PR TITLE
issue #28225 - scriptable namedColors, format* functions, encrypted metrics

### DIFF
--- a/common/format.cpp
+++ b/common/format.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -12,6 +12,7 @@
 
 #include <QSqlError>
 #include <QVariant>
+#include <QtScript>
 
 #include "format.h"
 #include "xsqlquery.h"
@@ -245,4 +246,115 @@ QString formatUOMRatio(double value)
 QString formatPercent(double value)
 {
   return formatNumber(value * 100.0, percentscale);
+}
+
+QString formatDate(const QDate &pDate)
+{
+  return QLocale().toString(pDate, QLocale::ShortFormat);
+}
+
+static QScriptValue wrapDecimalPlaces(QScriptContext *context, QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+  return decimalPlaces(context->argument(0).toString());
+}
+
+static QScriptValue wrapFormatNumber(QScriptContext *context, QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+  return formatNumber(context->argument(0).toNumber(), context->argument(1).toInt32());
+}
+
+static QScriptValue wrapFormatMoney(QScriptContext *context, QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+  return formatMoney(context->argument(0).toNumber(),
+                     context->argument(1).toInt32(),
+                     context->argument(1).toInt32());
+}
+
+static QScriptValue wrapFormatCost(QScriptContext *context, QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+  return formatCost(context->argument(0).toNumber(), context->argument(1).toInt32());
+}
+
+static QScriptValue wrapFormatExtPrice(QScriptContext *context, QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+  return formatExtPrice(context->argument(0).toNumber(), context->argument(1).toInt32());
+}
+
+static QScriptValue wrapFormatWeight(QScriptContext *context, QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+  return formatWeight(context->argument(0).toNumber());
+}
+
+static QScriptValue wrapFormatQty(QScriptContext *context, QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+  return formatQty(context->argument(0).toNumber());
+}
+
+static QScriptValue wrapFormatQtyPer(QScriptContext *context, QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+  return formatQtyPer(context->argument(0).toNumber());
+}
+
+static QScriptValue wrapFormatSalesPrice(QScriptContext *context, QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+  return formatSalesPrice(context->argument(0).toNumber(), context->argument(1).toInt32());
+}
+
+static QScriptValue wrapFormatPurchPrice(QScriptContext *context, QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+  return formatPurchPrice(context->argument(0).toNumber(), context->argument(1).toInt32());
+}
+
+static QScriptValue wrapFormatUOMRatio(QScriptContext *context, QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+  return formatUOMRatio(context->argument(0).toNumber());
+}
+
+static QScriptValue wrapFormatPercent(QScriptContext *context, QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+  return formatPercent(context->argument(0).toNumber());
+}
+
+static QScriptValue wrapFormatDate(QScriptContext *context, QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+  return formatDate(context->argument(0).toDateTime().date());
+}
+
+// for now, return the #RRGGBB for the named color.
+static QScriptValue wrapNamedColor(QScriptContext *context, QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+  return namedColor(context->argument(0).toString()).name();
+}
+
+void setupFormat(QScriptEngine *engine)
+{
+  Q_UNUSED(engine);
+  engine->globalObject().setProperty("decimalPlaces",    engine->newFunction(wrapDecimalPlaces));
+  engine->globalObject().setProperty("formatNumber",     engine->newFunction(wrapFormatNumber));
+  engine->globalObject().setProperty("formatMoney",      engine->newFunction(wrapFormatMoney));
+  engine->globalObject().setProperty("formatCost",       engine->newFunction(wrapFormatCost));
+  engine->globalObject().setProperty("formatExtPrice",   engine->newFunction(wrapFormatExtPrice));
+  engine->globalObject().setProperty("formatWeight",     engine->newFunction(wrapFormatWeight));
+  engine->globalObject().setProperty("formatQty",        engine->newFunction(wrapFormatQty));
+  engine->globalObject().setProperty("formatQtyPer",     engine->newFunction(wrapFormatQtyPer));
+  engine->globalObject().setProperty("formatSalesPrice", engine->newFunction(wrapFormatSalesPrice));
+  engine->globalObject().setProperty("formatPurchPrice", engine->newFunction(wrapFormatPurchPrice));
+  engine->globalObject().setProperty("formatUOMRatio",   engine->newFunction(wrapFormatUOMRatio));
+  engine->globalObject().setProperty("formatPercent",    engine->newFunction(wrapFormatPercent));
+  engine->globalObject().setProperty("formatDate",       engine->newFunction(wrapFormatDate));
+  engine->globalObject().setProperty("namedColor",       engine->newFunction(wrapNamedColor));
 }

--- a/common/format.h
+++ b/common/format.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -15,6 +15,8 @@
 #include <QLocale>
 #include <QString>
 
+class QScriptEngine;
+
 int             decimalPlaces(QString);
 QString         formatNumber(double, int);
 QString         formatMoney(double, int = -1, int = 0);
@@ -27,11 +29,9 @@ QString         formatSalesPrice(double, int = -1);
 QString         formatPurchPrice(double, int = -1);
 QString         formatUOMRatio(double);
 QString         formatPercent(double);
+QString         formatDate(const QDate &pDate);
 QColor          namedColor(QString);
 
-inline QString  formatDate(const QDate &pDate)
-{
-  return QLocale().toString(pDate, QLocale::ShortFormat);
-}
+void            setupFormat(QScriptEngine *engine);
 
 #endif

--- a/common/metrics.h
+++ b/common/metrics.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -15,6 +15,8 @@
 #include <QObject>
 #include <QString>
 #include <QMap>
+
+class QScriptEngine;
 
 typedef QMap<QString, QString> MetricMap;
 
@@ -91,6 +93,8 @@ class Privileges : public Parameters
     bool check(const QString &);
     bool isDba();
 };
+
+void setupParameters(QScriptEngine *engine, QString name, Parameters *params);
 
 #endif
 

--- a/common/metricsenc.cpp
+++ b/common/metricsenc.cpp
@@ -1,21 +1,24 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
  * to be bound by its terms.
  */
 
-
 #include "metricsenc.h"
 #include "xsqlquery.h"
 
-Parametersenc::Parametersenc(QObject * parent)
-  : QObject(parent)
+#include <QtScript>
+
+#include "errorReporter.h"
+
+Parametersenc::Parametersenc(const QString &key, QObject *parent)
+  : Parameters(parent),
+    _key(key)
 {
-  _dirty = false;
 }
 
 void Parametersenc::load()
@@ -24,99 +27,26 @@ void Parametersenc::load()
 
   XSqlQuery q;
   q.prepare(_readSql);
-//  q.bindValue(":username", _username);
-  q.bindValue(":key", _key);
+  q.bindValue(":username", _username);
+  q.bindValue(":key",      _key);
   q.exec();
   while (q.next())
     _values[q.value("key").toString()] = q.value("value").toString();
+  if (ErrorReporter::error(QtCriticalMsg, 0,
+                           tr("Error loading %1").arg(metaObject()->className()),
+                           q, __FILE__, __LINE__))
+    return;
 
   _dirty = false;
-}
 
-QString Parametersenc::value(const char *pName)
-{
-  return value(QString(pName));
-}
-
-QString Parametersenc::value(const QString &pName)
-{
-  MetricMap::iterator it = _values.find(pName);
-  if (it == _values.end())
-    return QString::null;
-  else
-    return it.value();
-}
-
-bool Parametersenc::boolean(const char *pName)
-{
-  return boolean(QString(pName));
-}
-
-bool Parametersenc::boolean(const QString &pName)
-{
-  MetricMap::iterator it = _values.find(pName);
-  if (it == _values.end())
-    return false;
-  else if (it.value() == "t")
-    return true;
-
-  return false;
-}
-
-void Parametersenc::set(const char *pName, bool pValue)
-{
-  set(QString(pName), pValue);
-}
-
-void Parametersenc::set(const QString &pName, bool pValue)
-{
-  MetricMap::iterator it = _values.find(pName);
-  if ( (it != _values.end()) && (it.value() == ((pValue) ? "t" : "f")) )
-    return;
-
-  _set(pName, ((pValue) ? QString("t") : QString("f")));
-}
-
-void Parametersenc::set(const char *pName, int pValue)
-{
-  set(QString(pName), pValue);
-}
-
-void Parametersenc::set(const QString &pName, int pValue)
-{
-  MetricMap::iterator it = _values.find(pName);
-  if ( (it != _values.end()) && (it.value().toInt() == pValue) )
-    return;
-
-  _set(pName, pValue);
-}
-
-void Parametersenc::set(const char *pName, const QString &pValue)
-{
-  set(QString(pName), pValue);
-}
-
-void Parametersenc::set(const QString &pName, const QString &pValue)
-{
-  MetricMap::iterator it = _values.find(pName);
-  if (it != _values.end())
-  {
-    if (it.value() == pValue)
-      return;
-    else
-      it.value() =  pValue;
-  }
-  else
-    _values[pName] = pValue;
-
-  _set(pName, pValue);
+  emit loaded();
 }
 
 void Parametersenc::_set(const QString &pName, QVariant pValue)
 {
   XSqlQuery q;
   q.prepare(_setSql);
-//  q.bindValue(":username", _username);
+  q.bindValue(":username", _username);
   q.bindValue(":name", pName);
   q.bindValue(":value", pValue);
   q.bindValue(":key", _key);
@@ -125,24 +55,13 @@ void Parametersenc::_set(const QString &pName, QVariant pValue)
   _dirty = true;
 }
 
-QString Parametersenc::parent(const QString &pValue)
+Metricsenc::Metricsenc(const QString &pKey, QObject *parent)
+  : Parametersenc(pKey, parent)
 {
-  for (MetricMap::iterator it = _values.begin(); it != _values.end(); it++)
-    if (it.value() == pValue)
-      return it.key();
-
-  return QString::null;
-}
-
-
-Metricsenc::Metricsenc(const QString &pKey)
-{
-  _readSql = "SELECT metricenc_name AS key, decrypt(setbytea(metricenc_value), setbytea(:key), 'bf') AS value FROM metricenc;";
+  _readSql = "SELECT metricenc_name AS key,"
+             "       decrypt(setbytea(metricenc_value), setbytea(:key), 'bf') AS value"
+             "  FROM metricenc;";
   _setSql  = "SELECT setMetricEnc(:name, :value, :key);";
-  _key = pKey;
 
   load();
 }
-
-
-

--- a/common/metricsenc.h
+++ b/common/metricsenc.h
@@ -1,69 +1,45 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
  * to be bound by its terms.
  */
 
-
 #ifndef metricsenc_h
 #define metricsenc_h
+
+#include "metrics.h"
 
 #include <QObject>
 #include <QString>
 #include <QMap>
 #include <QVariant>
 
-typedef QMap<QString, QString> MetricMap;
-
-class Parametersenc : public QObject
+class Parametersenc : public Parameters
 {
   Q_OBJECT
 
   protected:
-    MetricMap _values;
-    QString   _readSql;
-    QString   _setSql;
-    QString   _username;
     QString   _key;
-    bool      _dirty;
 
   public:
-    Parametersenc(QObject * parent = 0);
+    Parametersenc(const QString &key, QObject *parent = 0);
     virtual ~Parametersenc() {};
 
     void load();
 
-    QString value(const char *);
-    bool    boolean(const char *);
-
-    void set(const char *, bool);
-    void set(const QString &, bool);
-    void set(const char *, int);
-    void set(const QString &, int);
-    void set(const char *, const QString &);
-    void set(const QString &, const QString &);
-
-    QString parent(const QString &);
-
-  public slots:
-    QString value(const QString &);
-    bool    boolean(const QString &);
-
   protected:
-    void _set(const QString &, QVariant);
+    void _set(const QString &pName, QVariant pValue);
 
 };
 
 class Metricsenc : public Parametersenc
 {
   public:
-//    metricsenc();
-    Metricsenc() {};
-    Metricsenc(const QString &);
+    Metricsenc(const QString &key, QObject *parent = 0);
 };
 
 #endif

--- a/guiclient/displays/dspCostedBOMBase.h
+++ b/guiclient/displays/dspCostedBOMBase.h
@@ -23,6 +23,7 @@ public:
     dspCostedBOMBase(QWidget* parent = 0, const char* name = 0, Qt::WindowFlags fl = Qt::Window);
 
     virtual bool setParams(ParameterList &params);
+    using display::sFillList;
 
 public slots:
     virtual enum SetResponse set( const ParameterList & pParams );

--- a/guiclient/displays/dspCostedSummarizedBOM.h
+++ b/guiclient/displays/dspCostedSummarizedBOM.h
@@ -24,6 +24,7 @@ public:
     dspCostedSummarizedBOM(QWidget* parent = 0, const char* name = 0, Qt::WindowFlags fl = Qt::Window);
 
     virtual bool setParams(ParameterList &params);
+    using display::sFillList;
 
 public slots:
     virtual enum SetResponse set( const ParameterList & pParams );

--- a/guiclient/guiclient.cpp
+++ b/guiclient/guiclient.cpp
@@ -2276,18 +2276,10 @@ void GUIClient::loadScriptGlobals(QScriptEngine * engine)
   mainwindowval.setProperty("S60",      QScriptValue(engine, S60), ro);
   mainwindowval.setProperty("Unknown",  QScriptValue(engine, Unknown), ro);
 
-
-  QScriptValue metricsval = engine->newQObject(_metrics);
-  engine->globalObject().setProperty("metrics", metricsval);
-
-  QScriptValue metricsencval = engine->newQObject(_metricsenc);
-  engine->globalObject().setProperty("metricsenc", metricsencval);
-
-  QScriptValue preferencesval = engine->newQObject(_preferences);
-  engine->globalObject().setProperty("preferences", preferencesval);
-
-  QScriptValue privilegesval = engine->newQObject(_privileges);
-  engine->globalObject().setProperty("privileges", privilegesval);
+  setupParameters(engine, "metrics",      _metrics);
+  setupParameters(engine, "metricsenc",   _metricsenc);
+  setupParameters(engine, "preferences",  _preferences);
+  setupParameters(engine, "privileges",   _privileges);
 
   QScriptValue settingsval = engine->newFunction(settingsValue, 2);
   engine->globalObject().setProperty("settingsValue", settingsval);
@@ -2327,7 +2319,7 @@ void GUIClient::loadScriptGlobals(QScriptEngine * engine)
   mainwindowval.setProperty("cNoReportDefinition", QScriptValue(engine, cNoReportDefinition), ro);
 
   setupScriptApi(engine);
-  setupWidgetsScriptApi(engine);
+  setupWidgetsScriptApi(engine, ScriptableWidget::_guiClientInterface); // what's a better way?
   setupSetupApi(engine);
   setupGuiErrorCheck(engine);
 

--- a/guiclient/xtupleguiclientinterface.cpp
+++ b/guiclient/xtupleguiclientinterface.cpp
@@ -104,3 +104,24 @@ int xTupleGuiClientInterface::hunspell_ignore(const QString word)
 {
   return omfgThis->hunspell_ignore(word);
 }
+
+Metrics *xTupleGuiClientInterface::getMetrics()
+{
+  return _metrics;
+}
+
+Metricsenc *xTupleGuiClientInterface::getMetricsenc()
+{
+  return _metricsenc;
+}
+
+Preferences *xTupleGuiClientInterface::getPreferences()
+{
+  return _preferences;
+}
+
+Privileges *xTupleGuiClientInterface::getPrivileges()
+{
+  return _privileges;
+}
+

--- a/guiclient/xtupleguiclientinterface.h
+++ b/guiclient/xtupleguiclientinterface.h
@@ -26,4 +26,9 @@ class xTupleGuiClientInterface : public GuiClientInterface
     virtual const QStringList hunspell_suggest(const QString word);
     virtual int               hunspell_add(const QString word);
     virtual int               hunspell_ignore(const QString word);
+
+    virtual Metrics     *getMetrics();
+    virtual Metricsenc  *getMetricsenc();
+    virtual Preferences *getPreferences();
+    virtual Privileges  *getPrivileges();
 };

--- a/scriptapi/qmainwindowproto.cpp
+++ b/scriptapi/qmainwindowproto.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which(including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -52,7 +52,7 @@ QScriptValue constructQMainWindow(QScriptContext * context,
 }
 
 QMainWindowProto::QMainWindowProto(QObject *parent)
-    : QObject(parent)
+    : QWidgetProto(parent)
 {
 }
 
@@ -307,6 +307,4 @@ bool QMainWindowProto::toolBarBreak ( QToolBar * toolbar ) const
     return toolBarBreak (toolbar);
   return false;
 }
-
-
 

--- a/scriptapi/qmainwindowproto.h
+++ b/scriptapi/qmainwindowproto.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which(including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -17,7 +17,7 @@
 #include <QString>
 #include <QMainWindow>
 
-Q_DECLARE_METATYPE(QMainWindow*)
+#include "qwidgetproto.h"
 
 void setupQMainWindowProto(QScriptEngine *engine);
 void DockOptionScriptValue(const QScriptValue &obj, enum QMainWindow::DockOption &p);
@@ -25,7 +25,7 @@ void DockOptionScriptValue(const QScriptValue &obj, enum QMainWindow::DockOption
 QScriptValue constructQMainWindow(QScriptContext *context, QScriptEngine *engine);
 QScriptValue DockOptiontoScriptValue(QScriptEngine *engine, const enum QMainWindow::DockOption &p);
 
-class QMainWindowProto : public QObject, public QScriptable
+class QMainWindowProto : public QWidgetProto
 {
   Q_OBJECT
 

--- a/scriptapi/qobjectproto.h
+++ b/scriptapi/qobjectproto.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -13,8 +13,6 @@
 
 #include <QObject>
 #include <QtScript>
-
-Q_DECLARE_METATYPE(QObject*)
 
 void setupQObjectProto(QScriptEngine *engine);
 QScriptValue constructQObject(QScriptContext *context, QScriptEngine *engine);
@@ -41,6 +39,8 @@ class QObjectProto : public QObject, public QScriptable
     Q_INVOKABLE QList<QByteArray>           dynamicPropertyNames() const;
     Q_INVOKABLE bool                        event(QEvent * e);
     Q_INVOKABLE bool                        eventFilter(QObject * watched, QEvent * event);
+
+    Q_INVOKABLE QList<QObject*>            *findChildren(const QString &name = QString(), Qt::FindChildOptions options = Qt::FindChildrenRecursively, const QString &classname = QString()) const;
     // TODO: Does not work. `T` does not have a type
     /*
     Q_INVOKABLE T                           findChild(const QString & name = QString(), Qt::FindChildOptions options = Qt::FindChildrenRecursively) const;
@@ -83,5 +83,6 @@ class QObjectProto : public QObject, public QScriptable
 };
 
 Q_SCRIPT_DECLARE_QMETAOBJECT(QObjectProto, QObject*)
+Q_DECLARE_METATYPE(QList<QObject*>*)
 
 #endif

--- a/scriptapi/qpushbuttonproto.cpp
+++ b/scriptapi/qpushbuttonproto.cpp
@@ -55,7 +55,7 @@ QScriptValue constructQPushButton(QScriptContext * context,
 }
 
 QPushButtonProto::QPushButtonProto(QObject *parent)
-    : QObject(parent)
+    : QWidgetProto(parent)
 {
 }
 

--- a/scriptapi/qpushbuttonproto.h
+++ b/scriptapi/qpushbuttonproto.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which(including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -15,12 +15,12 @@
 #include <QtScript>
 #include <QPushButton>
 
-Q_DECLARE_METATYPE(QPushButton*)
+#include "qwidgetproto.h"
 
 void setupQPushButtonProto(QScriptEngine *engine);
 QScriptValue constructQPushButton(QScriptContext *context, QScriptEngine *engine);
 
-class QPushButtonProto : public QObject, public QScriptable
+class QPushButtonProto : public QWidgetProto
 {
   Q_OBJECT
 

--- a/scriptapi/qsqldatabaseproto.h
+++ b/scriptapi/qsqldatabaseproto.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -21,9 +21,6 @@
 #include <QtScript>
 
 class QSqlDriver;
-
-Q_DECLARE_METATYPE(QSqlDatabase*)
-Q_DECLARE_METATYPE(QSqlDatabase)
 
 void setupQSqlDatabaseProto(QScriptEngine *engine);
 QScriptValue constructQSqlDatabase(QScriptContext *context, QScriptEngine *engine);
@@ -66,5 +63,8 @@ class QSqlDatabaseProto : public QObject, public QScriptable
     Q_INVOKABLE bool         transaction();
     Q_INVOKABLE QString      userName()                      const;
 };
+
+Q_DECLARE_METATYPE(QSqlDatabase)
+Q_DECLARE_METATYPE(QSqlDatabase*)
 
 #endif

--- a/scriptapi/qsqlqueryproto.cpp
+++ b/scriptapi/qsqlqueryproto.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree

--- a/scriptapi/qtsetup.cpp
+++ b/scriptapi/qtsetup.cpp
@@ -115,6 +115,16 @@ QScriptValue FillRuletoScriptValue(QScriptEngine *engine, const enum Qt::FillRul
   return QScriptValue(engine, (int)p);
 }
 
+QScriptValue FindChildOptionToScriptValue(QScriptEngine *engine, const enum Qt::FindChildOption &p)
+{
+  return QScriptValue(engine, (int)p);
+}
+
+QScriptValue FindChildOptionsToScriptValue(QScriptEngine *engine, const Qt::FindChildOptions &p)
+{
+  return QScriptValue(engine, (int)p);
+}
+
 QScriptValue FocusPolicytoScriptValue(QScriptEngine *engine, const Qt::FocusPolicy &p)
 {
   return QScriptValue(engine, (int)p);
@@ -432,6 +442,16 @@ void EventPriorityfromScriptValue(const QScriptValue &obj, enum Qt::EventPriorit
 void FillRulefromScriptValue(const QScriptValue &obj, enum Qt::FillRule &p)
 {
   p = (enum Qt::FillRule)obj.toInt32();
+}
+
+void FindChildOptionFromScriptValue(const QScriptValue &obj, enum Qt::FindChildOption &p)
+{
+  p = (enum Qt::FindChildOption)obj.toInt32();
+}
+
+void FindChildOptionsFromScriptValue(const QScriptValue &obj, Qt::FindChildOptions &p)
+{
+  p = (Qt::FindChildOptions)obj.toInt32();
 }
 
 void FocusPolicyfromScriptValue(const QScriptValue &obj, Qt::FocusPolicy &p)
@@ -823,6 +843,11 @@ void setupQt(QScriptEngine *engine)
   widget.setProperty("StrongFocus",               QScriptValue(engine, Qt::StrongFocus),            ro);
   widget.setProperty("WheelFocus",                QScriptValue(engine, Qt::WheelFocus),             ro);
   widget.setProperty("NoFocus",                   QScriptValue(engine, Qt::NoFocus),                ro);
+
+  qScriptRegisterMetaType(engine,  FindChildOptionToScriptValue,  FindChildOptionFromScriptValue);
+  qScriptRegisterMetaType(engine,  FindChildOptionsToScriptValue, FindChildOptionsFromScriptValue);
+  widget.setProperty("FindDirectChildrenOnly",    QScriptValue(engine, Qt::FindDirectChildrenOnly), ro);
+  widget.setProperty("FindChildrenRecursively",   QScriptValue(engine, Qt::FindChildrenRecursively),ro);
 
   qScriptRegisterMetaType(engine, FocusReasontoScriptValue, FocusReasonfromScriptValue);
   widget.setProperty("MouseFocusReason",          QScriptValue(engine, Qt::MouseFocusReason),       ro);

--- a/scriptapi/qtsetup.h
+++ b/scriptapi/qtsetup.h
@@ -38,6 +38,8 @@ Q_DECLARE_METATYPE(enum Qt::DockWidgetArea);
 Q_DECLARE_METATYPE(enum Qt::DropAction);
 Q_DECLARE_METATYPE(enum Qt::EventPriority);
 Q_DECLARE_METATYPE(enum Qt::FillRule);
+Q_DECLARE_METATYPE(enum Qt::FindChildOption);
+Q_DECLARE_METATYPE(Qt::FindChildOptions);
 Q_DECLARE_METATYPE(enum Qt::FocusReason);
 Q_DECLARE_METATYPE(enum Qt::GlobalColor);
 Q_DECLARE_METATYPE(enum Qt::HitTestAccuracy);

--- a/scriptapi/qwidgetproto.cpp
+++ b/scriptapi/qwidgetproto.cpp
@@ -1,7 +1,7 @@
 /*
  *This file is part of the xTuple ERP: PostBooks Edition, a free and
  *open source Enterprise Resource Planning software suite,
- *Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ *Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  *It is licensed to you under the Common Public Attribution License
  *version 1.0, the full text of which(including xTuple-specific Exhibits)
  *is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -14,7 +14,7 @@
 
 #define DEBUG false
 
-QScriptValue scriptFind(QScriptContext *context, QScriptEngine  * engine)
+QScriptValue scriptFind(QScriptContext *context, QScriptEngine *engine)
 {
 #ifndef Q_OS_WIN
   if (context->argumentCount() >= 1 &&
@@ -24,21 +24,21 @@ QScriptValue scriptFind(QScriptContext *context, QScriptEngine  * engine)
   return 0;
 }
 
-QScriptValue scriptKeyboardGrabber(QScriptContext * /*context*/,
-                                    QScriptEngine  *engine)
+QScriptValue scriptKeyboardGrabber(QScriptContext *context, QScriptEngine *engine)
 {
+  Q_UNUSED(context);
   return engine->toScriptValue(QWidget::keyboardGrabber());
 }
 
-QScriptValue scriptMouseGrabber(QScriptContext * /*context*/,
-                                 QScriptEngine  *engine)
+QScriptValue scriptMouseGrabber(QScriptContext *context, QScriptEngine *engine)
 {
+  Q_UNUSED(context);
   return engine->toScriptValue(QWidget::mouseGrabber());
 }
 
-QScriptValue scriptSetTabOrder(QScriptContext *context,
-                               QScriptEngine  * /*engine*/)
+QScriptValue scriptSetTabOrder(QScriptContext *context, QScriptEngine *engine)
 {
+  Q_UNUSED(engine);
   if (context->argumentCount() >= 2 &&
       qscriptvalue_cast<QWidget*>(context->argument(0)) &&
       qscriptvalue_cast<QWidget*>(context->argument(1)))
@@ -70,8 +70,7 @@ void setupQWidgetProto(QScriptEngine *engine)
   constructor.setProperty("setTabOrder",    engine->newFunction(scriptSetTabOrder));
 }
 
-QScriptValue constructQWidget(QScriptContext *context,
-                              QScriptEngine  *engine)
+QScriptValue constructQWidget(QScriptContext *context, QScriptEngine  *engine)
 {
   QWidget *obj = 0;
   if (context->argumentCount() >= 2)
@@ -85,7 +84,7 @@ QScriptValue constructQWidget(QScriptContext *context,
 }
 
 QWidgetProto::QWidgetProto(QObject *parent)
-    : QObject(parent)
+    : QObjectProto(parent)
 {
 }
 
@@ -272,16 +271,6 @@ QGraphicsProxyWidget *QWidgetProto::graphicsProxyWidget() const
   return 0;
 }
 
-/*
-bool QWidgetProto::hasEditFocus() const
-{
-  QWidget *item = qscriptvalue_cast<QWidget*>(thisObject());
-  if (item)
-    return item->hasEditFocus();
-  return false;
-}
-*/
-
 bool QWidgetProto::hasFocus() const
 {
   QWidget *item = qscriptvalue_cast<QWidget*>(thisObject());
@@ -297,17 +286,6 @@ int QWidgetProto::heightForWidth(int w) const
     return item->heightForWidth(w);
   return 0;
 }
-
-#if QT_VERSION < 0x050000
-QInputContext *QWidgetProto::inputContext()
-{
-  QWidget *item = qscriptvalue_cast<QWidget*>(thisObject());
-  if (item)
-    return item->inputContext();
-  return 0;
-}
-#endif
-
 
 QVariant QWidgetProto::inputMethodQuery(int query) const
 {
@@ -582,15 +560,6 @@ void QWidgetProto::setContentsMargins(int left, int top, int right, int bottom)
     item->setContentsMargins(left, top, right, bottom);
 }
 
-/*
-void QWidgetProto::setEditFocus(bool enable)
-{
-  QWidget *item = qscriptvalue_cast<QWidget*>(thisObject());
-  if (item)
-    item->setEditFocus(enable);
-}
-*/
-
 void QWidgetProto::setFixedHeight(int h)
 {
   QWidget *item = qscriptvalue_cast<QWidget*>(thisObject());
@@ -639,15 +608,6 @@ void QWidgetProto::setForegroundRole(int role)
   if (item)
     item->setForegroundRole((QPalette::ColorRole)role);
 }
-
-#if QT_VERSION < 0x050000
-void QWidgetProto::setInputContext(QInputContext *context)
-{
-  QWidget *item = qscriptvalue_cast<QWidget*>(thisObject());
-  if (item)
-    item->setInputContext(context);
-}
-#endif
 
 void QWidgetProto::setLayout(QLayout *layout)
 {

--- a/scriptapi/qwidgetproto.h
+++ b/scriptapi/qwidgetproto.h
@@ -1,7 +1,7 @@
 /*
  *This file is part of the xTuple ERP: PostBooks Edition, a free and
  *open source Enterprise Resource Planning software suite,
- *Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ *Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  *It is licensed to you under the Common Public Attribution License
  *version 1.0, the full text of which(including xTuple-specific Exhibits)
  *is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -18,9 +18,6 @@
 #include <QFontInfo>
 #include <QFontMetrics>
 #include <QGraphicsProxyWidget>
-#if QT_VERSION < 0x050000
-#include <QInputContext>
-#endif
 #include <QKeySequence>
 #include <QLayout>
 #include <QList>
@@ -43,13 +40,12 @@
 #include <QWidget>
 #include <QtScript>
 
-Q_DECLARE_METATYPE(QWidget*)
-//Q_DECLARE_METATYPE(QWidget)
+#include "qobjectproto.h"
 
 void setupQWidgetProto(QScriptEngine *engine);
 QScriptValue constructQWidget(QScriptContext *context, QScriptEngine *engine);
 
-class QWidgetProto : public QObject, public QScriptable
+class QWidgetProto : public QObjectProto
 {
   Q_OBJECT
 
@@ -83,12 +79,8 @@ class QWidgetProto : public QObject, public QScriptable
     Q_INVOKABLE int                   grabShortcut(const QKeySequence &key, int context = Qt::WindowShortcut);
     Q_INVOKABLE QGraphicsProxyWidget *graphicsProxyWidget() const;
 
-    //Q_INVOKABLE bool                  hasEditFocus() const;
     Q_INVOKABLE bool                  hasFocus() const;
     Q_INVOKABLE int                   heightForWidth(int w) const;
-    #if QT_VERSION < 0x050000
-    Q_INVOKABLE QInputContext        *inputContext();
-    #endif
     Q_INVOKABLE QVariant              inputMethodQuery(int query) const;
     Q_INVOKABLE void                  insertAction(QAction *before, QAction *action);
     Q_INVOKABLE void                  insertActions(QAction *before, QList<QAction *> actions);
@@ -125,7 +117,6 @@ class QWidgetProto : public QObject, public QScriptable
     Q_INVOKABLE void                  setAttribute(int attribute, bool on = true);
     Q_INVOKABLE void                  setBackgroundRole(int role);
     Q_INVOKABLE void                  setContentsMargins(int left, int top, int right, int bottom);
-    //Q_INVOKABLE void setEditFocus(bool enable);
     Q_INVOKABLE void                  setFixedHeight(int h);
     Q_INVOKABLE void                  setFixedSize(const QSize &s);
     Q_INVOKABLE void                  setFixedSize(int w, int h);
@@ -133,9 +124,6 @@ class QWidgetProto : public QObject, public QScriptable
     Q_INVOKABLE void                  setFocus(int reason);
     Q_INVOKABLE void                  setFocusProxy(QWidget *w);
     Q_INVOKABLE void                  setForegroundRole(int role);
-    #if QT_VERSION < 0x050000
-    Q_INVOKABLE void                  setInputContext(QInputContext *context);
-    #endif
     Q_INVOKABLE void                  setLayout(QLayout *layout);
     Q_INVOKABLE void                  setMask(const QBitmap &bitmap);
     Q_INVOKABLE void                  setMask(const QRegion &region);

--- a/scriptapi/setupscriptapi.cpp
+++ b/scriptapi/setupscriptapi.cpp
@@ -13,6 +13,7 @@
 #include "char.h"
 #include "engineevaluate.h"
 #include "exporthelper.h"
+#include "format.h"
 #include "include.h"
 #include "jsconsole.h"
 #include "metasqlhighlighterproto.h"
@@ -284,4 +285,5 @@ void setupScriptApi(QScriptEngine *engine)
   setupXWebSync(engine);
   setupchar(engine);
 
+  setupFormat(engine);
 }

--- a/scriptapi/setupscriptapi.h
+++ b/scriptapi/setupscriptapi.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree

--- a/scriptapi/xsqlqueryproto.cpp
+++ b/scriptapi/xsqlqueryproto.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2012 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -11,6 +11,8 @@
 #include "xsqlqueryproto.h"
 
 #include <QSqlError>
+
+#include "qsqldatabaseproto.h"
 
 void setupXSqlQueryProto(QScriptEngine *engine)
 {
@@ -25,29 +27,15 @@ void setupXSqlQueryProto(QScriptEngine *engine)
 QScriptValue constructXSqlQuery(QScriptContext *context, QScriptEngine  *engine)
 {
   XSqlQuery *obj = 0;
-  if (context->argumentCount() > 0) {
-    QScriptValue arg = context->argument(0);
-    if (arg.isString()) {
-      /* TODO: Cannot pass QSqlDatabase.
-      if (context->argumentCount() == 2) {
-        QSqlDatabase db = context->argument(1).toVariant().value<QSqlDatabase>();
-        obj = new XSqlQuery(arg.toString(), db);
-      } else {
-        obj = new XSqlQuery(arg.toString());
-      }
-      */
-      obj = new XSqlQuery(arg.toString());
-    } else {
-      /* TODO: Cannot pass QSqlDatabase.
-      QSqlDatabase db = arg.toVariant().value<QSqlDatabase>();
-      obj = new XSqlQuery(db);
-      */
-      context->throwError(QScriptContext::UnknownError,
-                          "Qt Script XSqlQuery() can only take one QString arg. No other instantiation is supported at this time.");
-    }
-  } else {
+  if (context->argumentCount() >= 2)
+    obj = new XSqlQuery(context->argument(0).toString(),
+                        context->argument(1).toVariant().value<QSqlDatabase>());
+  else if (context->argumentCount() == 1 && context->argument(0).isString())
+    obj = new XSqlQuery(context->argument(0).toString());
+  else if (context->argumentCount() == 1)
+    obj = new XSqlQuery(context->argument(0).toVariant().value<QSqlDatabase>());
+  else
     obj = new XSqlQuery();
-  }
 
   return engine->toScriptValue(obj);
 }

--- a/scriptapi/xsqlqueryproto.h
+++ b/scriptapi/xsqlqueryproto.h
@@ -1,15 +1,15 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2012 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
  * to be bound by its terms.
  */
 
-#ifndef __SCRIPTQUERY_H__
-#define __SCRIPTQUERY_H__
+#ifndef __XSQLQUERYPROTO_H__
+#define __XSQLQUERYPROTO_H__
 
 #include <QObject>
 #include <QVariant>
@@ -17,9 +17,6 @@
 #include <QSqlRecord>
 
 #include <xsqlquery.h>
-
-Q_DECLARE_METATYPE(XSqlQuery*)
-Q_DECLARE_METATYPE(XSqlQuery)
 
 void setupXSqlQueryProto(QScriptEngine *engine);
 QScriptValue constructXSqlQuery(QScriptContext *context, QScriptEngine *engine);
@@ -59,4 +56,7 @@ class XSqlQueryProto : public QObject, public QScriptable
     bool previous();
 };
 
-#endif // __SCRIPTQUERY_H__
+Q_DECLARE_METATYPE(XSqlQuery*)
+Q_DECLARE_METATYPE(XSqlQuery)
+
+#endif // __XSQLQUERYPROTO_H__

--- a/widgets/guiclientinterface.h
+++ b/widgets/guiclientinterface.h
@@ -16,6 +16,11 @@
 #include <QString>
 #include <QAction>
 
+class Metrics;
+class Metricsenc;
+class Preferences;
+class Privileges;
+
 class GuiClientInterface : public QObject
 {
   Q_OBJECT
@@ -35,6 +40,11 @@ class GuiClientInterface : public QObject
     virtual const QStringList hunspell_suggest(const QString word) = 0;
     virtual int hunspell_add(const QString word) = 0;
     virtual int hunspell_ignore(const QString word) = 0;
+
+    virtual Metrics     *getMetrics()               = 0;
+    virtual Metricsenc  *getMetricsenc()            = 0;
+    virtual Preferences *getPreferences()           = 0;
+    virtual Privileges  *getPrivileges()            = 0;
 
   signals:
     void dbConnectionLost();

--- a/widgets/scriptablewidget.cpp
+++ b/widgets/scriptablewidget.cpp
@@ -22,10 +22,11 @@
 #include "include.h"
 #include "qtsetup.h"
 #include "scriptcache.h"
+#include "setupscriptapi.h"
 #include "widgets.h"
 #include "xsqlquery.h"
 
-#define DEBUG true
+#define DEBUG false
 
 GuiClientInterface *ScriptableWidget::_guiClientInterface = 0;
 ScriptCache        *ScriptableWidget::_cache              = 0;
@@ -58,6 +59,8 @@ QScriptEngine *ScriptableWidget::engine()
 
     setupQt(_engine);
     setupInclude(_engine);
+    setupScriptApi(_engine);
+    setupWidgetsScriptApi(_engine, _guiClientInterface);
     QScriptValue mywidget = _engine->newQObject(w);
     _engine->globalObject().setProperty("mywidget",  mywidget);
   }

--- a/widgets/widgets.cpp
+++ b/widgets/widgets.cpp
@@ -9,6 +9,8 @@
  */
 
 #include "widgets.h"
+#include "metrics.h"
+#include "metricsenc.h"
 
 #include "xtupleplugin.h"
 
@@ -204,7 +206,7 @@ void initializePlugin(Preferences *pPreferences, Metrics *pMetrics, Privileges *
   _x_username = pUsername;
 }
 
-void setupWidgetsScriptApi(QScriptEngine *engine)
+void setupWidgetsScriptApi(QScriptEngine *engine, GuiClientInterface *client)
 {
 
   setupAddressCluster(engine);
@@ -246,4 +248,11 @@ void setupWidgetsScriptApi(QScriptEngine *engine)
   setupXTreeWidgetItem(engine);
   setupXt(engine);
 
+  if (client)
+  {
+    setupParameters(engine, "metrics",      client->getMetrics());
+    setupParameters(engine, "metricsenc",   client->getMetricsenc());
+    setupParameters(engine, "preferences",  client->getPreferences());
+    setupParameters(engine, "privileges",   client->getPrivileges());
+  }
 }

--- a/widgets/widgets.h
+++ b/widgets/widgets.h
@@ -41,6 +41,7 @@ class Privileges;
 class QMdiArea;
 class QScriptEngine;
 class QWidget;
+class GuiClientInterface;
 
 extern Preferences *_x_preferences;
 extern Metrics     *_x_metrics;
@@ -48,7 +49,7 @@ extern QMdiArea    *_x_workspace;
 extern Privileges  *_x_privileges;
 extern QString     _x_username;
 
-void setupWidgetsScriptApi(QScriptEngine *engine);
+void setupWidgetsScriptApi(QScriptEngine *engine, GuiClientInterface *client = 0);
 
 #endif
 

--- a/widgets/widgets.pro
+++ b/widgets/widgets.pro
@@ -1,19 +1,24 @@
 include( ../global.pri )
+
 TARGET   = xtuplewidgets
 TEMPLATE = lib
 CONFIG  += qt warn_on plugin
-QT      += sql script scripttools
+QT      += core network printsupport script scripttools sql \
+           webkit webkitwidgets widgets xml
 
 greaterThan(QT_MAJOR_VERSION, 4) {
-  QT += widgets printsupport designer uitools
+  QT += designer printsupport serialport uitools \
+        webchannel websockets widgets
 } else {
   CONFIG += designer uitools
 }
 
-INCLUDEPATH += ../common ../scriptapi .
 DBFILE       = widgets.db
 LANGUAGE     = C++
-DEPENDPATH  += ../common ../scriptapi
+INCLUDEPATH += ../common ../scriptapi .
+DEPENDPATH  += $${INCLUDEPATH} ../lib
+LIBS        += -lxtuplescriptapi -lxtuplecommon -lwrtembed \
+               -lqzint -ldmtx -lrenderer -lMetaSQL -lopenrptcommon
 
 dynamic { 
     CONFIG      += dll # plugin implies dll but this fixes a cross-compile problem
@@ -21,7 +26,6 @@ dynamic {
     MOC_DIR      = tmp/dll
     OBJECTS_DIR  = tmp/dll
     UI_DIR       = tmp/dll
-    LIBS        += -lxtuplescriptapi -lxtuplecommon -lwrtembed -lrenderer -lMetaSQL -lopenrptcommon
     DEFINES     += MAKEDLL
     QMAKE_LIBDIR = ../lib $$OPENRPT_LIBDIR $$QMAKE_LIBDIR
 } else {

--- a/widgets/xtreeview.h
+++ b/widgets/xtreeview.h
@@ -28,7 +28,7 @@ class XTUPLEWIDGETS_EXPORT XTreeView : public QTreeView
     Q_PROPERTY(QString         schemaName            READ schemaName           WRITE setSchemaName       )
     Q_PROPERTY(QString         tableName             READ tableName            WRITE setTableName        )
     Q_PROPERTY(int             primaryKeyCoulmns     READ primaryKeyColumns    WRITE setPrimaryKeyColumns)
-    
+
     public:
       XTreeView(QWidget *parent = 0);
       ~XTreeView();
@@ -53,18 +53,20 @@ class XTUPLEWIDGETS_EXPORT XTreeView : public QTreeView
       virtual bool ignoreGeometrySizing() { return _ignoreSizing; }
       virtual void setIgnoreGeometrySizing(bool ignore) { _ignoreSizing = ignore; }
       virtual void setGeometry( int x, int y, int w, int h );
-            
+
+      using QTreeView::dataChanged;
+
     public slots:
       virtual int  currentIndex();
       virtual int  rowCount();
       virtual int  rowCountVisible();
       virtual QString filter();
       virtual QVariant value(int row, int column);
-      virtual QVariant selectedValue(int column); 
+      virtual QVariant selectedValue(int column);
       virtual void insert();
       virtual void populate(int p);
       virtual void removeSelected();
-      virtual void revertAll(); 
+      virtual void revertAll();
       virtual void save();
       virtual void select();
       virtual void selectRow(int index);
@@ -91,7 +93,7 @@ class XTUPLEWIDGETS_EXPORT XTreeView : public QTreeView
       void  valid(bool);
       void  saved();
       void  populateMenu(QMenu *, QModelIndex);
-      
+
     protected:
       virtual void resizeEvent(QResizeEvent*);
       virtual void selectionChanged(const QItemSelection & selected, const QItemSelection & deselected);
@@ -122,7 +124,7 @@ class XTUPLEWIDGETS_EXPORT XTreeView : public QTreeView
       QString              _tableName;
       QString              _windowName;
 
-      struct ColumnProps { 
+      struct ColumnProps {
         QString columnName;
         int     logicalIndex;
         int     defaultWidth;


### PR DESCRIPTION
- allow scripts to get namedColors() and the various old locale format functions
- remove redundant code by using inheritance for metricsenc
- expand inheritance in scriptapi dir
- fix some compiler warnings