### PR TITLE
issue #27513 - possible to make changes to order while being edited by another user

### DIFF
--- a/guiclient/addPoComment.cpp
+++ b/guiclient/addPoComment.cpp
@@ -16,6 +16,8 @@ addPoComment::addPoComment(QWidget* parent, const char* name, bool modal, Qt::Wi
     : XDialog(parent, name, modal, fl)
 {
   setupUi(this);
+
+  _po->setLockSelected(true);
 }
 
 addPoComment::~addPoComment()

--- a/guiclient/changePoitemQty.cpp
+++ b/guiclient/changePoitemQty.cpp
@@ -28,6 +28,8 @@ changePoitemQty::changePoitemQty(QWidget* parent, const char* name, bool modal, 
   connect(_po, SIGNAL(newId(int, QString)), this, SLOT(sPopulatePoitem(int)));
   connect(_poitem, SIGNAL(newID(int)), this, SLOT(sPopulate(int)));
 
+  _po->setLockSelected(true);
+
   _captive = false;
   _cacheFreight = 0.0;
 

--- a/guiclient/reschedulePoitem.cpp
+++ b/guiclient/reschedulePoitem.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree

--- a/guiclient/reschedulePoitem.cpp
+++ b/guiclient/reschedulePoitem.cpp
@@ -24,6 +24,8 @@ reschedulePoitem::reschedulePoitem(QWidget* parent, const char* name, bool modal
   connect(_po, SIGNAL(newId(int, QString)), this, SLOT(sPopulatePoitem(int)));
   connect(_poitem, SIGNAL(newID(int)), this, SLOT(sPopulate(int)));
   connect(_allItems, SIGNAL(clicked()), this, SLOT(sAllItems()));
+
+  _po->setLockSelected(true);
 }
 
 reschedulePoitem::~reschedulePoitem()

--- a/guiclient/unpostedPurchaseOrders.cpp
+++ b/guiclient/unpostedPurchaseOrders.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -158,7 +158,7 @@ void unpostedPurchaseOrders::sDelete()
         if (selected[i]->rawValue("pohead_status").toString() == "U")
         {
           if (selected[i]->altId() != -1)
-		  {
+		      {
             QString question = tr("<p>The Purchase Order that you selected to delete was created "
             "to satisfy Sales Order demand. If you delete the selected "
             "Purchase Order then the Sales Order demand will remain but "
@@ -168,8 +168,13 @@ void unpostedPurchaseOrders::sDelete()
                                       question,
                                       QMessageBox::Yes,
                                       QMessageBox::No | QMessageBox::Default) == QMessageBox::No)
-			  continue;
-		  }
+			        continue;
+		      }
+
+          // If locked, don't proceed
+          if (!_lock.acquire("pohead", ((XTreeWidgetItem*)(selected[i]))->id(), AppLock::Interactive))
+            continue;
+
           unpostedDelete.bindValue(":pohead_id", ((XTreeWidgetItem*)(selected[i]))->id());
           unpostedDelete.exec();
           if (unpostedDelete.first() && ! unpostedDelete.value("result").toBool())
@@ -247,7 +252,11 @@ void unpostedPurchaseOrders::sRelease()
     if ((selected[i]->rawValue("pohead_status").toString() == "U")
       && (_privileges->check("ReleasePurchaseOrders"))
       && (checkSitePrivs(((XTreeWidgetItem*)(selected[i]))->id())))
-      {
+    {
+      // If locked, don't proceed
+      if (!_lock.acquire("pohead", ((XTreeWidgetItem*)(selected[i]))->id(), AppLock::Interactive))
+        continue;
+
       unpostedRelease.bindValue(":pohead_id", ((XTreeWidgetItem*)(selected[i]))->id());
       unpostedRelease.exec();
       if (unpostedRelease.first())
@@ -276,6 +285,7 @@ void unpostedPurchaseOrders::sRelease()
 
 void unpostedPurchaseOrders::sUnrelease()
 {
+
   XSqlQuery unRelease;
   unRelease.prepare("SELECT unreleasePurchaseOrder(:pohead_id) AS result;");
   
@@ -287,6 +297,10 @@ void unpostedPurchaseOrders::sUnrelease()
         && (_privileges->check("UnreleasePurchaseOrders"))
         && (checkSitePrivs(((XTreeWidgetItem*)(selected[i]))->id())))
     {
+      // If locked, don't proceed
+      if (!_lock.acquire("pohead", ((XTreeWidgetItem*)(selected[i]))->id(), AppLock::Interactive))
+        continue;
+
       unRelease.bindValue(":pohead_id", ((XTreeWidgetItem*)(selected[i]))->id());
       unRelease.exec();
       if (unRelease.first())

--- a/guiclient/unpostedPurchaseOrders.cpp
+++ b/guiclient/unpostedPurchaseOrders.cpp
@@ -173,7 +173,12 @@ void unpostedPurchaseOrders::sDelete()
 
           // If locked, don't proceed
           if (!_lock.acquire("pohead", ((XTreeWidgetItem*)(selected[i]))->id(), AppLock::Interactive))
-            continue;
+          {
+            if (i == selected.size() - 1)
+              return;
+            else
+              continue;
+          }
 
           unpostedDelete.bindValue(":pohead_id", ((XTreeWidgetItem*)(selected[i]))->id());
           unpostedDelete.exec();
@@ -190,6 +195,8 @@ void unpostedPurchaseOrders::sDelete()
                                unpostedDelete, __FILE__, __LINE__);
           else
             done = true;
+
+          _lock.release();
         }
       }
     }
@@ -255,7 +262,12 @@ void unpostedPurchaseOrders::sRelease()
     {
       // If locked, don't proceed
       if (!_lock.acquire("pohead", ((XTreeWidgetItem*)(selected[i]))->id(), AppLock::Interactive))
-        continue;
+      {
+        if (i == selected.size() - 1)
+          return;
+        else
+          continue;
+      }
 
       unpostedRelease.bindValue(":pohead_id", ((XTreeWidgetItem*)(selected[i]))->id());
       unpostedRelease.exec();
@@ -272,6 +284,8 @@ void unpostedPurchaseOrders::sRelease()
       else if (unpostedRelease.lastError().type() != QSqlError::NoError)
         ErrorReporter::error(QtCriticalMsg, this, tr("Error Releasing Purchase Order"),
                            unpostedRelease, __FILE__, __LINE__);
+
+      _lock.release();
     }
   }
   if (done)
