### PR TITLE
issue #22868 - remove LAST of remaining distribution locking (printMulticopyDocument.cpp)

### DIFF
--- a/guiclient/printCreditMemo.cpp
+++ b/guiclient/printCreditMemo.cpp
@@ -43,7 +43,7 @@ printCreditMemo::printCreditMemo(QWidget* parent, const char* name, bool modal, 
                        "   SET cmhead_printed=true "
                        " WHERE (cmhead_id=<? value('docid') ?>);" ;
   _postFunction = "postCreditMemo";
-  _postQuery    = "SELECT postCreditMemo(<? value('docid') ?>, 0) AS result;" ;
+  _postQuery    = "SELECT postCreditMemo(<? value('docid') ?>, fetchJournalNumber('AR-CM'), <? value('itemlocSeries') ?>, true) AS result;";
 
   connect(this, SIGNAL(docUpdated(int)),       this, SLOT(sHandleDocUpdated(int)));
   connect(this, SIGNAL(populated(XSqlQuery*)), this, SLOT(sHandlePopulated(XSqlQuery*)));
@@ -73,59 +73,56 @@ void printCreditMemo::sHandleDocUpdated(int docid)
   omfgThis->sCreditMemosUpdated();
 }
 
-bool printCreditMemo::distributeInventory(XSqlQuery *qry)
+int printCreditMemo::distributeInventory(XSqlQuery *qry)
 {
-  if (qry)
+  int creditMemoId = qry->value("docid").toInt();
+  int itemlocSeries = distributeInventory::SeriesCreate(0, 0, QString(), QString());
+  if (itemlocSeries < 0)
+    return -1;
+
+  XSqlQuery cleanup; // Stage cleanup function to be called on error
+  cleanup.prepare("SELECT deleteitemlocseries(:itemlocSeries, TRUE);");
+  cleanup.bindValue(":itemlocSeries", itemlocSeries);
+  
+  // Cycle through credit memo items that are controlled and have qty returned, create an itemlocdist record for each
+  bool hasControlledItems = false;
+  XSqlQuery cmitems;
+  cmitems.prepare("SELECT itemsite_id, item_number, "
+                    " SUM(cmitem_qtyreturned * cmitem_qty_invuomratio) AS qty "
+                    "FROM cmhead JOIN cmitem ON cmitem_cmhead_id=cmhead_id "
+                    " JOIN itemsite ON itemsite_id=cmitem_itemsite_id "
+                    " JOIN item ON item_id=itemsite_item_id "
+                    " JOIN costcat ON costcat_id=itemsite_costcat_id "
+                    "WHERE cmhead_id=:cmheadId "
+                    " AND cmitem_qtyreturned <> 0 "
+                    " AND cmitem_updateinv "
+                    " AND isControlledItemsite(itemsite_id) "
+                    " AND itemsite_costmethod != 'J' "
+                    "GROUP BY itemsite_id, item_number "
+                    "ORDER BY itemsite_id;");
+  cmitems.bindValue(":cmheadId", creditMemoId);
+  cmitems.exec();
+  while (cmitems.next())
   {
-    int creditMemoId = qry->value("docid").toInt();
-    int itemlocSeries = distributeInventory::SeriesCreate(0, 0, QString(), QString());
-    if (itemlocSeries < 0)
-      return false;
-
-    XSqlQuery cleanup; // Stage cleanup function to be called on error
-    cleanup.prepare("SELECT deleteitemlocseries(:itemlocSeries, TRUE);");
-    cleanup.bindValue(":itemlocSeries", itemlocSeries);
-    
-    // Cycle through credit memo items that are controlled and have qty returned, create an itemlocdist record for each
-    bool hasControlledItems = false;
-    XSqlQuery cmitems;
-    cmitems.prepare("SELECT itemsite_id, item_number, "
-                      " SUM(cmitem_qtyreturned * cmitem_qty_invuomratio) AS qty "
-                      "FROM cmhead JOIN cmitem ON cmitem_cmhead_id=cmhead_id "
-                      " JOIN itemsite ON itemsite_id=cmitem_itemsite_id "
-                      " JOIN item ON item_id=itemsite_item_id "
-                      " JOIN costcat ON costcat_id=itemsite_costcat_id "
-                      "WHERE cmhead_id=:cmheadId "
-                      " AND cmitem_qtyreturned <> 0 "
-                      " AND cmitem_updateinv "
-                      " AND isControlledItemsite(itemsite_id) "
-                      " AND itemsite_costmethod != 'J' "
-                      "GROUP BY itemsite_id, item_number "
-                      "ORDER BY itemsite_id;");
-    cmitems.bindValue(":cmheadId", creditMemoId);
-    cmitems.exec();
-    while (cmitems.next())
-    {
-      if (distributeInventory::SeriesCreate(cmitems.value("itemsite_id").toInt(), 
-        cmitems.value("qty").toDouble(), "CM", "RS", cmitems.value("cmitem_id").toInt(), itemlocSeries) < 0)
-      {
-        cleanup.exec();
-        return false;
-      }
-      
-      hasControlledItems = true;
-    }
-
-    // Distribute detail for the records created above
-    if (hasControlledItems && distributeInventory::SeriesAdjust(itemlocSeries, this, QString(), QDate(),
-      QDate(), true) == XDialog::Rejected)
+    if (distributeInventory::SeriesCreate(cmitems.value("itemsite_id").toInt(), 
+      cmitems.value("qty").toDouble(), "CM", "RS", cmitems.value("cmitem_id").toInt(), itemlocSeries) < 0)
     {
       cleanup.exec();
-      QMessageBox::information( this, tr("Print Credit Memo"), tr("Detail Distribution was Cancelled") );
-      return false;
+      return -1;
     }
-
-    return true;
+    
+    hasControlledItems = true;
   }
+
+  // Distribute detail for the records created above
+  if (hasControlledItems && distributeInventory::SeriesAdjust(itemlocSeries, this, QString(), QDate(),
+    QDate(), true) == XDialog::Rejected)
+  {
+    cleanup.exec();
+    QMessageBox::information( this, tr("Print Credit Memo"), tr("Detail Distribution was Cancelled") );
+    return -1;
+  }
+
+  return itemlocSeries;
 }
 

