### PR TITLE
[11131] Add CSV support to Export Data Functionality

### DIFF
--- a/common/exporthelper.cpp
+++ b/common/exporthelper.cpp
@@ -928,7 +928,7 @@ int ExportHelper::validDelim(QString delim, QString &msg)
   if (delim.length() > 1 && delim != "{tab}")
   {
     msg = tr("Avoid delimiters more than 1 char long.");
-    valid = 1; // delim is too long
+    valid = tooLong; // delim is too long
   }
     
   else if (disallowed.contains(delim))

--- a/common/exporthelper.cpp
+++ b/common/exporthelper.cpp
@@ -27,6 +27,7 @@
 #include "mqlutil.h"
 #include "xsqlquery.h"
 
+
 #define DEBUG false
 
 bool ExportHelper::exportHTML(const int qryheadid, ParameterList &params, QString &filename, QString &errmsg)
@@ -903,4 +904,45 @@ void setupExportHelper(QScriptEngine *engine)
   obj.setProperty("XSLTConvertString", engine->newFunction(XSLTConvertString), QScriptValue::ReadOnly | QScriptValue::Undeletable);
 
   engine->globalObject().setProperty("ExportHelper", obj, QScriptValue::ReadOnly | QScriptValue::Undeletable);
+}
+
+QStringList ExportHelper::parseDelim(QString delim)
+{ 
+  QStringList delimItems; 
+  int i = delim.indexOf('{') ;
+  if ( i >=0)
+    delim.remove("{tab}");  
+  foreach(QChar c, delim)
+    delimItems.append(c);  
+  if(i>=0)
+    delimItems.insert(i,"{tab}");
+  return delimItems;
+}
+
+
+bool ExportHelper::validDelim(QString delim)
+{ 
+  QString msg;
+  QString disallowed = "(){}[]\"'`<>.{blank}";
+  QString discouraged = " @#$%&*_=-+/? ";
+  bool valid = true;
+  if (delim.length() > 1 && delim != "{tab}")
+    msg = tr("Avoid delimiters more than 1 char long.");
+  else if (disallowed.contains(delim))
+    msg = tr("%1 is not permitted as a delimiter. The following characters are not allowed: %2").arg(delim, disallowed);
+  else if (discouraged.contains(delim))
+  {
+    msg = tr("%1 may cause problems. We suggest avoiding the following: %2").arg(delim, discouraged);
+    valid = true;
+  }
+  else
+    valid = true;
+
+  if(! msg.isEmpty())
+  {
+    QMessageBox msgBox;
+    msgBox.exec();
+  }
+    
+  return valid;
 }

--- a/common/exporthelper.cpp
+++ b/common/exporthelper.cpp
@@ -919,28 +919,24 @@ QStringList ExportHelper::parseDelim(QString delim)
   return delimItems;
 }
 
-
-int ExportHelper::validDelim(QString delim, QString &msg)
+enum ExportHelper::delimCheck ExportHelper::validDelim(QString delim, QString &msg)
 { 
-  QString disallowed = "(){}[]\"'`<>.{blank}";
-  QString discouraged = " @#$%&*_=-+/? ";
-  int valid = 0; // delim is valid
+  QString disallowedChars = "(){}[]\"'`<>.{blank}";
+  QString discouragedChars = " @#$%&*_=-+/? ";
   if (delim.length() > 1 && delim != "{tab}")
-  {
+  { 
     msg = tr("Avoid delimiters more than 1 char long.");
-    valid = tooLong; // delim is too long
+    return tooLong; // delim is too long
   }
-    
-  else if (disallowed.contains(delim))
+  else if (disallowedChars.contains(delim))
   {
-    msg = tr("%1 is not permitted as a delimiter. The following characters are not allowed: %2").arg(delim, disallowed);
-    valid = 2; // delim error
+    msg = tr("%1 is not permitted as a delimiter. The following characters are not allowed: %2").arg(delim, disallowedChars);
+    return disallowed; // delim error
   }
-  else if (discouraged.contains(delim))
+  else if (discouragedChars.contains(delim))
   {
-    msg = tr("%1 may cause problems. We suggest avoiding the following: %2").arg(delim, discouraged);
-    valid = 3; // delim warning
+    msg = tr("%1 may cause problems. We suggest avoiding the following: %2").arg(delim, discouragedChars);
+    return disencouraged; // delim warning
   }
-
   return valid;
 }

--- a/common/exporthelper.cpp
+++ b/common/exporthelper.cpp
@@ -920,29 +920,27 @@ QStringList ExportHelper::parseDelim(QString delim)
 }
 
 
