### PR TITLE
[33431] Allow deletion of voided EFT payment even if printed

### DIFF
--- a/common/storedProcErrorLookup.cpp
+++ b/common/storedProcErrorLookup.cpp
@@ -531,9 +531,9 @@ const struct {
                                "you may delete the selected Characteristic."),
 			       					 0, "" },
 
-  { "deleteCheck", -1, QT_TRANSLATE_NOOP("storedProcErrorLookup", "Cannot delete this Payment because either it has not "
-                          "been voided, it has already been posted or replaced,"
-                          " or it has been transmitted electronically."),
+  { "deleteCheck",     -1, QT_TRANSLATE_NOOP("storedProcErrorLookup", "Cannot delete this Payment because either it has not "
+                          "been voided, it has already been posted or replaced, "
+                          "or it has been transmitted electronically and printed."),
 			           					0, "" },
 
   { "deleteClassCode", -1, QT_TRANSLATE_NOOP("storedProcErrorLookup",  "The selected Class Code cannot be deleted "

--- a/guiclient/viewCheckRun.cpp
+++ b/guiclient/viewCheckRun.cpp
@@ -105,23 +105,9 @@ void viewCheckRun::sDelete()
              "WHERE (checkhead_id=:checkhead_id);" );
   viewDelete.bindValue(":checkhead_id", _check->id());
   viewDelete.exec();
-  if (viewDelete.first())
-  {
-    int result = viewDelete.value("result").toInt();
-    if (result < 0)
-    {
-      ErrorReporter::error(QtCriticalMsg, this, tr("Error Deleting Check Information"),
-                             storedProcErrorLookup("deleteCheck", result),
-                             __FILE__, __LINE__);
-      return;
-    }
-    omfgThis->sChecksUpdated(viewDelete.value("checkhead_bankaccnt_id").toInt(), _check->id(), true);
-  }
-  else if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Deleting Check Information"),
-                                viewDelete, __FILE__, __LINE__))
-  {
-    return;
-  }
+  ErrorReporter::error(QtCriticalMsg, this, tr("Error Deleting Check Information"),
+                                viewDelete, __FILE__, __LINE__);
+  sFillList();
 }
 
 void viewCheckRun::sNewMiscCheck()


### PR DESCRIPTION
To ensure consistency with other payment types.

requires xtuple/xtuple#3360