### PR TITLE
Issue #29225: APOpenItems screen did not open voided item correctly

### DIFF
--- a/guiclient/apOpenItem.h
+++ b/guiclient/apOpenItem.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -41,6 +41,7 @@ public slots:
     virtual void sReleaseNumber();
     virtual void sToggleAccount();
     virtual void sCalcBalance();
+    virtual void sViewMode();
 
 protected slots:
     virtual void languageChange();

--- a/guiclient/apOpenItem.ui
+++ b/guiclient/apOpenItem.ui
@@ -2,7 +2,7 @@
 <ui version="4.0">
  <comment>This file is part of the xTuple ERP: PostBooks Edition, a free and
 open source Enterprise Resource Planning software suite,
-Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
 It is licensed to you under the Common Public Attribution License
 version 1.0, the full text of which (including xTuple-specific Exhibits)
 is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -128,6 +128,9 @@ to be bound by its terms.</comment>
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="type">
+           <enum>XComboBox::APTerms</enum>
           </property>
          </widget>
         </item>

--- a/guiclient/miscVoucher.cpp
+++ b/guiclient/miscVoucher.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -124,7 +124,6 @@ enum SetResponse miscVoucher::set(const ParameterList &pParams)
       _invoiceDate->setEnabled(false);
       _dueDate->setEnabled(false);
       _terms->setEnabled(false);
-      _terms->setType(XComboBox::Terms);
       _vendor->setShowInactive(true);
       _invoiceNum->setEnabled(false);
       _reference->setEnabled(false);


### PR DESCRIPTION
Found a bunch of issues when investigating.  Corrected opening of APOpenItems screen, corrected opening of Misc Voucher screen. Tidied up a bunch of old rubbishy code.  
Possibly need to look into AR Open Items screen as this sometimes duplicates the AP screen logic.