-bool ExportHelper::validDelim(QString delim)
+int ExportHelper::validDelim(QString delim, QString &msg)
 { 
-  QString msg;
   QString disallowed = "(){}[]\"'`<>.{blank}";
   QString discouraged = " @#$%&*_=-+/? ";
-  bool valid = true;
+  int valid = 0; // delim is valid
   if (delim.length() > 1 && delim != "{tab}")
+  {
     msg = tr("Avoid delimiters more than 1 char long.");
+    valid = 1; // delim is too long
+  }
+    
   else if (disallowed.contains(delim))
+  {
     msg = tr("%1 is not permitted as a delimiter. The following characters are not allowed: %2").arg(delim, disallowed);
+    valid = 2; // delim error
+  }
   else if (discouraged.contains(delim))
   {
     msg = tr("%1 may cause problems. We suggest avoiding the following: %2").arg(delim, discouraged);
-    valid = true;
+    valid = 3; // delim warning
   }
-  else
-    valid = true;
 
-  if(! msg.isEmpty())
-  {
-    QMessageBox msgBox;
-    msgBox.exec();
-  }
-    
   return valid;
 }

--- a/common/exporthelper.h
+++ b/common/exporthelper.h
@@ -39,6 +39,8 @@ class ExportHelper : public QObject
     static QString XSLTConvertString(QString input, int xsltmapid, QString &errmsg);
     static QStringList parseDelim(QString delim);
     static int validDelim(QString delim, QString &errMsg);
+
+    enum delimCheck{valid=0, tooLong=1, disallowed=2, disencouraged=3};
 };
 
 void setupExportHelper(QScriptEngine *engine);

--- a/common/exporthelper.h
+++ b/common/exporthelper.h
@@ -26,6 +26,8 @@ class ExportHelper : public QObject
   Q_OBJECT
 
   public:
+    enum delimCheck{valid=0, tooLong=1, disallowed=2, disencouraged=3};
+
     static bool exportHTML(const int qryheadid, ParameterList &params, QString &filename, QString &errmsg);
     static bool exportXML(const int qryheadid, ParameterList &params, QString &filename, QString &errmsg, const int xsltmapid = -1);
     static QString generateDelimited(const int qryheadid, ParameterList &params, QString &errmsg);
@@ -38,9 +40,9 @@ class ExportHelper : public QObject
     static bool    XSLTConvertFile(QString inputfilename, QString outputfilename, int xsltmapid, QString &errmsg);
     static QString XSLTConvertString(QString input, int xsltmapid, QString &errmsg);
     static QStringList parseDelim(QString delim);
-    static int validDelim(QString delim, QString &errMsg);
+    static enum delimCheck validDelim(QString delim, QString &errMsg);
 
-    enum delimCheck{valid=0, tooLong=1, disallowed=2, disencouraged=3};
+    
 };
 
 void setupExportHelper(QScriptEngine *engine);

--- a/common/exporthelper.h
+++ b/common/exporthelper.h
@@ -38,7 +38,7 @@ class ExportHelper : public QObject
     static bool    XSLTConvertFile(QString inputfilename, QString outputfilename, int xsltmapid, QString &errmsg);
     static QString XSLTConvertString(QString input, int xsltmapid, QString &errmsg);
     static QStringList parseDelim(QString delim);
-    static bool validDelim(QString delim);
+    static int validDelim(QString delim, QString &errMsg);
 };
 
 void setupExportHelper(QScriptEngine *engine);

--- a/common/exporthelper.h
+++ b/common/exporthelper.h
@@ -37,6 +37,8 @@ class ExportHelper : public QObject
     static bool    XSLTConvertFile(QString inputfilename, QString outputfilename, QString xsltfilename, QString &errmsg);
     static bool    XSLTConvertFile(QString inputfilename, QString outputfilename, int xsltmapid, QString &errmsg);
     static QString XSLTConvertString(QString input, int xsltmapid, QString &errmsg);
+    static QStringList parseDelim(QString delim);
+    static bool validDelim(QString delim);
 };
 
 void setupExportHelper(QScriptEngine *engine);

--- a/guiclient/userPreferences.cpp
+++ b/guiclient/userPreferences.cpp
@@ -356,7 +356,6 @@ void userPreferences::sSave(bool close)
   omfgThis->_timeoutHandler->setIdleMinutes(_idleTimeout->value());
   
   //////// check delimiter /////////////////////////////////////////
-  enum delimCheck{valid=0, tooLong=1, disallowed=2, disencouraged=3};
   QString errMsg;
   int delimiter = ExportHelper::validDelim(_delimiter->currentText(),errMsg); 
   if(!errMsg.isEmpty())
@@ -365,12 +364,12 @@ void userPreferences::sSave(bool close)
     msgBox.setText(errMsg);
     msgBox.exec();
   } 
-  if(delimiter == tooLong)
+  if(delimiter == ExportHelper::tooLong)
   {
     _delimiter->setCurrentText(_delimiter->currentText().at(0));
     return;
   }
-  else if(delimiter == disallowed)
+  else if(delimiter == ExportHelper::disallowed)
     return;
 
   // save to DB

