### PR TITLE
Issue #30111: Lot selection on inventory history report

### DIFF
--- a/guiclient/displays/dspDetailedInventoryHistoryByLotSerial.cpp
+++ b/guiclient/displays/dspDetailedInventoryHistoryByLotSerial.cpp
@@ -226,7 +226,7 @@ bool dspDetailedInventoryHistoryByLotSerial::setParams(ParameterList &params)
   else
   {
     params.append("pattern", "t");
-    params.append("lotSerial", _lotSerialPattern->text().trimmed());
+    params.append("lotSerial", _lotSerialPattern->text().trimmed().toUpper());
   }
 
   return true;


### PR DESCRIPTION
Lot is capitalised when created so applying this to filter