### PR TITLE
Fix Order Number field

### DIFF
--- a/guiclient/taxdisplay.cpp
+++ b/guiclient/taxdisplay.cpp
@@ -104,7 +104,7 @@ void TaxDisplay::sOpen()
 
   _tax->wait();
 
-  taxBreakdown newdlg(this, "", true);
+  taxBreakdown newdlg(0, "", true);
   newdlg.set(params);
   newdlg.exec();
 


### PR DESCRIPTION
Moving the Tax Breakdown opening code to the taxdisplay widget caused the Order Number field on that screen to be shrunk and misaligned. I have no idea why, but this fixes it.