### PR TITLE
[22377] Prevent duplicate Item Sources based on tighter criteria and …

### DIFF
--- a/common/storedProcErrorLookup.cpp
+++ b/common/storedProcErrorLookup.cpp
@@ -1110,6 +1110,10 @@ const struct {
   { "issueWoMaterial", -3, QT_TRANSLATE_NOOP("storedProcErrorLookup", "Expected Count of Distribution Detail Records Posted for Controlled Item."),0, ""},
   { "issueWoMaterial", -4, QT_TRANSLATE_NOOP("storedProcErrorLookup", "Qty to Issue Must be Positive"),0, ""},
 
+  { "_itemsrcTrigger", -1, QT_TRANSLATE_NOOP("storedProcErrorLookup", "You do not have privileges to maintain Item Sources."), 0, "" },
+  { "_itemsrcTrigger", -2, QT_TRANSLATE_NOOP("storedProcErrorLookup", "An Item Source already exists for this Vendor/Item combination "
+                      "with an overlapping effective date range. "),    0, "" },
+
   { "login",  -1, QT_TRANSLATE_NOOP("storedProcErrorLookup", "The specified Username does not exist in the specified "
                      "Database. Contact your Systems Administrator to report "
                      "this issue"),                                     0, "" },

--- a/guiclient/itemSource.cpp
+++ b/guiclient/itemSource.cpp
@@ -295,42 +295,6 @@ bool itemSource::sSave()
                           tr( "You must indicate the Ratio of Inventory to Vendor Unit of Measures\n"
                                "before you may save this Item Source." ) )
      ;
-
-  itemSave.prepare( "SELECT itemsrc_id "
-                   "  FROM itemsrc "
-                   " WHERE ((itemsrc_item_id=:itemsrc_item_id) "
-                   "   AND (itemsrc_vend_id=:itemsrc_vend_id) "
-                   "   AND ((itemsrc_contrct_id=:itemsrc_contrct_id) "
-                   "    OR  (itemsrc_contrct_id IS NULL AND :itemsrc_contrct_id IS NULL)) "
-                   "   AND (itemsrc_effective=:itemsrc_effective) "
-                   "   AND (itemsrc_expires=:itemsrc_expires) "
-                   "   AND (itemsrc_vend_item_number=:itemsrc_vend_item_number) "
-                   "   AND (UPPER(itemsrc_manuf_name)=UPPER(:itemsrc_manuf_name)) "
-                   "   AND (UPPER(itemsrc_manuf_item_number)=UPPER(:itemsrc_manuf_item_number)) "
-                   "   AND (itemsrc_id != :itemsrc_id) );");
-  itemSave.bindValue(":itemsrc_id", _itemsrcid);
-  itemSave.bindValue(":itemsrc_item_id", _item->id());
-  itemSave.bindValue(":itemsrc_vend_id", _vendor->id());
-  if (_contract->isValid())
-    itemSave.bindValue(":itemsrc_contrct_id", _contract->id());
-  itemSave.bindValue(":itemsrc_effective", _dates->startDate());
-  itemSave.bindValue(":itemsrc_expires", _dates->endDate());
-  itemSave.bindValue(":itemsrc_vend_item_number", _vendorItemNumber->text());
-  itemSave.bindValue(":itemsrc_manuf_name", _manufName->currentText());
-  itemSave.bindValue(":itemsrc_manuf_item_number", _manufItemNumber->text());
-  itemSave.exec();
-  if(itemSave.first())
-  {
-    errors << GuiErrorCheck(true, _item,
-                            tr("An Item Source already exists for the Item Number, Vendor,\n"
-                               "Contract, Effective Date, Expires Date,\n"
-                               "Vendor Item, Manfacturer Name and Manufacturer Item Number you have specified."));
-  }
-  else if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Saving Item Source Information"),
-                                 itemSave, __FILE__, __LINE__))
-  {
-    return false;
-  }
   
   if(_active->isChecked())
   {


### PR DESCRIPTION
…effective dates.

Move check logic into BEFORE trigger so all clients access the same logic.

requires xtuple/xtuple#3366