--- a/guiclient/printCreditMemo.cpp
+++ b/guiclient/printCreditMemo.cpp
@@ -13,6 +13,9 @@
 #include <QDebug>
 #include <QSqlRecord>
 #include <QVariant>
+#include <QMessageBox>
+
+#include "errorReporter.h"
 
 printCreditMemo::printCreditMemo(QWidget* parent, const char* name, bool modal, Qt::WindowFlags fl)
     : printMulticopyDocument("CreditMemoCopies",     "CreditMemoWatermark",
@@ -69,3 +72,60 @@ void printCreditMemo::sHandleDocUpdated(int docid)
   Q_UNUSED(docid);
   omfgThis->sCreditMemosUpdated();
 }
+
+bool printCreditMemo::distributeInventory(XSqlQuery *qry)
+{
+  if (qry)
+  {
+    int creditMemoId = qry->value("docid").toInt();
+    int itemlocSeries = distributeInventory::SeriesCreate(0, 0, QString(), QString());
+    if (itemlocSeries < 0)
+      return false;
+
+    XSqlQuery cleanup; // Stage cleanup function to be called on error
+    cleanup.prepare("SELECT deleteitemlocseries(:itemlocSeries, TRUE);");
+    cleanup.bindValue(":itemlocSeries", itemlocSeries);
+    
+    // Cycle through credit memo items that are controlled and have qty returned, create an itemlocdist record for each
+    bool hasControlledItems = false;
+    XSqlQuery cmitems;
+    cmitems.prepare("SELECT itemsite_id, item_number, "
+                      " SUM(cmitem_qtyreturned * cmitem_qty_invuomratio) AS qty "
+                      "FROM cmhead JOIN cmitem ON cmitem_cmhead_id=cmhead_id "
+                      " JOIN itemsite ON itemsite_id=cmitem_itemsite_id "
+                      " JOIN item ON item_id=itemsite_item_id "
+                      " JOIN costcat ON costcat_id=itemsite_costcat_id "
+                      "WHERE cmhead_id=:cmheadId "
+                      " AND cmitem_qtyreturned <> 0 "
+                      " AND cmitem_updateinv "
+                      " AND isControlledItemsite(itemsite_id) "
+                      " AND itemsite_costmethod != 'J' "
+                      "GROUP BY itemsite_id, item_number "
+                      "ORDER BY itemsite_id;");
+    cmitems.bindValue(":cmheadId", creditMemoId);
+    cmitems.exec();
+    while (cmitems.next())
+    {
+      if (distributeInventory::SeriesCreate(cmitems.value("itemsite_id").toInt(), 
+        cmitems.value("qty").toDouble(), "CM", "RS", cmitems.value("cmitem_id").toInt(), itemlocSeries) < 0)
+      {
+        cleanup.exec();
+        return false;
+      }
+      
+      hasControlledItems = true;
+    }
+
+    // Distribute detail for the records created above
+    if (hasControlledItems && distributeInventory::SeriesAdjust(itemlocSeries, this, QString(), QDate(),
+      QDate(), true) == XDialog::Rejected)
+    {
+      cleanup.exec();
+      QMessageBox::information( this, tr("Print Credit Memo"), tr("Detail Distribution was Cancelled") );
+      return false;
+    }
+
+    return true;
+  }
+}
+

--- a/guiclient/printCreditMemo.h
+++ b/guiclient/printCreditMemo.h
@@ -23,7 +23,7 @@ class printCreditMemo : public printMulticopyDocument,
     printCreditMemo(QWidget* parent = 0, const char* name = 0, bool modal = false, Qt::WindowFlags fl = 0);
     ~printCreditMemo();
 