--- a/guiclient/userPreferences.cpp
+++ b/guiclient/userPreferences.cpp
@@ -354,15 +354,28 @@ void userPreferences::sSave(bool close)
 
   _pref->set("IdleTimeout", _idleTimeout->value());
   omfgThis->_timeoutHandler->setIdleMinutes(_idleTimeout->value());
-
-  if(ExportHelper::validDelim(_delimiter->currentText()))
+  
+  //////// check delimiter /////////////////////////////////////////
+  enum delimCheck{valid=0, tooLong=1, disallowed=2, disencouraged=3};
+  QString errMsg;
+  #pragma comment(linker,"/SUBSYSTEM:CONSOLE")
+  int delimiter = ExportHelper::validDelim(_delimiter->currentText(),errMsg); 
+  qDebug() << "error message: " << errMsg;
+  if(!errMsg.isEmpty())
   {
-    if(_delimiter->currentText().length() > 1)
-      _delimiter->setCurrentText(_delimiter->currentText().at(0));
-    else
-      _delimiter->clearEditText();
+    QMessageBox msgBox;
+    msgBox.setText(errMsg);
+    msgBox.exec();
+  } 
+  if(delimiter == tooLong)
+  {
+    _delimiter->setCurrentText(_delimiter->currentText().at(0));
     return;
   }
+  else if(delimiter == disallowed)
+    return;
+
+  // save to DB
   QString delim;
   for (int i=0; i<_delimiter->count(); i++)
     delim += _delimiter->itemText(i);
@@ -370,7 +383,7 @@ void userPreferences::sSave(bool close)
     delim.remove(_delimiter->currentText());
   delim.prepend(_delimiter->currentText());
   _pref->set("Delimiter",delim);
-  
+  ////////////////////////////////////////////////////////////////
 
   if(_ellipsesAction->id() == 2)
     _pref->set("DefaultEllipsesAction", QString("search"));

--- a/guiclient/userPreferences.cpp
+++ b/guiclient/userPreferences.cpp
@@ -358,9 +358,7 @@ void userPreferences::sSave(bool close)
   //////// check delimiter /////////////////////////////////////////
   enum delimCheck{valid=0, tooLong=1, disallowed=2, disencouraged=3};
   QString errMsg;
-  #pragma comment(linker,"/SUBSYSTEM:CONSOLE")
   int delimiter = ExportHelper::validDelim(_delimiter->currentText(),errMsg); 
