### PR TITLE
[31856] Copy Items - retain Item site location control settings. 

### DIFF
--- a/guiclient/itemSite.cpp
+++ b/guiclient/itemSite.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -331,6 +331,13 @@ enum SetResponse itemSite::set(const ParameterList &pParams)
       _comments->setReadOnly(true);
     }
     emit newMode(_mode);
+  }
+
+  param = pParams.value("copying", &valid);
+  if (valid)
+  {
+    int wh = _warehouse->findText(param.toString());
+    _warehouse->removeItem(wh);
   }
 
   return NoError;

--- a/guiclient/itemSites.cpp
+++ b/guiclient/itemSites.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -172,6 +172,7 @@ void itemSites::sCopy()
     }
     ParameterList params;
     params.append("mode", "edit");
+    params.append("copying", list()->currentItem()->rawValue("warehous_code"));
     params.append("itemsite_id", result);
 
     itemSite newdlg(this, "", true);


### PR DESCRIPTION
 Also correct SQL error when copying Item Sites over itself (new bug found when testing).