-    Q_INVOKABLE virtual bool distributeInventory(XSqlQuery *qry);
+    Q_INVOKABLE virtual int distributeInventory(XSqlQuery *qry);
 
   protected slots:
     virtual void languageChange();

--- a/guiclient/printCreditMemo.h
+++ b/guiclient/printCreditMemo.h
@@ -23,6 +23,8 @@ class printCreditMemo : public printMulticopyDocument,
     printCreditMemo(QWidget* parent = 0, const char* name = 0, bool modal = false, Qt::WindowFlags fl = 0);
     ~printCreditMemo();
 
+    Q_INVOKABLE virtual bool distributeInventory(XSqlQuery *qry);
+
   protected slots:
     virtual void languageChange();
     virtual void sHandleDocUpdated(int docid);

--- a/guiclient/printCreditMemos.cpp
+++ b/guiclient/printCreditMemos.cpp
@@ -53,7 +53,7 @@ printCreditMemos::printCreditMemos(QWidget* parent, const char* name, bool modal
                        ");" ;
               
   _postFunction = "postCreditMemo";
-  _postQuery    = "SELECT postCreditMemo(<? value('docid') ?>, 0) AS result;" ;
+  _postQuery    = "SELECT postCreditMemo(<? value('docid') ?>, fetchJournalNumber('AR-CM'), <? value('itemlocSeries') ?>, true) AS result;";
 
   connect(this, SIGNAL(finishedWithAll()), this, SLOT(sHandleFinishedWithAll()));
 }
@@ -74,58 +74,55 @@ void printCreditMemos::sHandleFinishedWithAll()
   this->close();
 }
 
-bool printCreditMemos::distributeInventory(XSqlQuery *qry)
+int printCreditMemos::distributeInventory(XSqlQuery *qry)
 {
-  if (qry)
+  int creditMemoId = qry->value("docid").toInt();
+  int itemlocSeries = distributeInventory::SeriesCreate(0, 0, QString(), QString());
+  if (itemlocSeries < 0)
+    return -1;
+
+  XSqlQuery cleanup; // Stage cleanup function to be called on error
+  cleanup.prepare("SELECT deleteitemlocseries(:itemlocSeries, TRUE);");
+  cleanup.bindValue(":itemlocSeries", itemlocSeries);
+  
+  // Cycle through credit memo items that are controlled and have qty returned, create an itemlocdist record for each
+  bool hasControlledItems = false;
+  XSqlQuery cmitems;
+  cmitems.prepare("SELECT itemsite_id, item_number, "
+                    " SUM(cmitem_qtyreturned * cmitem_qty_invuomratio) AS qty "
+                    "FROM cmhead JOIN cmitem ON cmitem_cmhead_id=cmhead_id "
+                    " JOIN itemsite ON itemsite_id=cmitem_itemsite_id "
+                    " JOIN item ON item_id=itemsite_item_id "
+                    " JOIN costcat ON costcat_id=itemsite_costcat_id "
+                    "WHERE cmhead_id=:cmheadId "
+                    " AND cmitem_qtyreturned <> 0 "
+                    " AND cmitem_updateinv "
+                    " AND isControlledItemsite(itemsite_id) "
+                    " AND itemsite_costmethod != 'J' "
+                    "GROUP BY itemsite_id, item_number "
+                    "ORDER BY itemsite_id;");
+  cmitems.bindValue(":cmheadId", creditMemoId);
+  cmitems.exec();
+  while (cmitems.next())
   {
-    int creditMemoId = qry->value("docid").toInt();
-    int itemlocSeries = distributeInventory::SeriesCreate(0, 0, QString(), QString());
-    if (itemlocSeries < 0)
-      return false;
-
-    XSqlQuery cleanup; // Stage cleanup function to be called on error
-    cleanup.prepare("SELECT deleteitemlocseries(:itemlocSeries, TRUE);");
-    cleanup.bindValue(":itemlocSeries", itemlocSeries);
-    
-    // Cycle through credit memo items that are controlled and have qty returned, create an itemlocdist record for each
-    bool hasControlledItems = false;
-    XSqlQuery cmitems;
-    cmitems.prepare("SELECT itemsite_id, item_number, "
-                      " SUM(cmitem_qtyreturned * cmitem_qty_invuomratio) AS qty "
-                      "FROM cmhead JOIN cmitem ON cmitem_cmhead_id=cmhead_id "
-                      " JOIN itemsite ON itemsite_id=cmitem_itemsite_id "
-                      " JOIN item ON item_id=itemsite_item_id "
-                      " JOIN costcat ON costcat_id=itemsite_costcat_id "
-                      "WHERE cmhead_id=:cmheadId "
-                      " AND cmitem_qtyreturned <> 0 "
-                      " AND cmitem_updateinv "
-                      " AND isControlledItemsite(itemsite_id) "
-                      " AND itemsite_costmethod != 'J' "
-                      "GROUP BY itemsite_id, item_number "
-                      "ORDER BY itemsite_id;");
-    cmitems.bindValue(":cmheadId", creditMemoId);
-    cmitems.exec();
-    while (cmitems.next())
-    {
-      if (distributeInventory::SeriesCreate(cmitems.value("itemsite_id").toInt(), 
-        cmitems.value("qty").toDouble(), "CM", "RS", cmitems.value("cmitem_id").toInt(), itemlocSeries) < 0)
-      {
-        cleanup.exec();
-        return false;
-      }
-      
-      hasControlledItems = true;
-    }
-
-    // Distribute detail for the records created above
-    if (hasControlledItems && distributeInventory::SeriesAdjust(itemlocSeries, this, QString(), QDate(),
-      QDate(), true) == XDialog::Rejected)
+    if (distributeInventory::SeriesCreate(cmitems.value("itemsite_id").toInt(), 
+      cmitems.value("qty").toDouble(), "CM", "RS", cmitems.value("cmitem_id").toInt(), itemlocSeries) < 0)
     {
       cleanup.exec();
-      QMessageBox::information( this, tr("Print Credit Memos"), tr("Detail Distribution was Cancelled") );
-      return false;
+      return -1;
     }
-
-    return true;
+    
+    hasControlledItems = true;
   }
+
+  // Distribute detail for the records created above
+  if (hasControlledItems && distributeInventory::SeriesAdjust(itemlocSeries, this, QString(), QDate(),
+    QDate(), true) == XDialog::Rejected)
+  {
+    cleanup.exec();
+    QMessageBox::information( this, tr("Print Credit Memos"), tr("Detail Distribution was Cancelled") );
+    return -1;
+  }
+
+  return itemlocSeries;
 }

