### PR TITLE
issue #32054 - fix a case of mistaken identity

### DIFF
--- a/guiclient/crmaccount.cpp
+++ b/guiclient/crmaccount.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -246,17 +246,27 @@ enum SetResponse crmaccount::set(const ParameterList &pParams)
 
     crmaccount *w = qobject_cast<crmaccount*>(widget);
 
-    if (w && w->id()==_crmacctId)
+    if (w && w != this && w->id()==_crmacctId)
     {
-      w->setFocus();
-
-      if (omfgThis->showTopLevel())
+      // detect "i'm my own grandpa"
+      QObject *p;
+      for (p = parent(); p && p != w ; p = p->parent())
+        ; // do nothing
+      if (p == w)
       {
-        w->raise();
-        w->activateWindow();
+        QMessageBox::warning(this, tr("Cannot Open Recursively"),
+                             tr("This account is already open and cannot be "
+                                "raised. Please close windows to get to it."));
+        _closed = true;
+      } else if (p) {
+        w->setFocus();
+        if (omfgThis->showTopLevel())
+        {
+          w->raise();
+          w->activateWindow();
+        }
+        _closed = true;
       }
-
-      _closed = true;
       break;
     }
   }


### PR DESCRIPTION
in which an instance of the CRM Account window mistakenly thinks
a _different_ instance of the window already has this same account
open.

also avoid raising windows that are buried in a modal dialog stack.