### PR TITLE
Issue #30138: Metricsenc.set() could not access _key through protected _set.

### DIFF
--- a/common/metricsenc.cpp
+++ b/common/metricsenc.cpp
@@ -58,6 +58,7 @@ void Parametersenc::_set(const QString &pName, QVariant pValue)
 Metricsenc::Metricsenc(const QString &pKey, QObject *parent)
   : Parametersenc(pKey, parent)
 {
+  _notifyName = "metricsencUpdated";
   _readSql = "SELECT metricenc_name AS key,"
              "       decrypt(setbytea(metricenc_value), setbytea(:key), 'bf') AS value"
              "  FROM metricenc;";


### PR DESCRIPTION
@gilmoskowitz 
I noticed that `load()` has the `_key`, but `set()` doesn't.
```
SELECT setMetricEnc('CCLogin', 'asdf', NULL);
SELECT setMetricEnc('CCPassword', 'asdf', NULL);
SELECT setMetricEnc('CCProxyLogin', 'asdf', NULL);
SELECT setMetricEnc('CCProxyPassword', 'asdf', NULL);
SELECT setMetricEnc('CCYPStoreNum', 'asdf', NULL);
SELECT setMetricEnc('CCPTDivisionNumber', 'asdf', NULL);
```
When `Metricsenc::set()` is called, it's calling the parent `Parameters::set()`, which then calls `Parameters::_set()`, not the child's  `Parametersenc::_set()` because it's `protected` and the parent doesn't have access to it or the `_key`.

I _think_ this will work, but there might be a better solution.