### PR TITLE
issue #28349 - allow scripts to create virtual clusters & vc line edits

### DIFF
--- a/widgets/virtualCluster.cpp
+++ b/widgets/virtualCluster.cpp
@@ -1483,3 +1483,87 @@ void VirtualInfo::showEvent(QShowEvent* e)
   QDialog::showEvent(e);
 }
 
+// script exposure /////////////////////////////////////////////////////////////
+
+QScriptValue constructVirtualClusterLineEdit(QScriptContext *context,
+                                             QScriptEngine  *engine)
+{
+  VirtualClusterLineEdit *w = 0;
+
+  if (context->argumentCount() >= 9)
+    w = new VirtualClusterLineEdit(qscriptvalue_cast<QWidget*>(context->argument(0)),
+                                   context->argument(1).toString().toLatin1().data(),
+                                   context->argument(2).toString().toLatin1().data(),
+                                   context->argument(3).toString().toLatin1().data(),
+                                   context->argument(4).toString().toLatin1().data(),
+                                   context->argument(5).toString().toLatin1().data(),
+                                   context->argument(6).toString().toLatin1().data(),
+                                   context->argument(7).toString().toLatin1().data(),
+                                   context->argument(8).toString().toLatin1().data());
+  else if (context->argumentCount() == 8)
+    w = new VirtualClusterLineEdit(qscriptvalue_cast<QWidget*>(context->argument(0)),
+                                   context->argument(1).toString().toLatin1().data(),
+                                   context->argument(2).toString().toLatin1().data(),
+                                   context->argument(3).toString().toLatin1().data(),
+                                   context->argument(4).toString().toLatin1().data(),
+                                   context->argument(5).toString().toLatin1().data(),
+                                   context->argument(6).toString().toLatin1().data(),
+                                   context->argument(7).toString().toLatin1().data());
+  else if (context->argumentCount() == 7)
+    w = new VirtualClusterLineEdit(qscriptvalue_cast<QWidget*>(context->argument(0)),
+                                   context->argument(1).toString().toLatin1().data(),
+                                   context->argument(2).toString().toLatin1().data(),
+                                   context->argument(3).toString().toLatin1().data(),
+                                   context->argument(4).toString().toLatin1().data(),
+                                   context->argument(5).toString().toLatin1().data(),
+                                   context->argument(6).toString().toLatin1().data());
+  else
+    context->throwError(QScriptContext::UnknownError,
+                        QString("Could not find an appropriate VirtualClusterLineEdit constructor"));
+
+  return engine->toScriptValue(w);
+}
+
+QScriptValue constructVirtualCluster(QScriptContext *context,
+                                     QScriptEngine  *engine)
+{
+  VirtualCluster         *w = 0;
+  VirtualClusterLineEdit *l = 0;
+  
+  if (context->argumentCount() >= 2)
+    l = qscriptvalue_cast<VirtualClusterLineEdit*>(context->argument(1));
+
+  if (context->argumentCount() >= 3)
+    w = new VirtualCluster(qscriptvalue_cast<QWidget*>(context->argument(0)),
+                           l,
+                           context->argument(2).toString().toLatin1().data());
+  else if (context->argumentCount() == 2 && l)
+    w = new VirtualCluster(qscriptvalue_cast<QWidget*>(context->argument(0)),
+                           l);
+  else if (context->argumentCount() == 2 && ! l)
+    w = new VirtualCluster(qscriptvalue_cast<QWidget*>(context->argument(0)),
+                           context->argument(1).toString().toLatin1().data());
+  else if (context->argumentCount() == 1)
+    w = new VirtualCluster(qscriptvalue_cast<QWidget*>(context->argument(0)), "VirtualCluster");
+  else
+    context->throwError(QScriptContext::UnknownError,
+                        QString("Could not find an appropriate VirtualCluster constructor"));
+
+  return engine->toScriptValue(w);
+}
+
+void setupVirtualCluster(QScriptEngine *engine)
+{
+  if (! engine->globalObject().property("VirtualClusterLineEdit").isFunction())
+  {
+    QScriptValue ctor = engine->newFunction(constructVirtualClusterLineEdit);
+    QScriptValue meta = engine->newQMetaObject(&VirtualClusterLineEdit::staticMetaObject, ctor);
+    engine->globalObject().setProperty("VirtualClusterLineEdit", meta,
+                                       QScriptValue::ReadOnly | QScriptValue::Undeletable);
+
+    ctor = engine->newFunction(constructVirtualCluster);
+    meta = engine->newQMetaObject(&VirtualCluster::staticMetaObject, ctor);
+    engine->globalObject().setProperty("VirtualCluster", meta,
+                                       QScriptValue::ReadOnly | QScriptValue::Undeletable);
+  }
+}

--- a/widgets/virtualCluster.h
+++ b/widgets/virtualCluster.h
@@ -168,9 +168,15 @@ class XTUPLEWIDGETS_EXPORT VirtualClusterLineEdit : public XLineEdit
     friend class VirtualSearch;
 
     public:
-        VirtualClusterLineEdit(QWidget*, const char*, const char*, const char*,
-                               const char*, const char*, const char*,
-                               const char* = 0, const char* = 0);
+        VirtualClusterLineEdit(QWidget    *parent,
+                               const char *pTabName,
+                               const char *pIdColumn,
+                               const char *pNumberColumn,
+                               const char *pNameColumn,
+                               const char *pDescripColumn,
+                               const char *pExtra,
+                               const char *pName         = 0,
+                               const char *pActiveColumn = 0);
 
        void setMenu(QMenu *menu);
        QMenu *menu() const { return _menu; }
@@ -320,8 +326,8 @@ class XTUPLEWIDGETS_EXPORT VirtualCluster : public QWidget, public ScriptableWid
     friend class VirtualClusterLineEdit;
 
     public:
-        VirtualCluster(QWidget*, const char* = 0);
-        VirtualCluster(QWidget*, VirtualClusterLineEdit* = 0, const char* = 0);
+        VirtualCluster(QWidget *pParent, const char *pName = 0);
+        VirtualCluster(QWidget *pParent, VirtualClusterLineEdit *pNumberWidget = 0, const char *pName = 0);
 
         Q_INVOKABLE virtual int     id()             const;
                     virtual QString label()          const;
@@ -397,5 +403,7 @@ class XTUPLEWIDGETS_EXPORT VirtualCluster : public QWidget, public ScriptableWid
     private:
         virtual void init();
 };
+
+void setupVirtualCluster(QScriptEngine *engine);
 
 #endif

--- a/widgets/widgets.cpp
+++ b/widgets/widgets.cpp
@@ -235,6 +235,7 @@ void setupWidgetsScriptApi(QScriptEngine *engine, GuiClientInterface *client)
   setupUsernameCluster(engine);
   setupUsernameLineEdit(engine);
   setupVendorGroup(engine);
+  setupVirtualCluster(engine);
   setupWComboBox(engine);
   setupWoCluster(engine);
   setupWomatlCluster(engine);


### PR DESCRIPTION
Note that to create a useful VirtualCluster you must first create a VirtualClusterLineEdit:
```javascript
// a dumb example
var charle, charcluster;
_charle = new VirtualClusterLineEdit(mywindow, "char", "char_id",
                                     "char_name", "char_mask", "char_notes",
                                     "length(char_name) < 15", "_charle");
_charcluster = new VirtualCluster(mywindow, _charle, "_charcluster");
_layout.addWidget(_charcluster, 2, 0);
```