### PR TITLE
[33559] fix designer crashes

### DIFF
--- a/widgets/apopencluster.cpp
+++ b/widgets/apopencluster.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2015 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -23,7 +23,8 @@ ApopenCluster::ApopenCluster(QWidget *pParent, const char *pName) :
 
 ApopenLineEdit::DocTypes ApopenCluster::allowedDocTypes()  const
 {
-  return (qobject_cast<ApopenLineEdit*>(_number))->allowedDocTypes();
+  ApopenLineEdit *w = qobject_cast<ApopenLineEdit*>(_number);
+  return w ? w->allowedDocTypes() : ApopenLineEdit::AnyType;
 }
 
 void ApopenLineEdit::setExtraClause(const QString &clause)
@@ -33,27 +34,32 @@ void ApopenLineEdit::setExtraClause(const QString &clause)
 
 void ApopenCluster::setExtraClause(const QString &clause, const QString&)
 {
-  (qobject_cast<ApopenLineEdit*>(_number))->setExtraClause(clause);
+  ApopenLineEdit *w = qobject_cast<ApopenLineEdit*>(_number);
+  if (w) w->setExtraClause(clause);
 }
 
-ApopenLineEdit::DocType  ApopenCluster::type()             const
+ApopenLineEdit::DocType ApopenCluster::type() const
 {
-  return (qobject_cast<ApopenLineEdit*>(_number))->type();
+  ApopenLineEdit *w = qobject_cast<ApopenLineEdit*>(_number);
+  return w ? w->type() : ApopenLineEdit::AnyType;
 }
 
-QString  ApopenCluster::typeString()       const
+QString ApopenCluster::typeString() const
 {
-  return (qobject_cast<ApopenLineEdit*>(_number))->typeString();
+  ApopenLineEdit *w = qobject_cast<ApopenLineEdit*>(_number);
+  return w ? w->typeString() : QString();
 }
 
 void ApopenCluster::setVendId(int pvendid)
 {
-  return (qobject_cast<ApopenLineEdit*>(_number))->setVendId(pvendid);
+  ApopenLineEdit *w = qobject_cast<ApopenLineEdit*>(_number);
+  if (w) w->setVendId(pvendid);
 }
 
 void ApopenCluster::setAllowedDocTypes(const ApopenLineEdit::DocTypes ptypes)
 {
-  return (qobject_cast<ApopenLineEdit*>(_number))->setAllowedDocTypes(ptypes);
+  ApopenLineEdit *w = qobject_cast<ApopenLineEdit*>(_number);
+  if (w) w->setAllowedDocTypes(ptypes);
 }
 
 ApopenLineEdit::ApopenLineEdit(QWidget *pParent, const char *pName) :

--- a/widgets/aropencluster.cpp
+++ b/widgets/aropencluster.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -27,9 +27,10 @@ AropenCluster::AropenCluster(QWidget *pParent, const char *pName) :
   addNumberWidget(new AropenLineEdit(this, pName));
 }
 
-AropenLineEdit::DocTypes AropenCluster::allowedDocTypes()  const
+AropenLineEdit::DocTypes AropenCluster::allowedDocTypes() const
 {
-  return (qobject_cast<AropenLineEdit*>(_number))->allowedDocTypes();
+  AropenLineEdit *w = qobject_cast<AropenLineEdit*>(_number);
+  return w ? w->allowedDocTypes() : AropenLineEdit::AnyType;
 }
 
 void AropenLineEdit::setExtraClause(const QString &clause)
@@ -39,27 +40,32 @@ void AropenLineEdit::setExtraClause(const QString &clause)
 
 void AropenCluster::setExtraClause(const QString &clause, const QString&)
 {
-  (qobject_cast<AropenLineEdit*>(_number))->setExtraClause(clause);
+  AropenLineEdit *w = qobject_cast<AropenLineEdit*>(_number);
+  if (w) w->setExtraClause(clause);
 }
 
-AropenLineEdit::DocType  AropenCluster::type()             const
+AropenLineEdit::DocType AropenCluster::type() const
 {
-  return (qobject_cast<AropenLineEdit*>(_number))->type();
+  AropenLineEdit *w = qobject_cast<AropenLineEdit*>(_number);
+  return w ? w->type() : AropenLineEdit::AnyType;
 }
 
