### PR TITLE
issue #31730 - handle vendor group instead of cluster

### DIFF
--- a/guiclient/apWorkBench.cpp
+++ b/guiclient/apWorkBench.cpp
@@ -75,15 +75,10 @@ apWorkBench::apWorkBench(QWidget* parent, const char* name, Qt::WindowFlags fl)
     _history = new dspVendorAPHistory(this, "dspVendorAPHistory", Qt::Widget);
     _apHistoryTab->layout()->addWidget(_history);
     _history->setCloseVisible(false);
-    _history->findChild<QWidget*>("_vendGroup")->hide();
     _history->findChild<DateCluster*>("_dates")->setStartNull(tr("Earliest"), omfgThis->startOfTime(), true);
     _history->findChild<DateCluster*>("_dates")->setEndNull(tr("Latest"),     omfgThis->endOfTime(),   true);
     _history->show();
-    VendorGroup *vend = _history->findChild<VendorGroup*>("_vend");
-    _vendorgroup->synchronize(vend);
-    connect(_vendorgroup, SIGNAL(newVendId(int)),          _history, SLOT(sFillList()));
-    connect(_vendorgroup, SIGNAL(newVendTypeId(int)),      _history, SLOT(sFillList()));
-    connect(_vendorgroup, SIGNAL(newTypePattern(QString)), _history, SLOT(sFillList()));
+    _vendorgroup->synchronize(_history->findChild<VendorGroup*>("_vend"));
   }
   else
     _apHistoryTab->setEnabled(false);

--- a/guiclient/apWorkBench.cpp
+++ b/guiclient/apWorkBench.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -77,10 +77,13 @@ apWorkBench::apWorkBench(QWidget* parent, const char* name, Qt::WindowFlags fl)
     _history->setCloseVisible(false);
     _history->findChild<QWidget*>("_vendGroup")->hide();
     _history->findChild<DateCluster*>("_dates")->setStartNull(tr("Earliest"), omfgThis->startOfTime(), true);
-    _history->findChild<DateCluster*>("_dates")->setEndNull(tr("Latest"),	  omfgThis->endOfTime(),   true);
-    VendorCluster *histvend = _history->findChild<VendorCluster*>("_vend");
-    connect(histvend, SIGNAL(newId(int)), _history,      SLOT(sFillList()));
-    connect(_vendorgroup,  SIGNAL(newVendId(int)), histvend,      SLOT(setId(int)));
+    _history->findChild<DateCluster*>("_dates")->setEndNull(tr("Latest"),     omfgThis->endOfTime(),   true);
+    _history->show();
+    VendorGroup *vend = _history->findChild<VendorGroup*>("_vend");
+    _vendorgroup->synchronize(vend);
+    connect(_vendorgroup, SIGNAL(newVendId(int)),          _history, SLOT(sFillList()));
+    connect(_vendorgroup, SIGNAL(newVendTypeId(int)),      _history, SLOT(sFillList()));
+    connect(_vendorgroup, SIGNAL(newTypePattern(QString)), _history, SLOT(sFillList()));
   }
   else
     _apHistoryTab->setEnabled(false);
@@ -90,6 +93,7 @@ apWorkBench::apWorkBench(QWidget* parent, const char* name, Qt::WindowFlags fl)
   connect(_query, SIGNAL(clicked()), _credits, SLOT(sFillList()));
   connect(_query, SIGNAL(clicked()), _selectedPayments, SLOT(sFillList()));
   connect(_query, SIGNAL(clicked()), _checkRun, SLOT(sFillList()));
+  connect(_query, SIGNAL(clicked()), _history,  SLOT(sFillList()));
 
   _payables->sFillList();
 }

--- a/guiclient/displays/dspVendorAPHistory.cpp
+++ b/guiclient/displays/dspVendorAPHistory.cpp
@@ -66,7 +66,11 @@ enum SetResponse dspVendorAPHistory::set(const ParameterList &pParams)
 
   param = pParams.value("vend_id", &valid);
   if (valid)
