### PR TITLE
issue #30363 - fix empty voucher documents tab

### DIFF
--- a/guiclient/voucher.ui
+++ b/guiclient/voucher.ui
@@ -972,7 +972,7 @@ to be bound by its terms.</comment>
        <item>
         <widget class="Documents" name="_documents">
          <property name="type">
-          <number>0</number>
+          <enum>Documents::Voucher</enum>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
this fixes a recent inadvertent change to the voucher window.
manifestation: documents attached to a voucher in previous versions
are not visible, while documents attached to a voucher in versions
with this bug are stored incorrectly (empty source type)