### PR TITLE
Issue #29304: Make SO selection on Packing List Batch screen consistent

### DIFF
--- a/guiclient/packingListBatch.cpp
+++ b/guiclient/packingListBatch.cpp
@@ -276,6 +276,7 @@ void packingListBatch::sAddSO()
   XSqlQuery packingAddSO;
   ParameterList params;
   params.append("soType", cSoOpen);
+  params.append("exclShipped", true);
   _warehouse->appendValue(params);
 
   salesOrderList newdlg(this, "", true);

--- a/widgets/salesOrderList.cpp
+++ b/widgets/salesOrderList.cpp
@@ -117,6 +117,10 @@ void salesOrderList::set(const ParameterList &pParams)
   if (valid)
     _type = param.toInt();
 
+  param = pParams.value("exclShipped", &valid);
+  if (valid)
+    _exclShipped = param.toBool();
+
   param = pParams.value("cust_id", &valid);
   if (valid)
     _custid = param.toInt();
@@ -204,6 +208,9 @@ void salesOrderList::sFillList()
         sql += " AND ";
       sql += "(cohead_cust_id=:cust_id)";
     }
+
+    if (_exclShipped)
+      sql += " AND (NOT orderhasshipped(cohead_id)) ";
 
     sql += ")) "
            "ORDER BY cohead_number;";

--- a/widgets/salesOrderList.h
+++ b/widgets/salesOrderList.h
@@ -51,6 +51,7 @@ private:
     int _soheadid;
     int _type;
     int _custid;
+    bool _exclShipped;
 };
 
 #endif


### PR DESCRIPTION
Make consistent with displayed list.  The SO List will now also exclude fully shipped order lines.  This only applies when accessing from the Packing List Batch screen.