### PR TITLE
Issue #14206: Credit Card Transaction screen

### DIFF
--- a/guiclient/externalCCTransaction.cpp
+++ b/guiclient/externalCCTransaction.cpp
@@ -47,6 +47,10 @@ enum SetResponse externalCCTransaction::set(const ParameterList &pParams)
   if (valid)
     _ccard->setText(param.toString());
 
+  param = pParams.value("ccard_exp", &valid);
+  if (valid)
+    _expDate->setDate(param.toString());
+
   param = pParams.value("currid", &valid);
   if (valid)
     _amount->setId(param.toInt());

--- a/guiclient/externalCCTransaction.ui
+++ b/guiclient/externalCCTransaction.ui
@@ -2,7 +2,7 @@
 <ui version="4.0">
  <comment>This file is part of the xTuple ERP: PostBooks Edition, a free and
 open source Enterprise Resource Planning software suite,
-Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
 It is licensed to you under the Common Public Attribution License
 version 1.0, the full text of which (including xTuple-specific Exhibits)
 is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -101,7 +101,20 @@ to be bound by its terms.</comment>
      </property>
     </widget>
    </item>
-   <item row="1" column="2" colspan="2">
+   <item row="1" column="2">
+    <widget class="QLabel" name="_expDateLit">
+     <property name="text">
+      <string>Expiry:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="buddy">
+      <cstring>_expDate</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="3">
     <widget class="DLineEdit" name="_expDate">
      <property name="enabled">
       <bool>false</bool>


### PR DESCRIPTION
Added label but could not see how this date field was ever being populated.  Should the widget be removed from the screen?  