### PR TITLE
resolves issue #19021 - inconsistency in RAs (receiving site)

### DIFF
--- a/guiclient/returnAuthorization.cpp
+++ b/guiclient/returnAuthorization.cpp
@@ -639,11 +639,13 @@ void returnAuthorization::sOrigSoChanged()
                      "       cohead_shiptocity, cohead_shiptostate,"
                      "       cohead_shiptozipcode, cohead_shiptocountry, cohead_warehous_id,"
                      "       cust_ffshipto, custtype_code, cohead_commission, "
-                     "       shipto_num"
+                     "       shipto_num, "
+                     "       warehous_code "
                      "  FROM cohead"
                      "  JOIN custinfo ON (cohead_cust_id=cust_id)"
                      "  JOIN custtype ON (cust_custtype_id=custtype_id)"
                      "  LEFT OUTER JOIN shiptoinfo ON (cohead_shipto_id=shipto_id)"
+                     "  LEFT OUTER JOIN warehous ON (cohead_warehous_id=warehous_id)"
                      " WHERE (cohead_id=:cohead_id)"
                      " LIMIT 1;");
       // TODO: why left outer join shipto if we don't use the shipto_num?
@@ -651,15 +653,59 @@ void returnAuthorization::sOrigSoChanged()
       sohead.exec();
       if (sohead.first())
       {
-        // Update Recv and Ship site to match that from SO
-        if (sohead.value("cohead_warehous_id").toInt() > 0 && (
-            _warehouse->id() != sohead.value("cohead_warehous_id").toInt() ||
-            _shipWhs->id() != sohead.value("cohead_warehous_id").toInt()))
+        // If the sites don't match the cohead ask the user if they want to make changes
+        if (_metrics->boolean("MultiWhs") && sohead.value("cohead_warehous_id").toInt() > 0 &&
+            (_warehouse->id() != sohead.value("cohead_warehous_id").toInt() ||
+             _shipWhs->id() != sohead.value("cohead_warehous_id").toInt()) )
         {
-          _ignoreWhsSignals = true;
-          _warehouse->setId(sohead.value("cohead_warehous_id").toInt());
-          _shipWhs->setId(sohead.value("cohead_warehous_id").toInt());
-          _ignoreWhsSignals = false;
+          if (_warehouse->id() != sohead.value("cohead_warehous_id").toInt() &&
+              _shipWhs->id() != sohead.value("cohead_warehous_id").toInt())
+          {
+            if (QMessageBox::question(this, tr("Sites Do Not Match"),
+                tr("The Orig. Sales Order Site (%1) does not match the Receiving Site (%2) nor Shipping Site (%3). <p>"
+                   "Do you want to update both of them to match the Sales Order?")
+                .arg(sohead.value("warehous_code").toString())
+                .arg(_warehouse->currentText())
+                .arg(_shipWhs->currentText()),
+                QMessageBox::Yes | QMessageBox::No,
+                QMessageBox::Yes) == QMessageBox::Yes)
+            {
+              _ignoreWhsSignals = true;
+              _warehouse->setId(sohead.value("cohead_warehous_id").toInt());
+              _shipWhs->setId(sohead.value("cohead_warehous_id").toInt());
+              _ignoreWhsSignals = false;
+            }
+          }
+          else if (_warehouse->id() != sohead.value("cohead_warehous_id").toInt())
+          {
+            if (QMessageBox::question(this, tr("Sites Do Not Match"),
+                tr("The Original Sales Order Site (%1) does not match the Receiving Site (%2). <p>"
+                   "Do you want to update it to match the Sales Order?")
+                .arg(sohead.value("warehous_code").toString())
+                .arg(_warehouse->currentText()),
+                QMessageBox::Yes | QMessageBox::No,
+                QMessageBox::Yes) == QMessageBox::Yes)
+            {
+              _ignoreWhsSignals = true;
+              _warehouse->setId(sohead.value("cohead_warehous_id").toInt());
+              _ignoreWhsSignals = false;
+            }
+          }
+          else if (_shipWhs->id() != sohead.value("cohead_warehous_id").toInt())
+          {
+            if (QMessageBox::question(this, tr("Sites Do Not Match"),
+                tr("The Original Sales Order Site (%1) does not match the Shipping Site (%2). <p>"
+                   "Do you want to update it to match the Sales Order?")
+                .arg(sohead.value("warehous_code").toString())
+                .arg(_shipWhs->currentText()),
+                QMessageBox::Yes | QMessageBox::No,
+                QMessageBox::Yes) == QMessageBox::Yes)
+            {
+              _ignoreWhsSignals = true;
+              _shipWhs->setId(sohead.value("cohead_warehous_id").toInt());
+              _ignoreWhsSignals = false;
+            }
+          }
         }
 
         if ( !_warehouse->isValid() )

--- a/guiclient/returnAuthorizationItem.cpp
+++ b/guiclient/returnAuthorizationItem.cpp
@@ -278,8 +278,6 @@ enum SetResponse returnAuthorizationItem::set(const ParameterList &pParams)
       _mode = cEdit;
 
       _item->setReadOnly(true);
-      _warehouse->setEnabled(false);
-      _shipWhs->setEnabled(false);
       _comments->setType(Comments::ReturnAuthItem);
       _comments->setReadOnly(false);
 
@@ -951,7 +949,11 @@ void returnAuthorizationItem::populate()
         raitem.value("qtyshipd").toDouble() > 0 ||
         raitem.value("qtytorcv").toDouble() > 0 ||
         _qtycredited > 0)
+    {
       _disposition->setEnabled(false);
+      _warehouse->setEnabled(false);
+      _shipWhs->setEnabled(false);
+    }
 
     if (_orderId != -1)
     {


### PR DESCRIPTION
1. Instead of disabling Recv/Ship Site comboboxes on edit, disable them in populate _IF_ qty credited, qty to receive, qty shipped > 0 https://github.com/xtuple/qt-client/pull/1668/files#diff-3ac3613b6d2a8f0f75c982a136e5a64cR954.
2. If Sales Order warehouse does not match the Recv/Ship on RA header, ask user if they'd like to update them to match the SO before proceeding. The default is Yes.

For 2 above, more details about this decision:
- I didn't want to make the combo boxes `allowNull` because Original Sales Order is optional and user should not always be expected to set the WH.
- Without changing to allowNull, there's no way to know if the WH(s) set previous to original SO should take precedence over the SO warehouse. I like asking the User with the default being Yes (update to match).