### PR TITLE
[25779] Allow Cash Receipt screen to remain open after save

### DIFF
--- a/guiclient/cashReceipt.h
+++ b/guiclient/cashReceipt.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -44,6 +44,7 @@ public slots:
     virtual void sApplyToBalance();
     virtual void sChangeCurrency( int newId );
     virtual void sClear();
+    virtual void sClearAndNew();
     virtual void sDelete();
     virtual void sEdit();
     virtual void sEditCreditCard();


### PR DESCRIPTION
Feature allows better user experience when mass entering receipts