### PR TITLE
issue #30469 Make sure JS DateTime objects coming from QDate have the timezone of …

### DIFF
--- a/scriptapi/qdateproto.cpp
+++ b/scriptapi/qdateproto.cpp
@@ -17,9 +17,12 @@ QScriptValue QDateToScriptValue(QScriptEngine *engine, const QDate &in)
   XSqlQuery getTZ("SELECT EXTRACT(TIMEZONE FROM now()) AS offset;");
   if (getTZ.first())
     return engine->newDate(QDateTime(in, QTime(), QTimeZone(getTZ.value("offset").toInt())));
-  else if (ErrorReporter::error(QtCriticalMsg, 0, "Failed to fetch server time zone",
-                                getTZ, __FILE__, __LINE__))
+  else
+  {
+    ErrorReporter::error(QtCriticalMsg, 0, "Failed to fetch server time zone",
+                                getTZ, __FILE__, __LINE__);
     return engine->newDate(QDateTime(in));
+  }
 }
 
 void QDateFromScriptValue(const QScriptValue &object, QDate &out)

--- a/scriptapi/qdateproto.cpp
+++ b/scriptapi/qdateproto.cpp
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which (including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#include "qdateproto.h"
+#include "xsqlquery.h"
+#include "errorReporter.h"
+
+QScriptValue QDateToScriptValue(QScriptEngine *engine, const QDate &in)
+{
+  XSqlQuery getTZ("SELECT EXTRACT(TIMEZONE FROM now()) AS offset;");
+  if (getTZ.first())
+    return engine->newDate(QDateTime(in, QTime(), QTimeZone(getTZ.value("offset").toInt())));
+  else if (ErrorReporter::error(QtCriticalMsg, 0, "Failed to fetch server time zone",
+                                getTZ, __FILE__, __LINE__))
+    return engine->newDate(QDateTime(in));
+}
+
+void QDateFromScriptValue(const QScriptValue &object, QDate &out)
+{
+  QDateTime obj = object.toDateTime();
+  obj.setTimeSpec(Qt::LocalTime);
+  out = obj.date();
+}
+
+void setupQDateProto(QScriptEngine *engine)
+{
+  qScriptRegisterMetaType(engine, QDateToScriptValue, QDateFromScriptValue);
+}

--- a/scriptapi/qdateproto.h
+++ b/scriptapi/qdateproto.h
@@ -1,0 +1,20 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which (including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#ifndef __QDATEPROTO_H__
+#define __QDATEPROTO_H__
+
+#include <QtScript>
+
+Q_DECLARE_METATYPE(QDate*)
+
+void setupQDateProto(QScriptEngine *engine);
+
+#endif

--- a/scriptapi/scriptapi.pro
+++ b/scriptapi/scriptapi.pro
@@ -43,6 +43,7 @@ HEADERS += setupscriptapi.h \
     qcoreapplicationproto.h \
     qcryptographichashproto.h \
     qdatawidgetmapperproto.h    \
+    qdateproto.h \
     qdialogbuttonboxproto.h \
     qdialogsetup.h \
     qdirproto.h \
@@ -176,6 +177,7 @@ SOURCES += setupscriptapi.cpp \
     qcoreapplicationproto.cpp \
     qcryptographichashproto.cpp \
     qdatawidgetmapperproto.cpp  \
+    qdateproto.cpp \
     qdialogbuttonboxproto.cpp \
     qdialogsetup.cpp \
     qdirproto.cpp \

--- a/scriptapi/setupscriptapi.cpp
+++ b/scriptapi/setupscriptapi.cpp
@@ -30,6 +30,7 @@
 #include "qcoreapplicationproto.h"
 #include "qcryptographichashproto.h"
 #include "qdatawidgetmapperproto.h"
+#include "qdateproto.h"
 #include "qdialogbuttonboxproto.h"
 #include "qdialogsetup.h"
 #include "qdirproto.h"
@@ -171,6 +172,7 @@ void setupScriptApi(QScriptEngine *engine)
   setupQCoreApplicationProto(engine);
   setupQCryptographicHashProto(engine);
   setupQDataWidgetMapperProto(engine);
+  setupQDateProto(engine);
   setupQDialog(engine);
   setupQDialogButtonBoxProto(engine);
   setupQDirProto(engine);


### PR DESCRIPTION
…the postgres server

Based off of https://github.com/xtuple/qt-client/pull/1642, which was rolled back due to breaking scripts that used JS DateTime functions on incoming QDate objects. This alternative solution keeps the script object coming from QDate objects as a JS DateTime, but adjusts the timezone to match the postgres server so that the date will not change when used in a postgres query.