### PR TITLE
[33966] Prepopulate Prospect when creating from Contact

### DIFF
--- a/guiclient/contacts.cpp
+++ b/guiclient/contacts.cpp
@@ -807,6 +807,8 @@ void contacts::sNewProspect()
       QString company = list()->currentItem()->rawValue("company").toString();
       if (company.size() > 0)
         params.append("company", company);
+
+      params.append("cntct_id", item->id());
     }
     else if (crmaccts.size() == 1)
       crmacctsel = crmaccts[0];

--- a/guiclient/prospect.cpp
+++ b/guiclient/prospect.cpp
@@ -144,7 +144,8 @@ enum SetResponse prospect::set(const ParameterList &pParams)
     getq.exec();
     if (getq.first())
     {
-      _number->setText(getq.value("prospect_name").toString());
+      if (_metrics->value("CRMAccountNumberGeneration") == "M")
+        _number->setText(getq.value("prospect_name").toString());
       _name->setText(getq.value("prospect_name").toString());
       _notes->setText(getq.value("prospect_comments").toString());
       _active->setChecked(getq.value("prospect_active").toBool());
@@ -161,7 +162,8 @@ enum SetResponse prospect::set(const ParameterList &pParams)
   if (valid && _mode == cNew)
   {
     _name->setText(param.toString());
-    _number->setText(param.toString());
+    if (_metrics->value("CRMAccountNumberGeneration") == "M")
+      _number->setText(param.toString());
   }
 
   param = pParams.value("prospect_id", &valid);

--- a/guiclient/prospect.cpp
+++ b/guiclient/prospect.cpp
@@ -128,6 +128,42 @@ enum SetResponse prospect::set(const ParameterList &pParams)
     _fromCRM = true;
   }
 
+  param = pParams.value("cntct_id", &valid);
+  if (valid)
+  {
+    _cntctid = param.toInt();
+    _fromContact = true;
+
+    getq.prepare("SELECT cntct_active AS prospect_active,"
+                 "       cntct_first_name || ' ' || cntct_last_name AS prospect_name,"
+                 "       geteffectivextuser() AS owner_username,"
+                 "       'Prospect generated from Contact' AS prospect_comments "
+                 "  FROM cntct"
+                 " WHERE (cntct_id=:id);");
+    getq.bindValue(":id", _cntctid);
+    getq.exec();
+    if (getq.first())
+    {
+      _number->setText(getq.value("prospect_name").toString());
+      _name->setText(getq.value("prospect_name").toString());
+      _notes->setText(getq.value("prospect_comments").toString());
+      _active->setChecked(getq.value("prospect_active").toBool());
+      _crmowner = getq.value("owner_username").toString();
+      _owner->setUsername(getq.value("owner_username").toString());
+      _created->setDate(QDate::currentDate());
+    }
+    else if (ErrorReporter::error(QtCriticalMsg, this, tr("Retrieve Contact Details"),
+                                getq, __FILE__, __LINE__))
+      return UndefinedError;
+  }
+
+  param = pParams.value("company", &valid);
+  if (valid && _mode == cNew)
+  {
+    _name->setText(param.toString());
+    _number->setText(param.toString());
+  }
+
   param = pParams.value("prospect_id", &valid);
   if (valid)
     _prospectid = param.toInt();
@@ -181,14 +217,6 @@ enum SetResponse prospect::set(const ParameterList &pParams)
     else if (param.toString() == "view")
       setViewMode();
   }
-
-  param = pParams.value("company", &valid);
-  if (valid && _mode == cNew)
-    _name->setText(param.toString());
-
-  if (_crmacctid >= 0 || _prospectid >= 0)
-    if (! sPopulate())
-      return UndefinedError;
 
   bool canEdit = (cEdit == _mode || cNew == _mode);
   _number->setEnabled(canEdit &&
@@ -362,6 +390,20 @@ bool prospect::sSave(bool pPartial)
   {
     omfgThis->sCrmAccountsUpdated(_crmacctid);
     emit newId(_prospectid);   // cluster listeners couldn't handle set()'s emit
+
+    if (_fromContact)
+      {
+        upsq.prepare("INSERT INTO crmacctcntctass (crmacctcntctass_crmacct_id, crmacctcntctass_cntct_id, "
+                     "                             crmacctcntctass_crmrole_id) "
+                     " VALUES (:crmacct, :cntct, getcrmroleid())"
+                     " ON CONFLICT DO NOTHING;" );
+        upsq.bindValue(":crmacct", _crmacctid);
+        upsq.bindValue(":cntct", _cntctid);
+        upsq.exec();
+        if (ErrorReporter::error(QtCriticalMsg, this, tr("Saving Prospect"),
+                                 upsq, __FILE__, __LINE__))
+           return false;
+      }
   }
   _saved = true;
 
@@ -505,7 +547,6 @@ void prospect::sPopulateQuotesMenu(QMenu *menuThis)
 bool prospect::sPopulate()
 {
   XSqlQuery getq;
-
   if (_prospectid >= 0)
   {
     if (_mode == cEdit && !_lock.acquire("prospect", _prospectid, AppLock::Interactive))

--- a/guiclient/prospect.h
+++ b/guiclient/prospect.h
@@ -69,6 +69,7 @@ protected:
 
 private:
     int  _crmacctid;
+    int  _cntctid;
     int  _mode;
     int  _prospectid;
     int  _NumberGen;
@@ -76,6 +77,7 @@ private:
     bool _isSaved;
     bool _saved;
     bool _fromCRM;
+    bool _fromContact;
     QMap<QString, int> cmap;
     QString _cachedNumber;
     QString _crmowner;


### PR DESCRIPTION
If a contact is linked to an Account it will create a prospect from the Account details.  However, if a contact is not linked (standalone) no details where passed into the created prospect.  This change pre-populates some of the Prospect fields from the Contact information.  The link between Contact/Prospect/CRM Account is made when the prospect is saved due to CRM Account timing issues.