### PR TITLE
[29272] Streamline lot/serial traceability on Transfer Orders. 

### DIFF
--- a/guiclient/createLotSerial.h
+++ b/guiclient/createLotSerial.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -47,6 +47,7 @@ private:
     LotSerialUtils _lschars;
     QList<QWidget *> _charWidgets;
     bool _lotsFound;
+    QMap<int, double> _lsMap;
 
 };
 

--- a/guiclient/item.cpp
+++ b/guiclient/item.cpp
@@ -183,10 +183,11 @@ item::item(QWidget* parent, const char* name, Qt::WindowFlags fl)
 
   _itemSite->addColumn(tr("Active"),        _dateColumn, Qt::AlignCenter, true, "itemsite_active" );
   _itemSite->addColumn(tr("Site"),          _whsColumn,  Qt::AlignCenter, true, "warehous_code" );
-  _itemSite->addColumn(tr("Description"),   -1,          Qt::AlignLeft, true, "warehous_descrip"   );
-  _itemSite->addColumn(tr("Cntrl. Method"), _itemColumn, Qt::AlignCenter, true, "controlmethod" );
-  _itemSite->addColumn(tr("Cost Method"),   _itemColumn, Qt::AlignCenter, true, "costmethod" );
-  _itemSite->addColumn(tr("Avg. Cost"),     _moneyColumn, Qt::AlignRight, true, "avgcost" );
+  _itemSite->addColumn(tr("Description"),   -1,          Qt::AlignLeft,   true, "warehous_descrip"   );
+  _itemSite->addColumn(tr("Cntrl. Method"), -1,          Qt::AlignCenter, true, "controlmethod" );
+  _itemSite->addColumn(tr("Loc. Cntrl."),   -1,          Qt::AlignCenter, true, "itemsite_loccntrl" );
+  _itemSite->addColumn(tr("Cost Method"),   -1,          Qt::AlignCenter, true, "costmethod" );
+  _itemSite->addColumn(tr("Avg. Cost"),     -1,          Qt::AlignRight,  true, "avgcost" );
   _itemSite->setDragString("itemsiteid=");
 
   connect(omfgThis, SIGNAL(itemsitesUpdated()), SLOT(sFillListItemSites()));

--- a/guiclient/lotSerialUtils.cpp
+++ b/guiclient/lotSerialUtils.cpp
@@ -77,18 +77,16 @@ void LotSerialUtils::updateLotCharacteristics(int ls_id, const QList<QWidget *> 
         QString char_text;
 
         if (_charTypes.at(i) == 0)
-        {
-            char_text = qobject_cast<QLineEdit *>(widgets.at(i))->text();
-        }
+           char_text = qobject_cast<QLineEdit *>(widgets.at(i))->text();
         else if (_charTypes.at(i) == 1)
-        {
-            char_text = qobject_cast<XComboBox *>(widgets.at(i))->currentText();
-        }
+           char_text = qobject_cast<XComboBox *>(widgets.at(i))->currentText();
         else if (_charTypes.at(i) == 2)
         {
             QDate d = qobject_cast<DLineEdit *>(widgets.at(i))->date();
             char_text = d.toString("yyyy-MM-dd");
         }
+        else if (_charTypes.at(i) == 3)
+            char_text = qobject_cast<QLineEdit *>(widgets.at(i))->text();
 
         XSqlQuery q;
         q.prepare("INSERT INTO charass (charass_value, charass_target_type, charass_target_id, charass_char_id)"

--- a/widgets/xcombobox.cpp
+++ b/widgets/xcombobox.cpp
@@ -1011,7 +1011,6 @@ void XComboBox::setListIdFieldName(QString p)
   _data->_listIdFieldName = p;
 }
 
-// exists only for script exposure
 void XComboBox::removeItem(int idx)
 {
   QComboBox::removeItem(idx);


### PR DESCRIPTION
Also resolves a bunch of bugs around lot/serial on TO Receipts.
Streamlines the process and makes receiving lots on TOs much easier for end-users.
Fixed characteristic/expiry bug
Locks down Lot receipt so you cannot receive more than shipped

requires xtuple/private-extensions#1034