-    _vend->setId(param.toInt());
+    _vend->setVendId(param.toInt());
+
+  param = pParams.value("vendtype_id", &valid);
+  if (valid)
+    _vend->setVendTypeId(param.toInt());
 
   param = pParams.value("startDate", &valid);
   if (valid)
@@ -161,9 +165,7 @@ bool dspVendorAPHistory::setParams(ParameterList &params)
   if (isVisible())
   {
     QList<GuiErrorCheck> errors;
-    errors<< GuiErrorCheck(_vend->isVisible() && !_vend->isValid(), _vend,
-              tr("Please select a valid Vendor."))
-          << GuiErrorCheck(!_dates->startDate().isValid(), _dates,
+    errors<< GuiErrorCheck(!_dates->startDate().isValid(), _dates,
               tr("Please enter a valid Start Date."))
           << GuiErrorCheck(!_dates->endDate().isValid(), _dates,
               tr("Please enter a valid End Date."))
@@ -177,7 +179,7 @@ bool dspVendorAPHistory::setParams(ParameterList &params)
   params.append("check", tr("Check"));
   params.append("voucher", tr("Voucher"));
   params.append("other", tr("Other"));
-  params.append("vend_id", _vend->id());
+  _vend->appendValue(params);
   _dates->appendValue(params);
 
   return true;

--- a/guiclient/displays/dspVendorAPHistory.cpp
+++ b/guiclient/displays/dspVendorAPHistory.cpp
@@ -12,16 +12,16 @@
 
 #include <QAction>
 #include <QMenu>
-#include "guiErrorCheck.h"
 #include <QSqlError>
 #include <QVariant>
-#include <xdateinputdialog.h>
 
 #include "apOpenItem.h"
-#include "voucher.h"
-#include "miscVoucher.h"
 #include "dspGLSeries.h"
 #include "errorReporter.h"
+#include "guiErrorCheck.h"
+#include "miscVoucher.h"
+#include "voucher.h"
+#include "xdateinputdialog.h"
 
 dspVendorAPHistory::dspVendorAPHistory(QWidget* parent, const char*, Qt::WindowFlags fl)
   : display(parent, "dspVendorAPHistory", fl)
@@ -50,6 +50,10 @@ dspVendorAPHistory::dspVendorAPHistory(QWidget* parent, const char*, Qt::WindowF
   list()->addColumn(tr("Base Balance"), _bigMoneyColumn, Qt::AlignRight,  true,  "base_balance"  );
   list()->setPopulateLinear();
 
+  connect(_vend, SIGNAL(newVendId(int)),          this, SLOT(sFillList()));
+  connect(_vend, SIGNAL(newVendTypeId(int)),      this, SLOT(sFillList()));
+  connect(_vend, SIGNAL(newTypePattern(QString)), this, SLOT(sFillList()));
+
 }
 
 void dspVendorAPHistory::languageChange()
@@ -67,10 +71,6 @@ enum SetResponse dspVendorAPHistory::set(const ParameterList &pParams)
   param = pParams.value("vend_id", &valid);
   if (valid)
     _vend->setVendId(param.toInt());
-
-  param = pParams.value("vendtype_id", &valid);
-  if (valid)
-    _vend->setVendTypeId(param.toInt());
 
   param = pParams.value("startDate", &valid);
   if (valid)
@@ -165,7 +165,9 @@ bool dspVendorAPHistory::setParams(ParameterList &params)
   if (isVisible())
   {
     QList<GuiErrorCheck> errors;
-    errors<< GuiErrorCheck(!_dates->startDate().isValid(), _dates,
+    errors<< GuiErrorCheck(_vend->isVisible() && !_vend->isValid(), _vend,
+              tr("Please make a valid vendor selection."))
+          << GuiErrorCheck(!_dates->startDate().isValid(), _dates,
               tr("Please enter a valid Start Date."))
           << GuiErrorCheck(!_dates->endDate().isValid(), _dates,
               tr("Please enter a valid End Date."))

--- a/guiclient/displays/dspVendorAPHistory.h
+++ b/guiclient/displays/dspVendorAPHistory.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree

--- a/guiclient/displays/dspVendorAPHistory.ui
+++ b/guiclient/displays/dspVendorAPHistory.ui
@@ -2,7 +2,7 @@
 <ui version="4.0">
  <comment>This file is part of the xTuple ERP: PostBooks Edition, a free and
 open source Enterprise Resource Planning software suite,
-Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
 It is licensed to you under the Common Public Attribution License
 version 1.0, the full text of which (including xTuple-specific Exhibits)
 is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -13,8 +13,8 @@ to be bound by its terms.</comment>
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>554</width>
-    <height>155</height>
+    <width>741</width>
+    <height>283</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -33,11 +33,7 @@ to be bound by its terms.</comment>
          <number>0</number>
         </property>
         <item>
-         <widget class="VendorCluster" name="_vend">
-          <property name="label">
-           <string>Vendor:</string>
-          </property>
-         </widget>
+         <widget class="VendorGroup" name="_vend"/>
         </item>
         <item>
          <spacer name="Spacer32">
@@ -146,9 +142,9 @@ to be bound by its terms.</comment>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>VendorCluster</class>
+   <class>VendorGroup</class>
    <extends>QWidget</extends>
-   <header>vendorcluster.h</header>
+   <header>vendorgroup.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/guiclient/displays/dspVendorAPHistory.ui
+++ b/guiclient/displays/dspVendorAPHistory.ui
@@ -13,60 +13,39 @@ to be bound by its terms.</comment>
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>741</width>
+    <width>669</width>
     <height>283</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Vendor History</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QGroupBox" name="_vendGroup">
-       <property name="title">
-        <string/>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout">
-        <property name="spacing">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="VendorGroup" name="_vend"/>
-        </item>
-        <item>
-         <spacer name="Spacer32">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Preferred</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>7</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </widget>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0" rowspan="3" colspan="5">
+      <widget class="VendorGroup" name="_vend"/>
      </item>
-     <item>
-      <widget class="QGroupBox" name="groupBox">
-       <property name="title">
-        <string/>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_3">
-        <item row="0" column="0">
-         <widget class="DateCluster" name="_dates"/>
-        </item>
-       </layout>
-      </widget>
+     <item row="0" column="5">
+      <widget class="DateCluster" name="_dates"/>
      </item>
-     <item>
+     <item row="1" column="5" rowspan="2">
+      <spacer name="Spacer32">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Preferred</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>7</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="6" rowspan="3">
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -79,36 +58,26 @@ to be bound by its terms.</comment>
        </property>
       </spacer>
      </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout">
-     <item>
-      <widget class="QLabel" name="_searchInvoiceNumLit">
-       <property name="text">
-        <string>Find Vend. Invoice #:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <layout class="QHBoxLayout">
-       <property name="spacing">
-        <number>0</number>
-       </property>
+     <item row="3" column="0" colspan="6">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QLabel" name="_searchInvoiceNumLit">
+         <property name="text">
+          <string>Find Vend. Invoice #:</string>
+         </property>
+        </widget>
+       </item>
        <item>
         <widget class="QLineEdit" name="_searchInvoiceNum"/>
        </item>
        <item>
-        <spacer name="spacer5">
+        <spacer name="horizontalSpacer_2">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
          </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Expanding</enum>
-         </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>0</width>
+           <width>40</width>
            <height>20</height>
           </size>
          </property>
@@ -132,6 +101,11 @@ to be bound by its terms.</comment>
     </spacer>
    </item>
   </layout>
+  <zorder>_vend</zorder>
+  <zorder>_searchInvoiceNumLit</zorder>
+  <zorder>_dates</zorder>
+  <zorder>horizontalSpacer</zorder>
+  <zorder>verticalSpacer</zorder>
  </widget>
  <layoutdefault spacing="5" margin="5"/>
  <customwidgets>


### PR DESCRIPTION
the ap workbench uses a vendorgroup so the embedded vendor history
must do the same to keep pace.

requires xtuple/xtuple#3206