### PR TITLE
issue #30547 activateWindow() is no longer sufficient to bring to front on Mac as …

### DIFF
--- a/guiclient/menuWindow.cpp
+++ b/guiclient/menuWindow.cpp
@@ -179,7 +179,10 @@ void menuWindow::sActivateWindow()
   if (wind)
   {
     if (_parent->showTopLevel())
+    {
+      wind->raise();
       wind->activateWindow();
+    }
     else
       wind->setFocus();
   }


### PR DESCRIPTION
…of Qt5, call raise() as well