--- a/guiclient/printCreditMemos.h
+++ b/guiclient/printCreditMemos.h
@@ -23,7 +23,7 @@ class printCreditMemos : public printMulticopyDocument,
     printCreditMemos(QWidget* parent = 0, const char* name = 0, bool modal = false, Qt::WindowFlags fl = 0);
     ~printCreditMemos();
 
-    Q_INVOKABLE virtual bool distributeInventory(XSqlQuery *qry);
+    Q_INVOKABLE virtual int distributeInventory(XSqlQuery *qry);
 
   protected slots:
     virtual void languageChange();

--- a/guiclient/printCreditMemos.h
+++ b/guiclient/printCreditMemos.h
@@ -23,6 +23,8 @@ class printCreditMemos : public printMulticopyDocument,
     printCreditMemos(QWidget* parent = 0, const char* name = 0, bool modal = false, Qt::WindowFlags fl = 0);
     ~printCreditMemos();
 
+    Q_INVOKABLE virtual bool distributeInventory(XSqlQuery *qry);
+
   protected slots:
     virtual void languageChange();
     virtual void sHandleFinishedWithAll();

--- a/guiclient/printInvoice.cpp
+++ b/guiclient/printInvoice.cpp
@@ -10,8 +10,10 @@
 
 #include "printInvoice.h"
 
+#include "distributeInventory.h"
 #include <QSqlRecord>
 #include <QVariant>
