### PR TITLE
[24368] enable scrolling for customer characteristics in View mode

### DIFF
--- a/guiclient/customer.cpp
+++ b/guiclient/customer.cpp
@@ -418,15 +418,10 @@ void customer::setViewMode()
   _upCC->setEnabled(false);
   _downCC->setEnabled(false);
   _warnLate->setEnabled(false);
-  _charass->setEnabled(true);
   _chartempl->setEnabled(false);
 
   connect(_shipto, SIGNAL(itemSelected(int)), _viewShipto, SLOT(animateClick()));
   connect(_cc, SIGNAL(itemSelected(int)), _viewCC, SLOT(animateClick()));
-
-  connect(_deleteCharacteristic, SIGNAL(clicked()), this, SLOT(sDeleteCharacteristic()));
-  connect(_editCharacteristic, SIGNAL(clicked()), this, SLOT(sEditCharacteristic()));
-  connect(_newCharacteristic, SIGNAL(clicked()), this, SLOT(sNewCharacteristic()));
 
   disconnect(_taxreg, SIGNAL(valid(bool)), _deleteTaxreg, SLOT(setEnabled(bool)));
   disconnect(_taxreg, SIGNAL(valid(bool)), _editTaxreg, SLOT(setEnabled(bool)));

--- a/guiclient/customer.cpp
+++ b/guiclient/customer.cpp
@@ -418,11 +418,15 @@ void customer::setViewMode()
   _upCC->setEnabled(false);
   _downCC->setEnabled(false);
   _warnLate->setEnabled(false);
-  _charass->setEnabled(false);
+  _charass->setEnabled(true);
   _chartempl->setEnabled(false);
 
   connect(_shipto, SIGNAL(itemSelected(int)), _viewShipto, SLOT(animateClick()));
   connect(_cc, SIGNAL(itemSelected(int)), _viewCC, SLOT(animateClick()));
+
+  connect(_deleteCharacteristic, SIGNAL(clicked()), this, SLOT(sDeleteCharacteristic()));
+  connect(_editCharacteristic, SIGNAL(clicked()), this, SLOT(sEditCharacteristic()));
+  connect(_newCharacteristic, SIGNAL(clicked()), this, SLOT(sNewCharacteristic()));
 
   disconnect(_taxreg, SIGNAL(valid(bool)), _deleteTaxreg, SLOT(setEnabled(bool)));
   disconnect(_taxreg, SIGNAL(valid(bool)), _editTaxreg, SLOT(setEnabled(bool)));


### PR DESCRIPTION
the 'new', 'edit' and 'delete' buttons were already being disabled, so there was no need to disable the XTreeWidget. User cannot edit anything, even if an item is double clicked.
On right clicking, the user still has the option to export, or copy to clipboard. Not sure if that should be permitted in View mode