-QString  AropenCluster::typeString()       const
+QString AropenCluster::typeString() const
 {
-  return (qobject_cast<AropenLineEdit*>(_number))->typeString();
+  AropenLineEdit *w = qobject_cast<AropenLineEdit*>(_number);
+  return w ? w->typeString() : QString();
 }
 
 void AropenCluster::setCustId(int pcustid)
 {
-  return (qobject_cast<AropenLineEdit*>(_number))->setCustId(pcustid);
+  AropenLineEdit *w = qobject_cast<AropenLineEdit*>(_number);
+  if (w) w->setCustId(pcustid);
 }
 
 void AropenCluster::setAllowedDocTypes(const AropenLineEdit::DocTypes ptypes)
 {
-  return (qobject_cast<AropenLineEdit*>(_number))->setAllowedDocTypes(ptypes);
+  AropenLineEdit *w = qobject_cast<AropenLineEdit*>(_number);
+  if (w) w->setAllowedDocTypes(ptypes);
 }
 
 AropenLineEdit::AropenLineEdit(QWidget *pParent, const char *pName) :

--- a/widgets/contactCluster.cpp
+++ b/widgets/contactCluster.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -422,27 +422,22 @@ void ContactCluster::openUrl(QString url)
 
 void ContactCluster::addNumberWidget(VirtualClusterLineEdit* pNumberWidget)
 {
-	ContactClusterLineEdit *matchType = qobject_cast<ContactClusterLineEdit *>(pNumberWidget);
+  _number = qobject_cast<ContactClusterLineEdit *>(pNumberWidget);
+  if (! _number)
+    return;
 
-	if(matchType == 0)
-	  return;
+  _number->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+  _number->setMinimumWidth(200);
+  QHBoxLayout *hbox = new QHBoxLayout;
+  QSpacerItem *item = new QSpacerItem(100, 20, QSizePolicy::Fixed, QSizePolicy::Fixed);
+  hbox->addWidget(_number);
+  hbox->addItem(item);
+  _grid->addLayout(hbox, 0, 1, 1, 3);
+  setFocusProxy(pNumberWidget);
 
-    _number = matchType;
-    if (! _number)
-      return;
-
-    _number->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-    _number->setMinimumWidth(200);
-    QHBoxLayout* hbox = new QHBoxLayout;
-    QSpacerItem* item = new QSpacerItem(100, 20, QSizePolicy::Fixed, QSizePolicy::Fixed);
-    hbox->addWidget(_number);
-    hbox->addItem(item);
-    _grid->addLayout(hbox, 0, 1, 1, 3);
-    setFocusProxy(pNumberWidget);
-
-    connect(_number,    SIGNAL(newId(int)),     this,   SIGNAL(newId(int)));
-    connect(_number,    SIGNAL(parsed()),       this,   SLOT(sRefresh()));
-    connect(_number,    SIGNAL(valid(bool)),    this,   SIGNAL(valid(bool)));
+  connect(_number,    SIGNAL(newId(int)),     this,   SIGNAL(newId(int)));
+  connect(_number,    SIGNAL(parsed()),       this,   SLOT(sRefresh()));
+  connect(_number,    SIGNAL(valid(bool)),    this,   SIGNAL(valid(bool)));
 }
 
 void ContactCluster::setName(int segment, const QString& name)

--- a/widgets/documents.cpp
+++ b/widgets/documents.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -399,11 +399,9 @@ void Documents::sOpenDoc(QString mode)
                                           Qt::NonModal, Qt::Window);
   }
 
-  if (w && w->inherits("QDialog"))
-  {
-    QDialog* newdlg = qobject_cast<QDialog*>(w);
+  QDialog* newdlg = qobject_cast<QDialog*>(w);
+  if (newdlg)
     newdlg->exec();
-  }
 
   refresh();
 }

--- a/widgets/itemCluster.cpp
+++ b/widgets/itemCluster.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -547,12 +547,15 @@ void ItemLineEdit::sCopy()
   w = _guiClientInterface->openWindow(uiName, params, parentWidget()->window() , Qt::WindowModal, Qt::Dialog);
 
   QDialog* newdlg = qobject_cast<QDialog*>(w);
-  int id = newdlg->exec();
-  if (id != QDialog::Rejected)
+  if (newdlg)
   {
-    silentSetId(id);
-    emit newId(_id);
-    emit valid(_id != -1);
+    int id = newdlg->exec();
+    if (id != QDialog::Rejected)
+    {
+      silentSetId(id);
+      emit newId(_id);
+      emit valid(_id != -1);
+    }
   }
 
   return;
