### PR TITLE
Allow AR/AP Aging to process parameterWidget params

### DIFF
--- a/guiclient/displays/dspTimePhasedOpenAPItems.cpp
+++ b/guiclient/displays/dspTimePhasedOpenAPItems.cpp
@@ -56,6 +56,9 @@ dspTimePhasedOpenAPItems::~dspTimePhasedOpenAPItems()
 
 bool dspTimePhasedOpenAPItems::setParams(ParameterList &params)
 {
+  if (!display::setParams(params))
+    return false;
+
   if ((_custom->isChecked() && ! _periods->isPeriodSelected()) ||
       (!_custom->isChecked() && ! _asOf->isValid()))
   {

--- a/guiclient/displays/dspTimePhasedOpenAPItems.h
+++ b/guiclient/displays/dspTimePhasedOpenAPItems.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -34,7 +34,7 @@ public slots:
     virtual void sToggleReport();
 
 protected slots:
-    virtual bool setParams(ParameterList &);
+    Q_INVOKABLE virtual bool setParams(ParameterList &);
 
 private:
     int _column;

--- a/guiclient/displays/dspTimePhasedOpenARItems.cpp
+++ b/guiclient/displays/dspTimePhasedOpenARItems.cpp
@@ -59,6 +59,9 @@ dspTimePhasedOpenARItems::~dspTimePhasedOpenARItems()
 
 bool dspTimePhasedOpenARItems::setParams(ParameterList &params)
 {
+  if (!display::setParams(params))
+    return false;
+
   if ((_custom->isChecked() && ! _periods->isPeriodSelected()) ||
       (!_custom->isChecked() && !_asOf->isValid()))
   {

--- a/guiclient/displays/dspTimePhasedOpenARItems.h
+++ b/guiclient/displays/dspTimePhasedOpenARItems.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -25,7 +25,7 @@ public:
     dspTimePhasedOpenARItems(QWidget* parent = 0, const char* name = 0, Qt::WindowFlags fl = Qt::Window);
     ~dspTimePhasedOpenARItems();
 
-    virtual bool setParams(ParameterList &);
+    Q_INVOKABLE virtual bool setParams(ParameterList &);
 
 public slots:
     virtual void sViewOpenItems();


### PR DESCRIPTION
Allows scripts to activate the parameterWidget() and pass these to metaSQL