@@ -299,7 +313,12 @@ void unpostedPurchaseOrders::sUnrelease()
     {
       // If locked, don't proceed
       if (!_lock.acquire("pohead", ((XTreeWidgetItem*)(selected[i]))->id(), AppLock::Interactive))
-        continue;
+      {
+        if (i == selected.size() - 1)
+          return;
+        else
+          continue;
+      }
 
       unRelease.bindValue(":pohead_id", ((XTreeWidgetItem*)(selected[i]))->id());
       unRelease.exec();
@@ -316,6 +335,8 @@ void unpostedPurchaseOrders::sUnrelease()
       else if (unRelease.lastError().type() != QSqlError::NoError)
         ErrorReporter::error(QtCriticalMsg, this, tr("Error Unreleasing Purchase Order"),
                            unRelease, __FILE__, __LINE__);
+
+      _lock.release();
     }
   }
   if (done)

--- a/guiclient/unpostedPurchaseOrders.h
+++ b/guiclient/unpostedPurchaseOrders.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -11,6 +11,7 @@
 #ifndef UNPOSTEDPURCHASEORDERS_H
 #define UNPOSTEDPURCHASEORDERS_H
 
+#include "applock.h"
 #include "display.h"
 
 #include "ui_unpostedPurchaseOrders.h"
@@ -35,6 +36,9 @@ public slots:
     virtual void sPrintForms();
     virtual void sView();
     virtual bool setParams(ParameterList &);
+
+private:
+    AppLock _lock;
 };
 
 #endif // UNPOSTEDPURCHASEORDERS_H


### PR DESCRIPTION
Order locking in our application has many feature gaps. This pr adds locking to all Purchase Order list actions and utilities so that if a user is editing the PO it can not be modified elsewhere. If this approach is OK it can be extended to other order types.