+#include <QMessageBox>
 
 printInvoice::printInvoice(QWidget *parent, const char *name, bool modal, Qt::WindowFlags fl)
     : printMulticopyDocument("InvoiceCopies",     "InvoiceWatermark",
@@ -80,4 +82,68 @@ void printInvoice::sHandlePopulated(XSqlQuery *qry)
 void printInvoice::sHandleDocUpdated(int docid)
 {
   omfgThis->sInvoicesUpdated(docid, true);
+}
+
+bool printInvoice::distributeInventory(XSqlQuery *qry)
+{
+  if (qry)
+  {
+    int invoiceId = qry->value("docid").toInt();
+
+    // Set the series for this invoice
+    int itemlocSeries = distributeInventory::SeriesCreate(0, 0, QString(), QString());
+    if (itemlocSeries < 0)
+      return false;
+
+    XSqlQuery cleanup; // Stage cleanup function to be called on error
+    cleanup.prepare("SELECT deleteitemlocseries(:itemlocSeries, TRUE);");
+    cleanup.bindValue(":itemlocSeries", itemlocSeries);
+
+    bool hasControlledItems = false;
+
+    // Handle the Inventory and G/L Transactions for any billed Inventory where invcitem_updateinv is true
+    XSqlQuery items;
+    items.prepare("SELECT item_number, itemsite_id, invcitem_id, "
+                  " (invcitem_billed * invcitem_qty_invuomratio) * -1 AS qty, "
+                  " invchead_invcnumber "
+                  "FROM invchead " 
+                  " JOIN invcitem ON invcitem_invchead_id = invchead_id "
+                  "   AND invcitem_billed <> 0 " 
+                  "   AND invcitem_updateinv "
+                  " JOIN itemsite ON itemsite_item_id = invcitem_item_id " 
+                  "   AND itemsite_warehous_id = invcitem_warehous_id "
+                  " JOIN item ON item_id = invcitem_item_id "
+                  "WHERE invchead_id = :invchead_id "
+                  " AND itemsite_costmethod != 'J' "
+                  " AND (itemsite_loccntrl OR itemsite_controlmethod IN ('L', 'S')) "
+                  " AND itemsite_controlmethod != 'N' "
+                  "ORDER BY invcitem_id;");
+    items.bindValue(":invchead_id", invoiceId);
+    items.exec();
+    while (items.next())
+    {
+      int result = distributeInventory::SeriesCreate(items.value("itemsite_id").toInt(), 
+        items.value("qty").toDouble(), "IN", "SH", items.value("invcitem_id").toInt(), itemlocSeries);
+      if (result < 0)
+      {
+        cleanup.exec();
+        return false;
+      }
+      else if (itemlocSeries == 0) // The first time through the loop, set itemlocSeries
+        itemlocSeries = result;
+
+      hasControlledItems = true;
+    }
+
+    // Distribute the items from above
+    if (hasControlledItems && distributeInventory::SeriesAdjust(itemlocSeries, this, QString(), QDate(), QDate(), true)
+      == XDialog::Rejected)
+    {
+      cleanup.exec();
+      QMessageBox::information( this, tr("Print Invoice"), tr("Detail Distribution was Cancelled") );
+      return false;
+    }
+
+    return true;
+  }
 }

--- a/guiclient/printInvoice.cpp
+++ b/guiclient/printInvoice.cpp
@@ -55,7 +55,7 @@ printInvoice::printInvoice(QWidget *parent, const char *name, bool modal, Qt::Wi
                        " WHERE (invchead_id=<? value('docid') ?>);" ;
 
   _postFunction = "postInvoice";
-  _postQuery = "SELECT postInvoice(<? value('docid') ?>) AS result;" ;
+  _postQuery = "SELECT postInvoice(<? value('docid') ?>, fetchJournalNumber('AR-IN'), <? value('itemlocSeries') ?>, true) AS result;" ;
 
   connect(this, SIGNAL(docUpdated(int)),       this, SLOT(sHandleDocUpdated(int)));
   connect(this, SIGNAL(populated(XSqlQuery*)), this, SLOT(sHandlePopulated(XSqlQuery*)));
@@ -84,66 +84,61 @@ void printInvoice::sHandleDocUpdated(int docid)
   omfgThis->sInvoicesUpdated(docid, true);
 }
 
-bool printInvoice::distributeInventory(XSqlQuery *qry)
+int printInvoice::distributeInventory(XSqlQuery *qry)
 {
-  if (qry)
+  int invoiceId = qry->value("docid").toInt();
+
+  // Set the series for this invoice
+  int itemlocSeries = distributeInventory::SeriesCreate(0, 0, QString(), QString());
+  if (itemlocSeries < 0)
+    return -1;
+
+  XSqlQuery cleanup; // Stage cleanup function to be called on error
+  cleanup.prepare("SELECT deleteitemlocseries(:itemlocSeries, TRUE);");
+  cleanup.bindValue(":itemlocSeries", itemlocSeries);
+
+  bool hasControlledItems = false;
+
+  // Handle the Inventory and G/L Transactions for any billed Inventory where invcitem_updateinv is true
+  XSqlQuery items;
+  items.prepare("SELECT item_number, itemsite_id, invcitem_id, "
+                " (invcitem_billed * invcitem_qty_invuomratio) * -1 AS qty, "
+                " invchead_invcnumber "
+                "FROM invchead " 
+                " JOIN invcitem ON invcitem_invchead_id = invchead_id "
+                "   AND invcitem_billed <> 0 " 
+                "   AND invcitem_updateinv "
+                " JOIN itemsite ON itemsite_item_id = invcitem_item_id " 
+                "   AND itemsite_warehous_id = invcitem_warehous_id "
+                " JOIN item ON item_id = invcitem_item_id "
+                "WHERE invchead_id = :invchead_id "
+                " AND itemsite_costmethod != 'J' "
+                " AND (itemsite_loccntrl OR itemsite_controlmethod IN ('L', 'S')) "
+                " AND itemsite_controlmethod != 'N' "
+                "ORDER BY invcitem_id;");
+  items.bindValue(":invchead_id", invoiceId);
+  items.exec();
+  while (items.next())
   {
-    int invoiceId = qry->value("docid").toInt();
-
-    // Set the series for this invoice
-    int itemlocSeries = distributeInventory::SeriesCreate(0, 0, QString(), QString());
-    if (itemlocSeries < 0)
-      return false;
-
-    XSqlQuery cleanup; // Stage cleanup function to be called on error
-    cleanup.prepare("SELECT deleteitemlocseries(:itemlocSeries, TRUE);");
-    cleanup.bindValue(":itemlocSeries", itemlocSeries);
-
-    bool hasControlledItems = false;
-
-    // Handle the Inventory and G/L Transactions for any billed Inventory where invcitem_updateinv is true
-    XSqlQuery items;
-    items.prepare("SELECT item_number, itemsite_id, invcitem_id, "
-                  " (invcitem_billed * invcitem_qty_invuomratio) * -1 AS qty, "
-                  " invchead_invcnumber "
-                  "FROM invchead " 
-                  " JOIN invcitem ON invcitem_invchead_id = invchead_id "
-                  "   AND invcitem_billed <> 0 " 
-                  "   AND invcitem_updateinv "
-                  " JOIN itemsite ON itemsite_item_id = invcitem_item_id " 
-                  "   AND itemsite_warehous_id = invcitem_warehous_id "
-                  " JOIN item ON item_id = invcitem_item_id "
-                  "WHERE invchead_id = :invchead_id "
-                  " AND itemsite_costmethod != 'J' "
-                  " AND (itemsite_loccntrl OR itemsite_controlmethod IN ('L', 'S')) "
-                  " AND itemsite_controlmethod != 'N' "
-                  "ORDER BY invcitem_id;");
-    items.bindValue(":invchead_id", invoiceId);
-    items.exec();
-    while (items.next())
-    {
-      int result = distributeInventory::SeriesCreate(items.value("itemsite_id").toInt(), 
-        items.value("qty").toDouble(), "IN", "SH", items.value("invcitem_id").toInt(), itemlocSeries);
-      if (result < 0)
-      {
-        cleanup.exec();
-        return false;
-      }
-      else if (itemlocSeries == 0) // The first time through the loop, set itemlocSeries
-        itemlocSeries = result;
-
-      hasControlledItems = true;
-    }
-
-    // Distribute the items from above
-    if (hasControlledItems && distributeInventory::SeriesAdjust(itemlocSeries, this, QString(), QDate(), QDate(), true)
-      == XDialog::Rejected)
+    int result = distributeInventory::SeriesCreate(items.value("itemsite_id").toInt(), 
+      items.value("qty").toDouble(), "IN", "SH", items.value("invcitem_id").toInt(), itemlocSeries);
+    if (result < 0)
     {
       cleanup.exec();
-      QMessageBox::information( this, tr("Print Invoice"), tr("Detail Distribution was Cancelled") );
-      return false;
+      return -1;
     }
-
-    return true;
+    
+    hasControlledItems = true;
   }
+
+  // Distribute the items from above
+  if (hasControlledItems && distributeInventory::SeriesAdjust(itemlocSeries, this, QString(), QDate(), QDate(), true)
+    == XDialog::Rejected)
+  {
+    cleanup.exec();
+    QMessageBox::information( this, tr("Print Invoice"), tr("Detail Distribution was Cancelled") );
+    return -1;
+  }
+
+  return itemlocSeries;
 }

--- a/guiclient/printInvoice.h
+++ b/guiclient/printInvoice.h
@@ -23,7 +23,7 @@ class printInvoice : public printMulticopyDocument,
     printInvoice(QWidget *parent = 0, const char *name = 0, bool modal = false, Qt::WindowFlags fl = 0);
     ~printInvoice();
 
-    Q_INVOKABLE virtual bool distributeInventory(XSqlQuery *qry);
+    Q_INVOKABLE virtual int distributeInventory(XSqlQuery *qry);
 
   protected slots:
     virtual void languageChange();

--- a/guiclient/printInvoice.h
+++ b/guiclient/printInvoice.h
@@ -23,6 +23,8 @@ class printInvoice : public printMulticopyDocument,
     printInvoice(QWidget *parent = 0, const char *name = 0, bool modal = false, Qt::WindowFlags fl = 0);
     ~printInvoice();
 
+    Q_INVOKABLE virtual bool distributeInventory(XSqlQuery *qry);
+
   protected slots:
     virtual void languageChange();
     virtual void sHandlePopulated(XSqlQuery *qry);

--- a/guiclient/printInvoices.cpp
+++ b/guiclient/printInvoices.cpp
@@ -183,7 +183,7 @@ int printInvoices::distributeInventory(XSqlQuery *qry)
     == XDialog::Rejected)
   {
     cleanup.exec();
-    QMessageBox::information( this, tr("Print Invoice"), tr("Detail Distribution was Cancelled") );
+    QMessageBox::information( this, tr("Print Invoices"), tr("Detail Distribution was Cancelled") );
     return -1;
   }
 

