### PR TITLE
Issue #29166: Edit button not functional in Financial Reports screen

### DIFF
--- a/guiclient/financialLayoutColumns.ui
+++ b/guiclient/financialLayoutColumns.ui
@@ -2,7 +2,7 @@
 <ui version="4.0">
  <comment>This file is part of the xTuple ERP: PostBooks Edition, a free and
 open source Enterprise Resource Planning software suite,
-Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
 It is licensed to you under the Common Public Attribution License
 version 1.0, the full text of which (including xTuple-specific Exhibits)
 is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -98,16 +98,6 @@ to be bound by its terms.</comment>
          </property>
          <property name="type">
           <enum>XComboBox::Reports</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="_edit">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="text">
-          <string>&amp;Edit</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Tried completing functionality (which worked) but these screens are modal so sat over the report edit ui.  So removed button instead.