### PR TITLE
Revert "Expose currCluster currency id to scripting"

### DIFF
--- a/widgets/currcluster.h
+++ b/widgets/currcluster.h
@@ -174,7 +174,6 @@ class XTUPLEWIDGETS_EXPORT CurrCluster : public CurrDisplay
 						      WRITE setCurrencyVisible)
     Q_PROPERTY(bool enabled        READ isEnabled     WRITE setEnabled)
     Q_PROPERTY(QString fieldNameCurr  READ fieldNameCurr  WRITE setFieldNameCurr)
-    Q_PROPERTY(int id READ id WRITE setId)
 
     public:
 	CurrCluster(QWidget * parent, const char* name = 0);


### PR DESCRIPTION
Reverts xtuple/qt-client#1810

id was already exposed as a function in CurrDisplay, and CurrCluster inherits from CurrDisplay. Adding it as a property as well breaks existing uses of the function.