--- a/guiclient/printInvoices.h
+++ b/guiclient/printInvoices.h
@@ -25,6 +25,7 @@ class printInvoices : public printMulticopyDocument,
 
     Q_INVOKABLE virtual ParameterList getParamsDocList();
     Q_INVOKABLE virtual ParameterList getParamsOneCopy(const int row, XSqlQuery *qry);
+    Q_INVOKABLE virtual bool distributeInventory(XSqlQuery *qry);
 
   protected slots:
     virtual void languageChange();

--- a/guiclient/printInvoices.h
+++ b/guiclient/printInvoices.h
@@ -25,7 +25,7 @@ class printInvoices : public printMulticopyDocument,
 
     Q_INVOKABLE virtual ParameterList getParamsDocList();
     Q_INVOKABLE virtual ParameterList getParamsOneCopy(const int row, XSqlQuery *qry);
-    Q_INVOKABLE virtual bool distributeInventory(XSqlQuery *qry);
+    Q_INVOKABLE virtual int distributeInventory(XSqlQuery *qry);
 
   protected slots:
     virtual void languageChange();

--- a/guiclient/printMulticopyDocument.cpp
+++ b/guiclient/printMulticopyDocument.cpp
@@ -335,7 +335,8 @@ void printMulticopyDocument::sPrint()
 
     // This indirection allows scripts to replace core behavior - 14285
     emit aboutToStart(&docinfoq);