@@ -971,13 +974,7 @@ ItemCluster::ItemCluster(QWidget* pParent, const char* pName) :
 
 void ItemCluster::addNumberWidget(VirtualClusterLineEdit* pNumberWidget)
 {
-  VirtualClusterLineEdit *matchType = qobject_cast<VirtualClusterLineEdit *>(pNumberWidget);
-
-  if(matchType == 0)
-    return;
-
-  _number = matchType;
-
+  _number = qobject_cast<VirtualClusterLineEdit *>(pNumberWidget);
   if (! _number)
     return;
 

--- a/widgets/scriptablewidget.cpp
+++ b/widgets/scriptablewidget.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -73,6 +73,12 @@ QScriptEngine *ScriptableWidget::engine()
 
 void ScriptableWidget::loadScript(const QStringList &list)
 {
+  if (! _guiClientInterface)
+  {
+    qDebug() << "No GUIClientInterface to ask for scripts";
+    return;
+  }
+
   qDebug() << "Looking for scripts" << list;
   QString widgetName = list.last();
 

--- a/widgets/shiptoCluster.cpp
+++ b/widgets/shiptoCluster.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -110,9 +110,9 @@ void ShiptoEdit::sNew()
         w = _guiClientInterface->openWindow(_uiName, params, parentWidget()->window() , Qt::NonModal, Qt::Window);
     }
 
-    if (w->inherits("QDialog"))
+    QDialog* newdlg = qobject_cast<QDialog*>(w);
+    if (newdlg)
     {
-      QDialog* newdlg = qobject_cast<QDialog*>(w);
       int id = newdlg->exec();
       if (id != QDialog::Rejected)
       {

--- a/widgets/virtualCluster.cpp
+++ b/widgets/virtualCluster.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -96,28 +96,31 @@ VirtualCluster::VirtualCluster(QWidget* pParent,
     addNumberWidget(pNumberWidget);
 }
 
-int     VirtualCluster::id()             const { return _number->id(); }
-QString VirtualCluster::label()          const { return _label->text(); }
-QString VirtualCluster::number()         const { return _number->text(); }
-QString VirtualCluster::description()    const { return _description->text(); }
-bool    VirtualCluster::isValid()        const { return _number->isValid(); }
-QString VirtualCluster::name()           const { return _name->text(); }
-bool    VirtualCluster::isStrict()       const { return _number->isStrict(); }
+int     VirtualCluster::id()             const { return _number ? _number->id()             : -1; }
+QString VirtualCluster::label()          const { return _label  ? _label->text()            : QString(); }
+QString VirtualCluster::number()         const { return _number ? _number->text()           : QString(); }
+QString VirtualCluster::description()    const { return _description ? _description->text() : QString(); }
+bool    VirtualCluster::isValid()        const { return _number ? _number->isValid()        : false; }
+QString VirtualCluster::name()           const { return _name   ? _name->text()             : QString(); }
+bool    VirtualCluster::isStrict()       const { return _number ? _number->isStrict()       : false; }
 bool    VirtualCluster::readOnly()       const { return _readOnly; }
 QString VirtualCluster::defaultNumber()  const { return _default; }
 QString VirtualCluster::fieldName()      const { return _fieldName; }
-QString VirtualCluster::extraClause()    const { return _number->extraClause(); }
+QString VirtualCluster::extraClause()    const { return _number ? _number->extraClause()    : QString(); }
 
 // most of the heavy lifting is done by VirtualClusterLineEdit _number
-void VirtualCluster::clearExtraClause()                 { _number->clearExtraClause(); }
+void VirtualCluster::clearExtraClause()                 { if (_number) _number->clearExtraClause(); }
 void VirtualCluster::setDefaultNumber(const QString& p) { _default=p;}
-void VirtualCluster::setDescription(const QString& p)   { _description->setText(p); }
-void VirtualCluster::setExtraClause(const QString& p, const QString&)  { _number->setExtraClause(p); }
+void VirtualCluster::setDescription(const QString& p)   { if (_description) _description->setText(p); }
+void VirtualCluster::setExtraClause(const QString& p, const QString&)
+{
+  if (_number) _number->setExtraClause(p);
+}
 void VirtualCluster::setFieldName(QString p)            { _fieldName = p; }
-void VirtualCluster::setId(const int p, const QString&) { _number->setId(p); }
-void VirtualCluster::setName(int, const QString& p)     { _name->setText(p); }
-void VirtualCluster::setNumber(const int p)             { _number->setNumber(QString::number(p)); }
-void VirtualCluster::setNumber(QString p)               { _number->setNumber(p); }
+void VirtualCluster::setId(const int p, const QString&) { if (_number) _number->setId(p); }
+void VirtualCluster::setName(int, const QString& p)     { if (_name)   _name->setText(p); }
+void VirtualCluster::setNumber(const int p)             { if (_number) _number->setNumber(QString::number(p)); }
+void VirtualCluster::setNumber(QString p)               { if (_number) _number->setNumber(p); }
 
 void VirtualCluster::clear()
 {
@@ -994,9 +997,9 @@ QWidget* VirtualClusterLineEdit::sOpenWindow(const QString &uiName, ParameterLis
   if (parentWidget()->window())
     w = _guiClientInterface->openWindow(uiName, params, parentWidget()->window() , Qt::WindowModal, Qt::Dialog);
 
-  if (w->inherits("QDialog"))
+  QDialog* newdlg = qobject_cast<QDialog*>(w);
+  if (newdlg)
   {
-    QDialog* newdlg = qobject_cast<QDialog*>(w);
     int id = newdlg->exec();
     if (id != QDialog::Rejected)
     {

--- a/widgets/xcombobox.cpp
+++ b/widgets/xcombobox.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -820,10 +820,11 @@ void XComboBoxPrivate::sEdit()
                                      _parent->parentWidget()->window(),
                                      Qt::ApplicationModal,
                                      Qt::Dialog);
-    if (qobject_cast<QDialog*>(w))
+    QDialog *dlg = qobject_cast<QDialog*>(w);
+    if (dlg)
     {
-      connect(w, SIGNAL(accepted()), _parent, SLOT(populate()));
-      (qobject_cast<QDialog*>(w))->exec();
+      connect(dlg, SIGNAL(accepted()), _parent, SLOT(populate()));
+      dlg->exec();
     }
     else
     {

--- a/widgets/xlabel.cpp
+++ b/widgets/xlabel.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -103,8 +103,9 @@ void XLabel::setImage(QString image)
 
 void XLabel::setPrecision(QValidator *pVal)
 {
-  if (qobject_cast<QDoubleValidator *>(pVal))
-    _data->_precision = (qobject_cast<QDoubleValidator *>(pVal))->decimals();
+  QDoubleValidator *dval = qobject_cast<QDoubleValidator *>(pVal);
+  if (dval)
+    _data->_precision = dval->decimals();
   else if (qobject_cast<QIntValidator *>(pVal))
     _data->_precision = 0;
   else

--- a/widgets/xtextedit.cpp
+++ b/widgets/xtextedit.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -170,7 +170,8 @@ void XTextEditHighlighter::highlightBlock(const QString &text)
        enableSpellPref = (_x_preferences->value("SpellCheck")=="t");
 
     if(_guiClientInterface && _guiClientInterface->hunspell_ready()
-       && enableSpellPref && textEdit->spellEnabled()
+       && enableSpellPref
+       && textEdit && textEdit->spellEnabled()
        && textEdit->isEnabled() && !textEdit->isReadOnly())
     {
       QString widgetText = text.simplified();

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -729,16 +729,18 @@ void XTreeWidget::populateWorker()
         _last->setHidden(true);
       }
 
-      if (qobject_cast<XTreeWidget*>(parentItem))
+      XTreeWidget     *tree = qobject_cast<XTreeWidget*>(parentItem);
+      XTreeWidgetItem *item = qobject_cast<XTreeWidgetItem*>(parentItem);
+      if (tree)
       {
         //#13439 optimization - do not add items to 'this' until the very end
-        if(parentItem == this)
+        if (parentItem == this)
           topLevelItems.append(_last);
         else
-          qobject_cast<XTreeWidget*>(parentItem)->addTopLevelItem(_last);
+          tree->addTopLevelItem(_last);
       }
-      else if (qobject_cast<XTreeWidgetItem*>(parentItem))
-        qobject_cast<XTreeWidgetItem*>(parentItem)->addChild(_last);
+      else if (item)
+        item->addChild(_last);
 
     } while (pQuery.next());
 


### PR DESCRIPTION
Replaced qobject_casts that always succeeded with qobject_cast calls and
guarded dereferencing of the resulting pointers. Tested by creating a
uiform with the embedded designer that contains every xTuple custom widget