### PR TITLE
Fix QSerialPort open() script exposure to match what QSerialPort actually is

### DIFF
--- a/scriptapi/qserialportproto.cpp
+++ b/scriptapi/qserialportproto.cpp
@@ -330,7 +330,7 @@ bool QSerialPortProto::isRequestToSend()
   return false;
 }
 
-bool QSerialPortProto::open(QIODevice::OpenModeFlag mode)
+bool QSerialPortProto::open(QIODevice::OpenMode mode)
 {
   QSerialPort *item = qscriptvalue_cast<QSerialPort*>(thisObject());
   if (item)

--- a/scriptapi/qserialportproto.h
+++ b/scriptapi/qserialportproto.h
@@ -84,7 +84,7 @@ class QSerialPortProto : public QIODeviceProto
     Q_INVOKABLE bool                         canReadLine() const;
     Q_INVOKABLE void                         close();
     Q_INVOKABLE bool                         isSequential() const;
-    Q_INVOKABLE bool                         open(QIODevice::OpenModeFlag mode);
+    Q_INVOKABLE bool                         open(QIODevice::OpenMode mode);
     Q_INVOKABLE bool                         waitForBytesWritten(int msecs);
     Q_INVOKABLE bool                         waitForReadyRead(int msecs);
     // added custom


### PR DESCRIPTION
Script exposure had open(QIODevice::OpenModeFlag) when it should have been [open(QIODevice::OpenMode)](https://doc.qt.io/qt-5/qserialport.html#open). I do not have a clue what changed to make this only apparent now, as it has worked up until this point. At first I thought it might be with Qt 5.11 but going back to xTuple 4.10.1 it still happens.