### PR TITLE
Issue #30472: New Vendor displayed all vendor details under accounting

### DIFF
--- a/guiclient/vendor.cpp
+++ b/guiclient/vendor.cpp
@@ -267,6 +267,7 @@ SetResponse vendor::set(const ParameterList &pParams)
 
       
       clear();
+      _accountingTab->setEnabled(false);
 
       if (_privileges->check("MaintainVendorAddresses"))
       {

--- a/guiclient/vendor.ui
+++ b/guiclient/vendor.ui
@@ -1589,7 +1589,7 @@ and Purchase Order amounts</string>
           <item>
            <widget class="QRadioButton" name="_apChecksButton">
             <property name="text">
-             <string>Checks</string>
+             <string>Payments</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Turned off Accounting tab for NEW mode as the data is not relevant.  Also modified text from Check to Payment for consistency across the application.