-
+    emit timeToPrintOneDoc(&docinfoq);
+    emit timeToMarkOnePrinted(&docinfoq);
 
     // Distribute inventory detail
     int itemlocSeries = 0;
@@ -346,9 +347,7 @@ void printMulticopyDocument::sPrint()
       if (itemlocSeries <= 0)
         return;
     }
-
-    emit timeToPrintOneDoc(&docinfoq);
-    emit timeToMarkOnePrinted(&docinfoq);
+    
     emit timeToPostOneDoc(&docinfoq, itemlocSeries);
 
     message("");

--- a/guiclient/printMulticopyDocument.cpp
+++ b/guiclient/printMulticopyDocument.cpp
@@ -78,8 +78,8 @@ printMulticopyDocument::printMulticopyDocument(QWidget    *parent,
           this, SLOT(sPrintOneDoc(XSqlQuery*)));
   connect(this, SIGNAL(timeToMarkOnePrinted(XSqlQuery*)),
           this, SLOT(sMarkOnePrinted(XSqlQuery*)));
-  connect(this, SIGNAL(timeToPostOneDoc(XSqlQuery*)),
-          this, SLOT(sPostOneDoc(XSqlQuery*)));
+  connect(this, SIGNAL(timeToPostOneDoc(XSqlQuery*, int)),
+          this, SLOT(sPostOneDoc(XSqlQuery*, int)));
 
   _distributeInventory = false;
 }
@@ -107,8 +107,8 @@ printMulticopyDocument::printMulticopyDocument(QString numCopiesMetric,
           this, SLOT(sPrintOneDoc(XSqlQuery*)));
   connect(this, SIGNAL(timeToMarkOnePrinted(XSqlQuery*)),
           this, SLOT(sMarkOnePrinted(XSqlQuery*)));
-  connect(this, SIGNAL(timeToPostOneDoc(XSqlQuery*)),
-          this, SLOT(sPostOneDoc(XSqlQuery*)));
+  connect(this, SIGNAL(timeToPostOneDoc(XSqlQuery*, int)),
+          this, SLOT(sPostOneDoc(XSqlQuery*, int)));
 
   _distributeInventory = false;
 
@@ -208,7 +208,7 @@ bool printMulticopyDocument::sMarkOnePrinted(XSqlQuery *docq)
   return wasMarked;
 }
 
