### PR TITLE
Issue #30434: User account screen display issues

### DIFF
--- a/guiclient/user.cpp
+++ b/guiclient/user.cpp
@@ -70,6 +70,10 @@ user::user(QWidget* parent, const char * name, Qt::WindowFlags fl)
   _grantedSite->addColumn("Granted Sites",      -1, Qt::AlignLeft);
 
   _locale->setType(XComboBox::Locales);
+  XSqlQuery locq;
+  locq.exec("SELECT locale_id FROM locale WHERE locale_code='Default'");
+  if (locq.first())
+    _locale->setId(locq.value("locale_id").toInt());
 
   XSqlQuery modq;
   modq.exec( "SELECT DISTINCT priv_module FROM priv ORDER BY priv_module;" );

--- a/guiclient/user.ui
+++ b/guiclient/user.ui
@@ -295,9 +295,6 @@ to be bound by its terms.</comment>
        </item>
        <item row="6" column="0">
         <widget class="QLabel" name="_employeeLit">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
          <property name="text">
           <string>Employee:</string>
          </property>


### PR DESCRIPTION
Would be nice to pass user account username to the employee screen when selecting New Employee from the widget but not sure if that is possible.

Also correctly set default user locale