### PR TITLE
[32680] Make Ship Via on Sales Orders editable

### DIFF
--- a/guiclient/salesOrder.ui
+++ b/guiclient/salesOrder.ui
@@ -597,6 +597,9 @@ to be bound by its terms.</comment>
            <property name="type">
             <enum>XComboBox::ShipVias</enum>
            </property>
+           <property name="editable">
+            <bool>true</bool>
+           </property>
           </widget>
          </item>
          <item row="3" column="4">


### PR DESCRIPTION
Could not find what changed between 4.10 and 4.11 to make this widget non-editable, but this change fixes the issue.