### PR TITLE
[33879] Return Auth receipt of lot/serial items with itemsite auto-seqs

### DIFF
--- a/guiclient/distributeInventory.cpp
+++ b/guiclient/distributeInventory.cpp
@@ -279,10 +279,12 @@ int distributeInventory::SeriesAdjust(int pItemlocSeries, QWidget *pParent,
           params.append("itemlocdist_id", itemloc.value("itemlocdist_id").toInt());
           
           // Auto assign lot/serial if applicable
+          QStringList exclTransact;
+          exclTransact << "TR" << "RR";
           if (itemloc.value("itemsite_lsseq_id").toInt() != -1 &&
               !itemloc.value("itemsite_perishable").toBool() &&
               !itemloc.value("itemsite_warrpurc").toBool() &&
-              itemloc.value("itemlocdist_transtype").toString() != "TR") {
+              !exclTransact.contains(itemloc.value("itemlocdist_transtype").toString())) {
             XSqlQuery autocreatels;
             autocreatels.prepare("SELECT autocreatels(:itemlocdist_id) AS itemlocseries;");
             autocreatels.bindValue(":itemlocdist_id", itemloc.value("itemlocdist_id").toInt());


### PR DESCRIPTION
Item Site auto sequences overrode return of items from S/Os.  This was previously applied to Transfer order receipts, but had to also be applied to Return Receipts.