### PR TITLE
[33214] Resolve issue where Sales Order intermittently opens ui form empty

### DIFF
--- a/guiclient/salesOrder.cpp
+++ b/guiclient/salesOrder.cpp
@@ -411,6 +411,7 @@ enum SetResponse salesOrder:: set(const ParameterList &pParams)
     }
     else if (param.toString() == "view")
     {
+      _mode = cView;
       setViewMode();
       _cust->setType(CLineEdit::AllCustomers);
 


### PR DESCRIPTION
Traced issue to a problem with the `_mode` value which was incorrectly set by a function that required _mode as an input parameter (?!?).  Could not reproduce error after making this change.