-bool printMulticopyDocument::sPostOneDoc(XSqlQuery *docq)
+bool printMulticopyDocument::sPostOneDoc(XSqlQuery *docq, int itemlocSeries)
 {
   if (! _postQuery.isEmpty()    &&
       _data->_post->isChecked() &&
@@ -222,6 +222,13 @@ bool printMulticopyDocument::sPostOneDoc(XSqlQuery *docq)
     postp.append("docid",     docq->value("docid"));
     postp.append("docnumber", docq->value("docnumber"));
 
+    XSqlQuery cleanup; // Stage cleanup function to be called on error
+    cleanup.prepare("SELECT deleteitemlocseries(:itemlocSeries, TRUE);");
+    cleanup.bindValue(":itemlocSeries", itemlocSeries);
+  
+    if (itemlocSeries > 0)
+      postp.append("itemlocSeries", itemlocSeries);
+
     if (! _askBeforePostingQry.isEmpty())
     {
       MetaSQLQuery askm(_askBeforePostingQry);
@@ -229,14 +236,21 @@ bool printMulticopyDocument::sPostOneDoc(XSqlQuery *docq)
       if (ErrorReporter::error(QtCriticalMsg, this,
                                tr("Cannot Post %1").arg(docnumber),
                                askq, __FILE__, __LINE__))
+      {
+        cleanup.exec();
         return false;
+      }
+        
       else if (askq.value("ask").toBool() &&
                QMessageBox::question(this, tr("Post Anyway?"),
                                      _askBeforePostingMsg.arg(docnumber),
                                       QMessageBox::Yes,
                                       QMessageBox::No | QMessageBox::Default)
                   == QMessageBox::No)
+      {
+        cleanup.exec();
         return false;
+      }
     }
 
     if (! _errCheckBeforePostingQry.isEmpty())
@@ -246,13 +260,19 @@ bool printMulticopyDocument::sPostOneDoc(XSqlQuery *docq)
       if (ErrorReporter::error(QtCriticalMsg, this,
                                tr("Cannot Post %1").arg(docnumber),
                                errq, __FILE__, __LINE__))
+      {
+        cleanup.exec();
         return false;
+      }
       else if (! errq.first() || ! errq.value("ok").toBool())
       {
         ErrorReporter::error(QtCriticalMsg, this,
                              tr("Cannot Post %1").arg(docnumber),
                              _errCheckBeforePostingMsg, __FILE__, __LINE__);
-        return false;
+        {
+          cleanup.exec();
+          return false;
+        }
       }
     }
 
@@ -270,6 +290,7 @@ bool printMulticopyDocument::sPostOneDoc(XSqlQuery *docq)
       if (result < 0)
       {
         rollback.exec();
+        cleanup.exec();
         ErrorReporter::error(QtCriticalMsg, this,
                              tr("Cannot Post %1").arg(docnumber),
                              storedProcErrorLookup(_postFunction, result),
@@ -280,6 +301,7 @@ bool printMulticopyDocument::sPostOneDoc(XSqlQuery *docq)
     else if (postq.lastError().type() != QSqlError::NoError)
     {
       rollback.exec();
+      cleanup.exec();
       ErrorReporter::error(QtCriticalMsg, this,
                            tr("Cannot Post %1").arg(docnumber),
                            postq, __FILE__, __LINE__);
@@ -314,13 +336,20 @@ void printMulticopyDocument::sPrint()
     // This indirection allows scripts to replace core behavior - 14285
     emit aboutToStart(&docinfoq);
 
+
     // Distribute inventory detail
-    if (_distributeInventory && !distributeInventory(&docinfoq))
-      return;
+    int itemlocSeries = 0;
+
+    if (_distributeInventory)
+    {
+      itemlocSeries = distributeInventory(&docinfoq);
+      if (itemlocSeries <= 0)
+        return;
+    }
 
     emit timeToPrintOneDoc(&docinfoq);
     emit timeToMarkOnePrinted(&docinfoq);
-    emit timeToPostOneDoc(&docinfoq);
+    emit timeToPostOneDoc(&docinfoq, itemlocSeries);
 
     message("");
   }
@@ -453,9 +482,9 @@ XDocCopySetter *printMulticopyDocument::copies()
   return _data->_copies;
 }
 
-bool printMulticopyDocument::distributeInventory(XSqlQuery *qry)
+int printMulticopyDocument::distributeInventory(XSqlQuery *qry)
 {
-  return true;
+  return 0;
 }
 
 QString printMulticopyDocument::doctype()

--- a/guiclient/printMulticopyDocument.h
+++ b/guiclient/printMulticopyDocument.h
@@ -49,7 +49,7 @@ class printMulticopyDocument : public XDialog
 
     Q_INVOKABLE virtual void            clear();
     Q_INVOKABLE virtual XDocCopySetter *copies();
-    Q_INVOKABLE virtual bool            distributeInventory(XSqlQuery *qry);
+    Q_INVOKABLE virtual int             distributeInventory(XSqlQuery *qry);
                 virtual QString         doctype();
     Q_INVOKABLE virtual ParameterList   getParamsDocList();
     Q_INVOKABLE virtual ParameterList   getParamsOneCopy(const int row, XSqlQuery *qry);
@@ -70,7 +70,7 @@ class printMulticopyDocument : public XDialog
   public slots:
     virtual void    sAddToPrintedList(XSqlQuery *docq);
     virtual bool    sMarkOnePrinted(XSqlQuery *docq);
-    virtual bool    sPostOneDoc(XSqlQuery  *docq);
+    virtual bool    sPostOneDoc(XSqlQuery  *docq, int itemlocSeries = 0);
     virtual void    sPrint();
     virtual bool    sPrintOneDoc(XSqlQuery *docq);
     virtual void    setDoctype(QString doctype);
@@ -86,7 +86,7 @@ class printMulticopyDocument : public XDialog
     void posted(int);
     void timeToMarkOnePrinted(XSqlQuery *docq);
     void timeToPrintOneDoc(XSqlQuery    *docq);
-    void timeToPostOneDoc(XSqlQuery     *docq);
+    void timeToPostOneDoc(XSqlQuery     *docq, int itemlocSeries = 0);
 
   protected slots:
     virtual void languageChange();

--- a/guiclient/printMulticopyDocument.h
+++ b/guiclient/printMulticopyDocument.h
@@ -49,6 +49,7 @@ class printMulticopyDocument : public XDialog
 
     Q_INVOKABLE virtual void            clear();
     Q_INVOKABLE virtual XDocCopySetter *copies();
+    Q_INVOKABLE virtual bool            distributeInventory(XSqlQuery *qry);
                 virtual QString         doctype();
     Q_INVOKABLE virtual ParameterList   getParamsDocList();
     Q_INVOKABLE virtual ParameterList   getParamsOneCopy(const int row, XSqlQuery *qry);


### PR DESCRIPTION
There are 6 `printMulticopyDocument.cpp` inherited classes that set `_distributeInventory = true`, which if set will `DistributeInventory::SeriesAdjust`. I added a new method `distributeInventory` to printMulticopyDocument and then call it if `_distributeInventory`.