-  qDebug() << "error message: " << errMsg;
   if(!errMsg.isEmpty())
   {
     QMessageBox msgBox;

--- a/guiclient/userPreferences.cpp
+++ b/guiclient/userPreferences.cpp
@@ -29,7 +29,7 @@
 #include "timeoutHandler.h"
 #include "translations.h"
 #include "dictionaries.h"
-#include "xtreewidget.h"
+#include "exporthelper.h"
 
 extern QString __password;
 
@@ -116,7 +116,7 @@ userPreferences::userPreferences(QWidget* parent, const char* name, bool modal, 
     delim = _pref->value("Delimiter");
   else
     delim = ",{tab}~|;:^!";
-  _delimiter->insertItems(0,parseDelim(delim));
+  _delimiter->insertItems(0,ExportHelper::parseDelim(delim));
   _delimiter->setCurrentIndex(0);
 
 
@@ -355,7 +355,7 @@ void userPreferences::sSave(bool close)
   _pref->set("IdleTimeout", _idleTimeout->value());
   omfgThis->_timeoutHandler->setIdleMinutes(_idleTimeout->value());
 
-  if(invalidDelim(_delimiter->currentText()))
+  if(ExportHelper::validDelim(_delimiter->currentText()))
   {
     if(_delimiter->currentText().length() > 1)
       _delimiter->setCurrentText(_delimiter->currentText().at(0));

--- a/guiclient/userPreferences.cpp
+++ b/guiclient/userPreferences.cpp
@@ -110,7 +110,6 @@ userPreferences::userPreferences(QWidget* parent, const char* name, bool modal, 
   userPref = mql.toQuery(params);
   _user->populate(userPref);
 
-  /////////////////////////////////////////
   _delimiter->clear();
   QString delim;
   if(!_pref->value("Delimiter").isEmpty())
@@ -119,7 +118,6 @@ userPreferences::userPreferences(QWidget* parent, const char* name, bool modal, 
     delim = ",{tab}~|;:^!";
   _delimiter->insertItems(0,parseDelim(delim));
   _delimiter->setCurrentIndex(0);
-  //////////////////////////////////////////////
 
 
   _ellipsesAction->append(1, tr("List"));
@@ -357,7 +355,6 @@ void userPreferences::sSave(bool close)
   _pref->set("IdleTimeout", _idleTimeout->value());
   omfgThis->_timeoutHandler->setIdleMinutes(_idleTimeout->value());
 
-  //////////////////////////////////////////////////////////////////
   if(invalidDelim(_delimiter->currentText()))
   {
     if(_delimiter->currentText().length() > 1)
@@ -374,7 +371,6 @@ void userPreferences::sSave(bool close)
   delim.prepend(_delimiter->currentText());
   _pref->set("Delimiter",delim);
   
-  //////////////////////////////////////////////////////////////////
 
   if(_ellipsesAction->id() == 2)
     _pref->set("DefaultEllipsesAction", QString("search"));

--- a/guiclient/userPreferences.cpp
+++ b/guiclient/userPreferences.cpp
@@ -366,7 +366,14 @@ void userPreferences::sSave(bool close)
       _delimiter->clearEditText();
     return;
   }
-  saveDelim(_delimiter->currentText());
+  QString delim;
+  for (int i=0; i<_delimiter->count(); i++)
+    delim += _delimiter->itemText(i);
+  if(delim.contains(_delimiter->currentText()))
+    delim.remove(_delimiter->currentText());
+  delim.prepend(_delimiter->currentText());
+  _pref->set("Delimiter",delim);
+  
   //////////////////////////////////////////////////////////////////
 
   if(_ellipsesAction->id() == 2)

--- a/guiclient/userPreferences.cpp
+++ b/guiclient/userPreferences.cpp
@@ -357,7 +357,7 @@ void userPreferences::sSave(bool close)
   
   //////// check delimiter /////////////////////////////////////////
   QString errMsg;
-  int delimiter = ExportHelper::validDelim(_delimiter->currentText(),errMsg); 
+  ExportHelper::delimCheck delimiter = ExportHelper::validDelim(_delimiter->currentText(),errMsg); 
   if(!errMsg.isEmpty())
   {
     QMessageBox msgBox;
@@ -370,7 +370,11 @@ void userPreferences::sSave(bool close)
     return;
   }
   else if(delimiter == ExportHelper::disallowed)
+  {
+    _delimiter->clearEditText();
     return;
+  }
+    
 
   // save to DB
   QString delim;

--- a/guiclient/userPreferences.h
+++ b/guiclient/userPreferences.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree

--- a/guiclient/userPreferences.ui
+++ b/guiclient/userPreferences.ui
@@ -289,6 +289,20 @@ to be bound by its terms.</comment>
             </property>
            </widget>
           </item>
+          <item row="1" column="2">
+           <widget class="QComboBox" name="_delimiter">
+            <property name="editable">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1" alignment="Qt::AlignRight">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Default Delimiter:</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/widgets/exportOptions.cpp
+++ b/widgets/exportOptions.cpp
@@ -1,0 +1,93 @@
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which (including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
+
+#include "exportOptions.h"
+#include <QDebug>
+
+ExportOptions::ExportOptions(QWidget* parent, Qt::WindowFlags fl): QDialog(parent, fl)
+{
+  setupUi(this);
+  
+  connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+  connect(buttonBox, SIGNAL(accepted()), this, SLOT(sSave()));
+  connect(csvRB, SIGNAL(clicked()), this, SLOT(sEnableCB()));
+  connect(vcfRB, SIGNAL(clicked()), this, SLOT(sEnableCB()));
+  connect(txtRB, SIGNAL(clicked()), this, SLOT(sEnableCB()));
+  connect(htmlRB, SIGNAL(clicked()), this, SLOT(sEnableCB()));
+  connect(odtRB, SIGNAL(clicked()), this, SLOT(sEnableCB()));
+
+  populateDelim();
+  _filetype = csvRB->text();
+
+}
+
+ExportOptions::~ExportOptions()
+{
+  // no need to delete child widgets, Qt does it all for us
+}
+
+void ExportOptions::sEnableCB()
+{
+  if(csvRB->isChecked())
+  {
+    delimCB->setEnabled(true);
+    _filetype = csvRB->text();
+  }    
+  else if(vcfRB->isChecked())
+  {
+    delimCB->setEnabled(false);
+    _filetype = vcfRB->text();
+  }    
+  else if(txtRB->isChecked())
+  {
+    delimCB->setEnabled(false);
+    _filetype = txtRB->text();
+  }    
+  else if(htmlRB->isChecked())
+  {
+    delimCB->setEnabled(false);
+    _filetype = htmlRB->text();
+  }    
+  else if(odtRB->isChecked())
+  {
+    delimCB->setEnabled(false);
+    _filetype = odtRB->text();
+  }     
+}
+
+void ExportOptions::populateDelim()
+{
+  QStringList delimValues;
+  if(_x_preferences)
+    delimValues = parseDelim(_x_preferences->value("Delimiter"));
+  delimCB->insertItems(0,delimValues);
+}
+
+void ExportOptions::sSave()
+{
+  if(invalidDelim(delimCB->currentText()))
+  {
+    if(delimCB->currentText().length() > 1)
+      delimCB->setCurrentText(delimCB->currentText().at(0));
+    else
+      delimCB->clearEditText();
+    return;
+  }
+  QString delim;
+  for (int i=0; i<delimCB->count(); i++)
+    delim += delimCB->itemText(i);
+  if(delim.contains(delimCB->currentText()))
+    delim.remove(delimCB->currentText());
+  delim.prepend(delimCB->currentText());
+  _x_preferences->set("Delimiter",delim);
+
+  _delim = delimCB->currentText();
+  accept();
+}

--- a/widgets/exportOptions.cpp
+++ b/widgets/exportOptions.cpp
@@ -9,7 +9,7 @@
  */
 
 #include "exportOptions.h"
-#include "exportHelper.h"
+#include "exporthelper.h"
 #include <QMessageBox>
 
 ExportOptions::ExportOptions(QWidget* parent, Qt::WindowFlags fl): QDialog(parent, fl)

--- a/widgets/exportOptions.cpp
+++ b/widgets/exportOptions.cpp
@@ -9,7 +9,7 @@
  */
 
 #include "exportOptions.h"
-#include <QDebug>
+#include <QMessageBox>
 
 ExportOptions::ExportOptions(QWidget* parent, Qt::WindowFlags fl): QDialog(parent, fl)
 {
@@ -72,14 +72,25 @@ void ExportOptions::populateDelim()
 
 void ExportOptions::sSave()
 {
-  if(!ExportHelper::validDelim(delimCB->currentText()))
+  enum delimCheck{valid=0, tooLong=1, disallowed=2, disencouraged=3};
+  QString errMsg;
+  int delimiter = ExportHelper::validDelim(delimCB->currentText(),errMsg);
+  
+  if(!errMsg.isEmpty())
   {
-    if(delimCB->currentText().length() > 1)
-      delimCB->setCurrentText(delimCB->currentText().at(0));
-    else
-      delimCB->clearEditText();
+    QMessageBox msgBox;
+    msgBox.setText(errMsg);
+    msgBox.exec();
+  } 
+  if(delimiter == tooLong)
+  {
+    delimCB->setCurrentText(delimCB->currentText().at(0));
     return;
   }
+  else if(delimiter == disallowed)
+    return;
+
+  // save to DB
   QString delim;
   for (int i=0; i<delimCB->count(); i++)
     delim += delimCB->itemText(i);

--- a/widgets/exportOptions.cpp
+++ b/widgets/exportOptions.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "exportOptions.h"
+#include "exportHelper.h"
 #include <QMessageBox>
 
 ExportOptions::ExportOptions(QWidget* parent, Qt::WindowFlags fl): QDialog(parent, fl)
@@ -72,7 +73,6 @@ void ExportOptions::populateDelim()
 
 void ExportOptions::sSave()
 {
-  enum delimCheck{valid=0, tooLong=1, disallowed=2, disencouraged=3};
   QString errMsg;
   int delimiter = ExportHelper::validDelim(delimCB->currentText(),errMsg);
   
@@ -82,12 +82,12 @@ void ExportOptions::sSave()
     msgBox.setText(errMsg);
     msgBox.exec();
   } 
-  if(delimiter == tooLong)
+  if(delimiter == ExportHelper::tooLong)
   {
     delimCB->setCurrentText(delimCB->currentText().at(0));
     return;
   }
-  else if(delimiter == disallowed)
+  else if(delimiter == ExportHelper::disallowed)
     return;
 
   // save to DB

--- a/widgets/exportOptions.cpp
+++ b/widgets/exportOptions.cpp
@@ -74,7 +74,7 @@ void ExportOptions::populateDelim()
 void ExportOptions::sSave()
 {
   QString errMsg;
-  int delimiter = ExportHelper::validDelim(delimCB->currentText(),errMsg);
+  ExportHelper::delimCheck delimiter = ExportHelper::validDelim(delimCB->currentText(),errMsg);
   
   if(!errMsg.isEmpty())
   {

--- a/widgets/exportOptions.cpp
+++ b/widgets/exportOptions.cpp
@@ -66,13 +66,13 @@ void ExportOptions::populateDelim()
 {
   QStringList delimValues;
   if(_x_preferences)
-    delimValues = parseDelim(_x_preferences->value("Delimiter"));
+    delimValues = ExportHelper::parseDelim(_x_preferences->value("Delimiter"));
   delimCB->insertItems(0,delimValues);
 }
 
 void ExportOptions::sSave()
 {
-  if(invalidDelim(delimCB->currentText()))
+  if(!ExportHelper::validDelim(delimCB->currentText()))
   {
     if(delimCB->currentText().length() > 1)
       delimCB->setCurrentText(delimCB->currentText().at(0));

--- a/widgets/exportOptions.h
+++ b/widgets/exportOptions.h
@@ -1,0 +1,43 @@
+/********************************************************************************
+** Form generated from reading UI file 'exportOptions.ui'
+**
+** Created by: Qt User Interface Compiler version 5.5.1
+**
+** WARNING! All changes made in this file will be lost when recompiling UI file!
+********************************************************************************/
+
+#ifndef EXPORTOPTIONS_H
+#define EXPORTOPTIONS_H
+
+
+#include <QDialog>
+
+#include "ui_exportOptions.h"
+#include "xtreewidget.h"
+
+QT_BEGIN_NAMESPACE
+
+class ExportOptions: public QDialog , public Ui::ExportOptions
+{
+  Q_OBJECT
+  public:
+    ExportOptions(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    ~ExportOptions();
+   
+    void populateDelim();
+    QString getFiletype(){return _filetype;}
+    QString getDelim(){return _delim;} 
+
+  public slots:
+    void sEnableCB();  
+    void sSave();
+
+  private:
+    QString _filetype;
+    QString _delim;
+
+};
+
+QT_END_NAMESPACE
+
+#endif 

--- a/widgets/exportOptions.h
+++ b/widgets/exportOptions.h
@@ -1,10 +1,12 @@
-/********************************************************************************
-** Form generated from reading UI file 'exportOptions.ui'
-**
-** Created by: Qt User Interface Compiler version 5.5.1
-**
-** WARNING! All changes made in this file will be lost when recompiling UI file!
-********************************************************************************/
+/*
+ * This file is part of the xTuple ERP: PostBooks Edition, a free and
+ * open source Enterprise Resource Planning software suite,
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
+ * It is licensed to you under the Common Public Attribution License
+ * version 1.0, the full text of which (including xTuple-specific Exhibits)
+ * is available at www.xtuple.com/CPAL.  By using this software, you agree
+ * to be bound by its terms.
+ */
 
 #ifndef EXPORTOPTIONS_H
 #define EXPORTOPTIONS_H

--- a/widgets/exportOptions.h
+++ b/widgets/exportOptions.h
@@ -16,6 +16,7 @@
 
 #include "ui_exportOptions.h"
 #include "xtreewidget.h"
+#include "exporthelper.h"
 
 QT_BEGIN_NAMESPACE
 

--- a/widgets/exportOptions.ui
+++ b/widgets/exportOptions.ui
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ExportOptions</class>
+ <widget class="QDialog" name="ExportOptions">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>240</y>
+     <width>341</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+  <widget class="QWidget" name="layoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>30</y>
+     <width>351</width>
+     <height>134</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="2">
+       <widget class="QComboBox" name="delimCB">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QRadioButton" name="csvRB">
+        <property name="text">
+         <string>Text, Other Separator (*.csv)</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <widget class="QRadioButton" name="vcfRB">
+      <property name="text">
+       <string>Text VCF (*.vcf)</string>
+      </property>
+      <property name="checked">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QRadioButton" name="txtRB">
+      <property name="text">
+       <string>Text  (*.txt)</string>
+      </property>
+      <property name="checked">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QRadioButton" name="htmlRB">
+      <property name="text">
+       <string>HTML (*.html)</string>
+      </property>
+      <property name="checked">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QRadioButton" name="odtRB">
+      <property name="text">
+       <string>ODF Text Document (*.odt)</string>
+      </property>
+      <property name="checked">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/widgets/widgets.pro
+++ b/widgets/widgets.pro
@@ -148,6 +148,7 @@ SOURCES += widgets.cpp \
     empcluster.cpp \
     empgroupcluster.cpp \
     expensecluster.cpp \
+    exportOptions.cpp \
     filecluster.cpp \
     filemoveselector.cpp \
     filterManager.cpp \
@@ -247,6 +248,7 @@ HEADERS += widgets.h \
     empcluster.h \
     empgroupcluster.h \
     expensecluster.h \
+    exportOptions.h \
     filecluster.h \
     filemoveselector.h \
     filterManager.h \
@@ -324,6 +326,7 @@ FORMS += alarmMaint.ui \
     docAttach.ui \
     documents.ui \
     editwatermark.ui    \
+    exportOptions.ui \
     filemoveselector.ui \
     filterManager.ui \
     filterSave.ui \

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -39,6 +39,7 @@
 #include <QTextTableFormat>
 #include <QtScript>
 #include <QMessageBox>
+#include <QInputDialog>
 
 #include "xtreewidgetprogress.h"
 #include "xtsettings.h"
@@ -1625,8 +1626,27 @@ void XTreeWidget::sExport()
 {
   QString   path = xtsettingsValue(_settingsName + "/exportPath").toString();
   QString selectedFilter;
+  
+  // ask user to select separator
+  #pragma comment(linker, "/SUBSYSTEM:CONSOLE")
+  qDebug() << "qinput dialog";
+  QStringList items;
+  items << "," <<"{tab}" <<";" << "|" << "^";
+
+  bool ok;
+  QInputDialog qid;
+  QString item = qid.getItem(this, tr("Delimiter selection"),
+                                        tr("Select Delimiter :"), items, 0, true, &ok);
+  
+  if(!items.contains(item)){
+    items << item;
+  }
+  if (ok && !item.isEmpty())
+      qDebug() << "Cool";
+  ///////////////////////////
+
   QFileInfo fi(QFileDialog::getSaveFileName(this, tr("Export Save Filename"), path,
-                                            tr("Text CSV (*.csv);;Text VCF (*.vcf);;Text (*.txt);;ODF Text Document (*.odt);;HTML Document (*.html)"), &selectedFilter));
+                                            tr("Text, Other Separator (*.csv);;Text VCF (*.vcf);;Text (*.txt);;ODF Text Document (*.odt);;HTML Document (*.html)"), &selectedFilter));
   QString defaultSuffix;
   if(selectedFilter.contains("csv"))
     defaultSuffix = ".csv";
@@ -1636,7 +1656,7 @@ void XTreeWidget::sExport()
     defaultSuffix = ".odt";
   else if(selectedFilter.contains("html"))
     defaultSuffix = ".html";
-  else
+  else  
     defaultSuffix = ".txt";
 
   if (!fi.filePath().isEmpty())
@@ -2482,7 +2502,7 @@ QString XTreeWidget::toTxt() const
   return opText;
 }
 
-QString XTreeWidget::toCsv() const
+QString XTreeWidget::toSV(QString pSep) const
 {
   QString line;
   QString opText;
@@ -2495,7 +2515,7 @@ QString XTreeWidget::toCsv() const
     if (!QTreeWidget::isColumnHidden(counter))
     {
       if (colcount)
-        line = line + ",";
+        line = line + pSep;
       line = line + header->text(counter).replace("\"","\"\"").replace("\r\n"," ").replace("\n"," ");
       colcount++;
     }
@@ -2517,7 +2537,7 @@ QString XTreeWidget::toCsv() const
           if (!QTreeWidget::isColumnHidden(counter))
           {
             if (colcount)
-              line = line + ",";
+              line = line + pSep;
             if (item->data(counter,Qt::DisplayRole).type() == QVariant::String)
               line = line + "\"";
             line = line + item->text(counter).replace("\"","\"\"");

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -1628,8 +1628,6 @@ void XTreeWidget::sExport()
 {
   QString   path = xtsettingsValue(_settingsName + "/exportPath").toString();
 
-  #pragma comment(linker, "/SUBSYSTEM:CONSOLE")
-
   ExportOptions eo;
   QString filetype, delimSelected;
 

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -2491,6 +2491,8 @@ QString XTreeWidget::toTxt() const
   return opText;
 }
 
+
+
 QString XTreeWidget::toSV(QString pSep) const
 {
   QString line;
@@ -2540,6 +2542,11 @@ QString XTreeWidget::toSV(QString pSep) const
     }
   }
   return opText;
+}
+
+QString XTreeWidget::toCsv()
+{
+  return toSV(QString(','));
 }
 
 QString XTreeWidget::toVcf() const
@@ -2890,53 +2897,5 @@ void XTreeWidget::keyPressEvent(QKeyEvent* e)
     QTreeWidget::keyPressEvent(e);
 }
 
-QStringList parseDelim(QString delim)
-{ 
-  QStringList delimItems; 
-  int i = delim.indexOf('{') ;
-  if ( i >=0)
-    delim.remove("{tab}");  
-  foreach(QChar c, delim)
-    delimItems.append(c);  
-  if(i>=0)
-    delimItems.insert(i,"{tab}");
-  return delimItems;
-}
 
-
-bool invalidDelim(QString delim)
-{
-  bool invalid = false;
-  if (delim.length() > 1)
-  {
-    if(delim != "{tab}")
-    {
-      invalid = true;
-      QMessageBox msgBox;
-      msgBox.setText("Avoid delimiters more than 1 char long.");
-      msgBox.exec();
-    }
-  }
-  else //don't allow or encourage against certain characters
-  {
-    QString disallowed = "(){}[]\"'`<>.{blank}";
-    QString notEncouraged = " @#$%&*_=-+/? ";
-    if (disallowed.contains(delim))
-    {
-      invalid = true;
-      QMessageBox msgBox;
-      msgBox.setText("Invalid delimiter");
-      msgBox.setInformativeText("These characters cannot be used as delimiters: (){}[]\"'`<>.{blank} ");
-      msgBox.exec();
-    }
-    else if (notEncouraged.contains(delim))
-    {
-      QMessageBox msgBox;
-      msgBox.setText("Be careful with your selection of delimiter");
-      msgBox.setInformativeText("We suggest you avoid using these delimiters : @#$%&*_=-+/? ");
-      msgBox.exec();
-    }
-  } 
-  return invalid;
-}
 

--- a/widgets/xtreewidget.cpp
+++ b/widgets/xtreewidget.cpp
@@ -40,6 +40,7 @@
 #include <QtScript>
 #include <QMessageBox>
 #include <QInputDialog>
+#include <QDesktopServices>
 
 #include "xtreewidgetprogress.h"
 #include "xtsettings.h"
@@ -1638,9 +1639,10 @@ void XTreeWidget::sExport()
   QString item = qid.getItem(this, tr("Delimiter selection"),
                                         tr("Select Delimiter :"), items, 0, true, &ok);
   
-  if(!items.contains(item)){
-    items << item;
-  }
+  if(item == "{tab}")
+    item = "\t";
+
+
   if (ok && !item.isEmpty())
       qDebug() << "Cool";
   ///////////////////////////
@@ -1675,7 +1677,7 @@ void XTreeWidget::sExport()
     }
     else if (fi.suffix() == "csv")
     {
-      doc->setPlainText(toCsv());
+      doc->setPlainText(toSV(item));
       writer.setFormat("plaintext");
     }
     else if (fi.suffix() == "vcf")
@@ -1695,6 +1697,7 @@ void XTreeWidget::sExport()
     }
     writer.write(doc);
   }
+  QDesktopServices::openUrl(fi.filePath());
 }
 
 void XTreeWidget::mousePressEvent(QMouseEvent *event)

--- a/widgets/xtreewidget.h
+++ b/widgets/xtreewidget.h
@@ -375,6 +375,5 @@ void  setupXTreeWidget(QScriptEngine *engine);
 //for delimiter handling
 QStringList parseDelim(QString delim);
 bool invalidDelim(QString delim);
-void saveDelim(QString delim);
 
 #endif

--- a/widgets/xtreewidget.h
+++ b/widgets/xtreewidget.h
@@ -211,7 +211,8 @@ class XTUPLEWIDGETS_EXPORT XTreeWidget : public QTreeWidget
     Q_INVOKABLE XTreeWidgetItem         *findXTreeWidgetItemWithId(const XTreeWidgetItem *ptreeitem, const int pid);
 
     Q_INVOKABLE QString toTxt() const;
-    Q_INVOKABLE QString toCsv() const;
+    Q_INVOKABLE QString toSV(QString pSep) const;
+    Q_INVOKABLE QString toCsv() {return toSV(QString(','));} ;
     Q_INVOKABLE QString toVcf() const;
     Q_INVOKABLE QString toHtml() const;
 

--- a/widgets/xtreewidget.h
+++ b/widgets/xtreewidget.h
@@ -213,7 +213,7 @@ class XTUPLEWIDGETS_EXPORT XTreeWidget : public QTreeWidget
 
     Q_INVOKABLE QString toTxt() const;
     Q_INVOKABLE QString toSV(QString pSep) const;
-    Q_INVOKABLE QString toCsv() {return toSV(QString(','));} ;
+    Q_INVOKABLE QString toCsv();
     Q_INVOKABLE QString toVcf() const;
     Q_INVOKABLE QString toHtml() const;
 
@@ -371,9 +371,5 @@ class XTreeWidgetPopulateParams
 
 void  setupXTreeWidgetItem(QScriptEngine *engine);
 void  setupXTreeWidget(QScriptEngine *engine);
-
-//for delimiter handling
-QStringList parseDelim(QString delim);
-bool invalidDelim(QString delim);
 
 #endif

--- a/widgets/xtreewidget.h
+++ b/widgets/xtreewidget.h
@@ -21,6 +21,7 @@
 #include "widgets.h"
 #include "guiclientinterface.h"
 #include "xt.h"
+#include "metrics.h"
 
 //  Table Column Widths
 #define _itemColumn     100
@@ -160,7 +161,7 @@ class XTUPLEWIDGETS_EXPORT XTreeWidgetItem : public QObject, public QTreeWidgetI
 
 class XTreeWidgetPopulateParams;
 
-class XTUPLEWIDGETS_EXPORT XTreeWidget : public QTreeWidget
+class XTUPLEWIDGETS_EXPORT XTreeWidget : public QTreeWidget 
 {
   Q_OBJECT Q_PROPERTY(QString dragString READ dragString WRITE setDragString)
   Q_PROPERTY( QString altDragString READ altDragString WRITE setAltDragString)
@@ -370,5 +371,10 @@ class XTreeWidgetPopulateParams
 
 void  setupXTreeWidgetItem(QScriptEngine *engine);
 void  setupXTreeWidget(QScriptEngine *engine);
+
+//for delimiter handling
+QStringList parseDelim(QString delim);
+bool invalidDelim(QString delim);
+void saveDelim(QString delim);
 
 #endif


### PR DESCRIPTION
Added:
- functionality so that user can select any delimiter that he wants
- an editable combobox to  System > Preferences window, with a list of delimiter values from which the user must select a default.
- a window that prompts user to select export file type and delimiter (when applicable)
- ability to manually enter any file extension (in cases where user wants a .tsv or other extension not offered in our list)