### PR TITLE
[28731] Ellipses is used improperly in qt-client

### DIFF
--- a/guiclient/menuAccounting.cpp
+++ b/guiclient/menuAccounting.cpp
@@ -222,33 +222,33 @@ menuAccounting::menuAccounting(GUIClient *Pparent) :
     
     // Accounting | Accaunts Payable | Purchase Orders
     { "menu", tr("Purchase &Order"), (char*)apPurchaseMenu, apMenu, "true", NULL, NULL, true, NULL },
-    { "ap.enterPurchaseOrder", tr("&New..."), SLOT(sEnterPurchaseOrder()), apPurchaseMenu, "MaintainPurchaseOrders", NULL, NULL, true , NULL },
-    { "ap.listUnpostedPurchaseOrders", tr("&List Open..."), SLOT(sUnpostedPurchaseOrders()), apPurchaseMenu, "MaintainPurchaseOrders ViewPurchaseOrders", NULL, NULL, true , NULL },
+    { "ap.enterPurchaseOrder", tr("&New"), SLOT(sEnterPurchaseOrder()), apPurchaseMenu, "MaintainPurchaseOrders", NULL, NULL, true , NULL },
+    { "ap.listUnpostedPurchaseOrders", tr("&List Open"), SLOT(sUnpostedPurchaseOrders()), apPurchaseMenu, "MaintainPurchaseOrders ViewPurchaseOrders", NULL, NULL, true , NULL },
     { "separator", NULL, NULL, apPurchaseMenu, "true", NULL, NULL, true, NULL },
     { "ap.postPurchaseOrder", tr("&Release..."), SLOT(sPostPurchaseOrder()), apPurchaseMenu, "ReleasePurchaseOrders", NULL, NULL, true , NULL },
 
     // Accounting | Accaunts Payable | Vouchers
     { "menu", tr("&Voucher"), (char*)apVoucherMenu, apMenu, "true", NULL, NULL, true, NULL },
-    { "ar.enterNewVoucher", tr("&New..."), SLOT(sEnterVoucher()), apVoucherMenu, "MaintainVouchers", NULL, NULL, true , NULL },
-    { "ar.enterNewMiscVoucher", tr("New &Miscellaneous..."), SLOT(sEnterMiscVoucher()), apVoucherMenu, "MaintainVouchers", NULL, NULL, true , NULL },
-    { "ar.listUnpostedVouchers", tr("&List Unposted..."), SLOT(sUnpostedVouchers()), apVoucherMenu, "MaintainVouchers ViewVouchers", new QPixmap(":/images/listUnpostedVouchers.png"), toolBar, true , tr("List Unposted Vouchers") },
+    { "ar.enterNewVoucher", tr("&New"), SLOT(sEnterVoucher()), apVoucherMenu, "MaintainVouchers", NULL, NULL, true , NULL },
+    { "ar.enterNewMiscVoucher", tr("New &Miscellaneous"), SLOT(sEnterMiscVoucher()), apVoucherMenu, "MaintainVouchers", NULL, NULL, true , NULL },
+    { "ar.listUnpostedVouchers", tr("&List Unposted"), SLOT(sUnpostedVouchers()), apVoucherMenu, "MaintainVouchers ViewVouchers", new QPixmap(":/images/listUnpostedVouchers.png"), toolBar, true , tr("List Unposted Vouchers") },
     { "separator", NULL, NULL, apVoucherMenu, "true", NULL, NULL, true, NULL },
     { "ar.postVouchers", tr("&Post..."), SLOT(sPostVouchers()), apVoucherMenu, "PostVouchers", NULL, NULL, true , NULL },
 
     // Accounting | Accaunts Payable | Memos
     { "menu", tr("&Memos"), (char*)apMemosMenu, apMenu, "true", NULL, NULL, true, NULL },
-    { "ap.enterMiscCreditMemo", tr("&New Misc. Credit Memo..."), SLOT(sEnterMiscApCreditMemo()), apMemosMenu, "MaintainAPMemos", NULL, NULL, true , NULL },
-    { "ap.unapplidCreditMemo", tr("&List Unapplied Credit Memos..."), SLOT(sUnappliedApCreditMemos()), apMemosMenu, "MaintainAPMemos ViewAPMemos", NULL, NULL, true , NULL },
+    { "ap.enterMiscCreditMemo", tr("&New Misc. Credit Memo"), SLOT(sEnterMiscApCreditMemo()), apMemosMenu, "MaintainAPMemos", NULL, NULL, true , NULL },
+    { "ap.unapplidCreditMemo", tr("&List Unapplied Credit Memos"), SLOT(sUnappliedApCreditMemos()), apMemosMenu, "MaintainAPMemos ViewAPMemos", NULL, NULL, true , NULL },
     { "separator", NULL, NULL, apMemosMenu, "true", NULL, NULL, true, NULL },
-    { "ap.enterMiscDebitMemo", tr("New &Misc. Debit Memo..."), SLOT(sEnterMiscApDebitMemo()), apMemosMenu, "MaintainAPMemos", NULL, NULL, true , NULL },
+    { "ap.enterMiscDebitMemo", tr("New &Misc. Debit Memoz"), SLOT(sEnterMiscApDebitMemo()), apMemosMenu, "MaintainAPMemos", NULL, NULL, true , NULL },
 
     // Accounting | Accaunts Payable |  Payments
     { "menu", tr("&Payments"), (char*)apPaymentsMenu, apMenu, "true", NULL, NULL, true, NULL },
     { "ap.selectPayments", tr("&Approve..."), SLOT(sSelectPayments()), apPaymentsMenu, "MaintainPayments", NULL, NULL, true , tr("Approve Payments") },
-    { "ap.listSelectPayments", tr("&List Approved..."), SLOT(sSelectedPayments()), apPaymentsMenu, "MaintainPayments", NULL, NULL, true , NULL },
+    { "ap.listSelectPayments", tr("&List Approved"), SLOT(sSelectedPayments()), apPaymentsMenu, "MaintainPayments", NULL, NULL, true , NULL },
     { "separator", NULL, NULL, apPaymentsMenu, "true", NULL, NULL, true, NULL },
     { "ap.prepareCheckRun", tr("&Prepare Payment Run..."), SLOT(sPrepareCheckRun()), apPaymentsMenu, "MaintainPayments", NULL, NULL, true , NULL },
-    { "ap.createMiscCheck", tr("Create &Miscellaneous Payment..."), SLOT(sCreateMiscCheck()), apPaymentsMenu, "MaintainPayments", NULL, NULL, true , NULL },
+    { "ap.createMiscCheck", tr("Create &Miscellaneous Payment"), SLOT(sCreateMiscCheck()), apPaymentsMenu, "MaintainPayments", NULL, NULL, true , NULL },
     { "ap.viewCheckRun", tr("Vie&w Payment Run..."), SLOT(sViewCheckRun()), apPaymentsMenu, "MaintainPayments", NULL, NULL, true , NULL },
     { "separator", NULL, NULL, apPaymentsMenu, "true", NULL, NULL, true, NULL },
     { "ap.voidCheckRun", tr("&Void Payment Run..."), SLOT(sVoidCheckRun()), apPaymentsMenu, "MaintainPayments", NULL, NULL, true , NULL },
@@ -257,7 +257,7 @@ menuAccounting::menuAccounting(GUIClient *Pparent) :
     { "ap.postChecks", tr("P&ost Payments..."), SLOT(sPostChecks()), apPaymentsMenu, "PostPayments", NULL, NULL, true , NULL },
                        
     { "separator", NULL, NULL, apMenu, "true", NULL, NULL, true, NULL },
-    { "ap.workbench", tr("&Workbench..."), SLOT(sApWorkBench()), apMenu, "MaintainPayments MaintainAPMemos", new QPixmap(":/images/viewCheckRun.png"), toolBar, true, tr("Payables Workbench") },
+    { "ap.workbench", tr("&Workbench"), SLOT(sApWorkBench()), apMenu, "MaintainPayments MaintainAPMemos", new QPixmap(":/images/viewCheckRun.png"), toolBar, true, tr("Payables Workbench") },
     { "separator", NULL, NULL, apMenu, "true", NULL, NULL, true, NULL },
     
     // Accounting | Accaunts Payable | Forms
@@ -269,48 +269,48 @@ menuAccounting::menuAccounting(GUIClient *Pparent) :
     
     // Accounting | Accaunts Payable |  Reports
     { "menu", tr("&Reports"), (char*)apReportsMenu, apMenu, "true", NULL, NULL, true, NULL },
-    { "ap.uninvoicedReceipts", tr("&Uninvoiced Receipts and Returns..."), SLOT(sDspUninvoicedReceipts()), apReportsMenu, "ViewUninvoicedReceipts MaintainUninvoicedReceipts", NULL, NULL, true , NULL },
+    { "ap.uninvoicedReceipts", tr("&Uninvoiced Receipts and Returns"), SLOT(sDspUninvoicedReceipts()), apReportsMenu, "ViewUninvoicedReceipts MaintainUninvoicedReceipts", NULL, NULL, true , NULL },
     { "separator", NULL, NULL, apReportsMenu, "true", NULL, NULL, true, NULL },
-    { "ap.dspOpenAPItemsByVendor", tr("Open &Payables..."), SLOT(sDspAPOpenItemsByVendor()), apReportsMenu, "ViewAPOpenItems", NULL, NULL, true , NULL },
+    { "ap.dspOpenAPItemsByVendor", tr("Open &Payables"), SLOT(sDspAPOpenItemsByVendor()), apReportsMenu, "ViewAPOpenItems", NULL, NULL, true , NULL },
     { "ap.dspAPAging", tr("&Aging..."), SLOT(sDspTimePhasedOpenAPItems()), apReportsMenu, "ViewAPOpenItems", new QPixmap(":/images/apAging.png"), toolBar, true , tr("Payables Aging") },
     { "separator", NULL, NULL, apReportsMenu, "true", NULL, NULL, true, NULL },
-    { "ap.dspCheckRegister", tr("&Payment Register..."), SLOT(sDspCheckRegister()), apReportsMenu, "MaintainPayments", NULL, NULL, true , NULL },
-    { "ap.dspVoucherRegister", tr("&Voucher Register..."), SLOT(sDspVoucherRegister()), apReportsMenu, "MaintainVouchers ViewVouchers", NULL, NULL, true , NULL },
+    { "ap.dspCheckRegister", tr("&Payment Register"), SLOT(sDspCheckRegister()), apReportsMenu, "MaintainPayments", NULL, NULL, true , NULL },
+    { "ap.dspVoucherRegister", tr("&Voucher Register"), SLOT(sDspVoucherRegister()), apReportsMenu, "MaintainVouchers ViewVouchers", NULL, NULL, true , NULL },
     { "separator", NULL, NULL, apReportsMenu, "true", NULL, NULL, true, NULL },
-    { "ap.dspAPApplications", tr("&Applications..."), SLOT(sDspAPApplications()), apReportsMenu, "ViewAPOpenItems", NULL, NULL, true , NULL },
+    { "ap.dspAPApplications", tr("&Applications"), SLOT(sDspAPApplications()), apReportsMenu, "ViewAPOpenItems", NULL, NULL, true , NULL },
     { "separator", NULL, NULL, apReportsMenu, "true", NULL, NULL, true, NULL },
-    { "ap.dspVendorHistory", tr("Vendor &History..."), SLOT(sDspVendorHistory()), apReportsMenu, "ViewAPOpenItems", NULL, NULL, true , NULL },
+    { "ap.dspVendorHistory", tr("Vendor &History"), SLOT(sDspVendorHistory()), apReportsMenu, "ViewAPOpenItems", NULL, NULL, true , NULL },
 
     { "separator", NULL, NULL, apMenu, "true", NULL, NULL, true, NULL },
-    { "ap.vendors", tr("Ve&ndors..."), SLOT(sVendors()), apMenu, "MaintainVendors ViewVendors", NULL, NULL, true , NULL },
+    { "ap.vendors", tr("Ve&ndors"), SLOT(sVendors()), apMenu, "MaintainVendors ViewVendors", NULL, NULL, true , NULL },
     
     // Accounting | Accounts Receivable
     { "menu", tr("Accounts Recei&vable"),	(char*)arMenu,	mainMenu, "true", NULL, NULL, true, NULL },
   
     // Accounting | Accounts Receivable | Invoices
     { "menu", tr("&Invoice"), (char*)arInvoicesMenu,	arMenu, "true",	 NULL, NULL, true, NULL },
-    { "ar.createInvoice", tr("&New..."), SLOT(sCreateInvoice()), arInvoicesMenu, "MaintainMiscInvoices", NULL, NULL, true , NULL },
-    { "ar.listRecurringInvoices", tr("&List Recurring Invoices..."),	SLOT(sRecurringInvoices()), arInvoicesMenu, "SelectBilling",	NULL, NULL,  true, NULL },
-    { "ar.listUnpostedInvoices", tr("&List Unposted..."), SLOT(sUnpostedInvoices()), arInvoicesMenu, "SelectBilling", new QPixmap(":/images/unpostedInvoices.png"), toolBar, true , tr("List Unposted Invoices") },
+    { "ar.createInvoice", tr("&New"), SLOT(sCreateInvoice()), arInvoicesMenu, "MaintainMiscInvoices", NULL, NULL, true , NULL },
+    { "ar.listRecurringInvoices", tr("&List Recurring Invoices"),	SLOT(sRecurringInvoices()), arInvoicesMenu, "SelectBilling",	NULL, NULL,  true, NULL },
+    { "ar.listUnpostedInvoices", tr("&List Unposted"), SLOT(sUnpostedInvoices()), arInvoicesMenu, "SelectBilling", new QPixmap(":/images/unpostedInvoices.png"), toolBar, true , tr("List Unposted Invoices") },
     { "separator", NULL, NULL, arInvoicesMenu, "true", NULL, NULL, true, NULL },
     { "ar.postInvoices", tr("&Post..."), SLOT(sPostInvoices()), arInvoicesMenu, "PostMiscInvoices", NULL, NULL, true , NULL },
     { "ar.assessFinanceCharges", tr("&Assess Finance Charges..."), SLOT(sAssessFinanceCharges()), arInvoicesMenu, "PostMiscInvoices", NULL, NULL, true , NULL },
 
     // Accounting | Accounts Receivable | Memos
     { "menu", tr("&Memos"), (char*)arMemosMenu,	arMenu, "true",	 NULL, NULL, true, NULL },
-    { "ar.enterMiscCreditMemo", tr("&New Misc. Credit Memo..."), SLOT(sEnterMiscArCreditMemo()), arMemosMenu, "MaintainARMemos", NULL, NULL, true , NULL },
-    { "ar.unapplidCreditMemo", tr("&List Unapplied Credit Memos..."), SLOT(sUnappliedArCreditMemos()), arMemosMenu, "MaintainARMemos ViewARMemos", NULL, NULL, true , NULL },
+    { "ar.enterMiscCreditMemo", tr("&New Misc. Credit Memo"), SLOT(sEnterMiscArCreditMemo()), arMemosMenu, "MaintainARMemos", NULL, NULL, true , NULL },
+    { "ar.unapplidCreditMemo", tr("&List Unapplied Credit Memos"), SLOT(sUnappliedArCreditMemos()), arMemosMenu, "MaintainARMemos ViewARMemos", NULL, NULL, true , NULL },
     { "separator", NULL, NULL, arMemosMenu, "true", NULL, NULL, true, NULL },
-    { "ar.enterMiscDebitMemo", tr("New &Misc. Debit Memo..."), SLOT(sEnterMiscArDebitMemo()), arMemosMenu, "MaintainARMemos", NULL, NULL, true , NULL },
+    { "ar.enterMiscDebitMemo", tr("New &Misc. Debit Memo"), SLOT(sEnterMiscArDebitMemo()), arMemosMenu, "MaintainARMemos", NULL, NULL, true , NULL },
 
     // Accounting | Accounts Receivable | Cash Receipts
     { "menu", tr("C&ash Receipt"), (char*)arCashReceiptsMenu,	arMenu, "true",	 NULL, NULL, true, NULL },
-    { "ar.enterCashReceipt", tr("&New..."), SLOT(sEnterCashReceipt()), arCashReceiptsMenu, "MaintainCashReceipts", NULL, NULL, true , NULL },
+    { "ar.enterCashReceipt", tr("&New"), SLOT(sEnterCashReceipt()), arCashReceiptsMenu, "MaintainCashReceipts", NULL, NULL, true , NULL },
     { "ar.cashReceiptEditList", tr("&Edit List..."), SLOT(sCashReceiptEditList()), arCashReceiptsMenu, "MaintainCashReceipts ViewCashReceipt", new QPixmap(":/images/editCashReceipts.png"), toolBar, true , tr("Cash Receipt Edit List") },
     { "ar.postCashReceipts", tr("&Post..."), SLOT(sPostCashReceipts()), arCashReceiptsMenu, "PostCashReceipts", NULL, NULL, true , NULL },
 
     { "separator", NULL, NULL, arMenu, "true", NULL, NULL, true, NULL },
-    { "ar.arWorkBench", tr("&Workbench..."), SLOT(sArWorkBench()), arMenu, "ViewAROpenItems" , new QPixmap(":/images/arWorkbench.png"), toolBar, true , tr("Receivables Workbench") },
+    { "ar.arWorkBench", tr("&Workbench"), SLOT(sArWorkBench()), arMenu, "ViewAROpenItems" , new QPixmap(":/images/arWorkbench.png"), toolBar, true , tr("Receivables Workbench") },
 
     { "separator", NULL, NULL, arMenu, "true", NULL, NULL, true, NULL },
     // Accounting | Accounts Receivable | Forms
@@ -325,34 +325,34 @@ menuAccounting::menuAccounting(GUIClient *Pparent) :
     { "menu", tr("&Reports"), (char*)arReportsMenu,	arMenu, "true",	 NULL, NULL, true, NULL },
     { "ar.dspInvoiceInformation", tr("&Invoice Information..."), SLOT(sDspInvoiceInformation()), arReportsMenu, "ViewAROpenItems", NULL, NULL, true , NULL },
     { "separator", NULL, NULL, arReportsMenu, "true", NULL, NULL, true, NULL },
-    { "ar.dspOpenItems", tr("&Open Receivables..."), SLOT(sDspAROpenItems()), arReportsMenu, "ViewAROpenItems", NULL, NULL, true , NULL },
-    { "ar.dspARAging", tr("A&ging..."), SLOT(sDspTimePhasedOpenItems()), arReportsMenu, "ViewAROpenItems", new QPixmap(":/images/arAging.png"), toolBar, true , tr("Receivables Aging") },
+    { "ar.dspOpenItems", tr("&Open Receivables"), SLOT(sDspAROpenItems()), arReportsMenu, "ViewAROpenItems", NULL, NULL, true , NULL },
+    { "ar.dspARAging", tr("A&ging"), SLOT(sDspTimePhasedOpenItems()), arReportsMenu, "ViewAROpenItems", new QPixmap(":/images/arAging.png"), toolBar, true , tr("Receivables Aging") },
     { "separator", NULL, NULL, arReportsMenu, "true", NULL, NULL, true, NULL }, 
-    { "ar.dspInvoiceRegister", tr("In&voice Register..."), SLOT(sDspInvoiceRegister()), arReportsMenu, "ViewInvoiceRegister", NULL, NULL, true , NULL },
-    { "ar.dspCashReceipts", tr("Cash &Receipts..."), SLOT(sDspCashReceipts()), arReportsMenu, "ViewAROpenItems", NULL, NULL, true , NULL },
-    { "ar.dspARApplications", tr("&Applications..."), SLOT(sDspARApplications()), arReportsMenu, "ViewAROpenItems", NULL, NULL, true , NULL },
-    { "ar.dspDepositsRegister", tr("&Deposits Register..."), SLOT(sDspDepositsRegister()), arReportsMenu, "ViewDepositsRegister", NULL, NULL, true , NULL },
+    { "ar.dspInvoiceRegister", tr("In&voice Register"), SLOT(sDspInvoiceRegister()), arReportsMenu, "ViewInvoiceRegister", NULL, NULL, true , NULL },
+    { "ar.dspCashReceipts", tr("Cash &Receipts"), SLOT(sDspCashReceipts()), arReportsMenu, "ViewAROpenItems", NULL, NULL, true , NULL },
+    { "ar.dspARApplications", tr("&Applications"), SLOT(sDspARApplications()), arReportsMenu, "ViewAROpenItems", NULL, NULL, true , NULL },
+    { "ar.dspDepositsRegister", tr("&Deposits Register"), SLOT(sDspDepositsRegister()), arReportsMenu, "ViewDepositsRegister", NULL, NULL, true , NULL },
     { "separator", NULL, NULL, arReportsMenu, "true", NULL, NULL, true, NULL },
-    { "ar.dspCustomerHistory", tr("Customer &History..."), SLOT(sDspCustomerHistory()), arReportsMenu, "ViewAROpenItems", NULL, NULL, true , NULL },
+    { "ar.dspCustomerHistory", tr("Customer &History"), SLOT(sDspCustomerHistory()), arReportsMenu, "ViewAROpenItems", NULL, NULL, true , NULL },
 
     { "separator", NULL, NULL, arMenu, "true", NULL, NULL, true, NULL },
-    { "ar.customers", tr("&Customers..."), SLOT(sCustomers()), arMenu, "MaintainCustomerMasters ViewCustomerMasters", NULL, NULL, true , NULL },
+    { "ar.customers", tr("&Customers"), SLOT(sCustomers()), arMenu, "MaintainCustomerMasters ViewCustomerMasters", NULL, NULL, true , NULL },
   
     // Accounting | G/L
     { "menu",		    tr("General &Ledger"),		(char*)glMenu,	mainMenu,		"true",					NULL, NULL, true, NULL },
     
     // Accounting | G/L | Journals
     { "menu",		    tr("&Journal Entry"),		(char*)glEnterTransactionMenu,	glMenu,		"true",					NULL, NULL, true, NULL },
-    { "gl.simpleEntry",	    tr("S&imple..."),	SLOT(sSimpleEntry()),		glEnterTransactionMenu,	"PostJournalEntries", NULL, NULL, true, NULL },
-    { "gl.seriesEntry",     tr("&Series..."),	SLOT(sSeriesEntry()),		glEnterTransactionMenu,	"PostJournalEntries", NULL, NULL, true, NULL },
+    { "gl.simpleEntry",	    tr("S&imple"),	SLOT(sSimpleEntry()),		glEnterTransactionMenu,	"PostJournalEntries", NULL, NULL, true, NULL },
+    { "gl.seriesEntry",     tr("&Series"),	SLOT(sSeriesEntry()),		glEnterTransactionMenu,	"PostJournalEntries", NULL, NULL, true, NULL },
     { "separator",	    NULL,				NULL,			        glEnterTransactionMenu,   "true",					NULL, NULL, true, NULL },
-    { "gl.unpostedEntries", tr("&List Unposted..."), SLOT(sUnpostedEntries()),	glEnterTransactionMenu,	"PostJournalEntries", new QPixmap(":/images/journalEntries.png"), toolBar,  true, tr("List Unposted Journal Entries") },
+    { "gl.unpostedEntries", tr("&List Unposted"), SLOT(sUnpostedEntries()),	glEnterTransactionMenu,	"PostJournalEntries", new QPixmap(":/images/journalEntries.png"), toolBar,  true, tr("List Unposted Journal Entries") },
 
     // Accounting | G/L | Standard Journals
     { "menu",			     tr("&Standard Journals"),		   (char*)glStandardJournalsMenu,	     glMenu,		   "true",					      NULL, NULL, true, NULL },
-    { "gl.enterNewStandardJournal",  tr("&New..."),  SLOT(sEnterStandardJournal()),    glStandardJournalsMenu, "MaintainStandardJournals",     NULL, NULL, true, NULL },
-    { "gl.listStandardJournals",     tr("&List..."),	   SLOT(sStandardJournals()),	     glStandardJournalsMenu, "MaintainStandardJournals",     NULL, NULL, true, NULL },
-    { "gl.listStandardJournalGroups",tr("List &Groups..."),SLOT(sStandardJournalGroups()),   glStandardJournalsMenu, "MaintainStandardJournalGroups", NULL, NULL, true, NULL },
+    { "gl.enterNewStandardJournal",  tr("&New"),  SLOT(sEnterStandardJournal()),    glStandardJournalsMenu, "MaintainStandardJournals",     NULL, NULL, true, NULL },
+    { "gl.listStandardJournals",     tr("&List"),	   SLOT(sStandardJournals()),	     glStandardJournalsMenu, "MaintainStandardJournals",     NULL, NULL, true, NULL },
+    { "gl.listStandardJournalGroups",tr("List &Groups"),SLOT(sStandardJournalGroups()),   glStandardJournalsMenu, "MaintainStandardJournalGroups", NULL, NULL, true, NULL },
     { "separator",		     NULL,				   NULL,			     glStandardJournalsMenu, "true",					      NULL, NULL, true, NULL },
     { "gl.postStandardJournal",	     tr("&Post..."),	   SLOT(sPostStandardJournal()),     glStandardJournalsMenu, "PostStandardJournals",	      NULL, NULL, true, NULL },
     { "gl.postStandardJournalGroup", tr("Post G&roup..."), SLOT(sPostStandardJournalGroup()),glStandardJournalsMenu, "PostStandardJournalGroups",    NULL, NULL, true, NULL },
@@ -365,20 +365,20 @@ menuAccounting::menuAccounting(GUIClient *Pparent) :
     
     // Accounting | General Ledger |  Reports
     { "menu", tr("&Reports"), (char*)glReportsMenu, glMenu, "true", NULL, NULL, true, NULL },
-    { "gl.dspGLTransactions",		tr("&Transactions..."),		SLOT(sDspGLTransactions()),		glReportsMenu, "ViewGLTransactions",	NULL, NULL, true, NULL },
-    { "gl.dspSummarizedGLTransactions",	tr("Su&mmarized Transactions..."),	SLOT(sDspSummarizedGLTransactions()),	glReportsMenu, "ViewGLTransactions",	NULL, NULL, true, NULL },
-    { "gl.dspGLSeries",			tr("&Series..."),			SLOT(sDspGLSeries()),			glReportsMenu, "ViewGLTransactions",	NULL, NULL, true, NULL },
-    { "gl.dspStandardJournalHistory",	tr("Standard &Journal History..."),	SLOT(sDspStandardJournalHistory()),	glReportsMenu, "ViewGLTransactions",	NULL, NULL, true, NULL },
+    { "gl.dspGLTransactions",		tr("&Transactions"),		SLOT(sDspGLTransactions()),		glReportsMenu, "ViewGLTransactions",	NULL, NULL, true, NULL },
+    { "gl.dspSummarizedGLTransactions",	tr("Su&mmarized Transactions"),	SLOT(sDspSummarizedGLTransactions()),	glReportsMenu, "ViewGLTransactions",	NULL, NULL, true, NULL },
+    { "gl.dspGLSeries",			tr("&Series"),			SLOT(sDspGLSeries()),			glReportsMenu, "ViewGLTransactions",	NULL, NULL, true, NULL },
+    { "gl.dspStandardJournalHistory",	tr("Standard &Journal History"),	SLOT(sDspStandardJournalHistory()),	glReportsMenu, "ViewGLTransactions",	NULL, NULL, true, NULL },
     { "separator", NULL, NULL, glReportsMenu, "true", NULL, NULL, _metrics->boolean("UseJournals"), NULL },
-    { "gl.dspJournals",	  tr("Journals..."),	SLOT(sDspJournals()),	glReportsMenu, "ViewJournals",	     NULL, NULL, _metrics->boolean("UseJournals"), NULL },
+    { "gl.dspJournals",	  tr("Journals"),	SLOT(sDspJournals()),	glReportsMenu, "ViewJournals",	     NULL, NULL, _metrics->boolean("UseJournals"), NULL },
     { "separator",        NULL,                 NULL,                   glReportsMenu, "true",               NULL, NULL, true, NULL },
     { "gl.ledgerControl", tr("Ledger Control"), SLOT(sLedgerControl()), glReportsMenu, "ViewGLTransactions", NULL, NULL, true, NULL },
 
     { "menu",			tr("&Bank Reconciliation"), 	(char*)bankrecMenu,		mainMenu,    "true",						NULL, NULL, true, NULL },
     { "gl.reconcileBankaccnt",	tr("&Reconcile..."),SLOT(sReconcileBankaccount()),	bankrecMenu, "MaintainBankRec", new QPixmap(":/images/bankReconciliation.png"), toolBar,  true, tr("Reconcile Bank Account") },
     { "separator",		NULL,				NULL,				bankrecMenu, "true",						NULL, NULL, true, NULL },
-    { "gl.enterAdjustment",	tr("&New Adjustment..."),	SLOT(sEnterAdjustment()),	bankrecMenu, "MaintainBankAdjustments",	NULL, NULL, true, NULL },
-    { "gl.adjustmentEditList",	tr("Adjustment Edit &List..."),	SLOT(sAdjustmentEditList()),	bankrecMenu, "MaintainBankAdjustments ViewBankAdjustments", NULL, NULL, true, NULL },
+    { "gl.enterAdjustment",	tr("&New Adjustment"),	SLOT(sEnterAdjustment()),	bankrecMenu, "MaintainBankAdjustments",	NULL, NULL, true, NULL },
+    { "gl.adjustmentEditList",	tr("Adjustment Edit &List"),	SLOT(sAdjustmentEditList()),	bankrecMenu, "MaintainBankAdjustments ViewBankAdjustments", NULL, NULL, true, NULL },
  
     { "separator", NULL, NULL, bankrecMenu, "true", NULL, NULL, true, NULL },
  

--- a/guiclient/menuAccounting.cpp
+++ b/guiclient/menuAccounting.cpp
@@ -391,58 +391,58 @@ menuAccounting::menuAccounting(GUIClient *Pparent) :
     
     // Accounting | Statements
     { "menu",			  tr("Financial &Statements"),		(char*)financialReportsMenu,		mainMenu,			"true",					       NULL, NULL, true, NULL },
-    { "gl.createFinancialReports",tr("&New Financial Report..."),	SLOT(sNewFinancialReport()),		financialReportsMenu,		"MaintainFinancialLayouts", NULL, NULL, true, NULL },
-    { "gl.editFinancialReports",  tr("&List Financial Reports..."),	SLOT(sFinancialReports()),		financialReportsMenu,		"MaintainFinancialLayouts", NULL, NULL, true, NULL },
+    { "gl.createFinancialReports",tr("&New Financial Report"),	SLOT(sNewFinancialReport()),		financialReportsMenu,		"MaintainFinancialLayouts", NULL, NULL, true, NULL },
+    { "gl.editFinancialReports",  tr("&List Financial Reports"),	SLOT(sFinancialReports()),		financialReportsMenu,		"MaintainFinancialLayouts", NULL, NULL, true, NULL },
     { "separator",		  NULL,					NULL,					financialReportsMenu,		"true",					       NULL, NULL, true, NULL },
-    { "gl.dspTrialBalances",	  tr("View &Trial Balances..."),		SLOT(sDspTrialBalances()),		financialReportsMenu,		"ViewTrialBalances",	   new QPixmap(":/images/viewTrialBalance.png"), toolBar,  true, NULL },
-    { "gl.viewFinancialReport",	  tr("View &Financial Report..."),	SLOT(sViewFinancialReport()),		financialReportsMenu,		"ViewFinancialReports",   new QPixmap(":/images/viewFinancialReport.png"), toolBar, true, NULL },
+    { "gl.dspTrialBalances",	  tr("View &Trial Balances"),		SLOT(sDspTrialBalances()),		financialReportsMenu,		"ViewTrialBalances",	   new QPixmap(":/images/viewTrialBalance.png"), toolBar,  true, NULL },
+    { "gl.viewFinancialReport",	  tr("View &Financial Report"),	SLOT(sViewFinancialReport()),		financialReportsMenu,		"ViewFinancialReports",   new QPixmap(":/images/viewFinancialReport.png"), toolBar, true, NULL },
 
     { "separator",		  NULL,					NULL,					mainMenu,		"true",					       NULL, NULL, true, NULL },
     
     // Accounting | Fiscal Calendar
     { "menu", tr("&Fiscal Calendar"), (char*)calendarMenu, mainMenu,	"true",	NULL, NULL, true, NULL },
-    { "gl.accountingYearPeriods",	tr("Fiscal &Years..."),	SLOT(sAccountingYearPeriods()),	calendarMenu,	"MaintainAccountingPeriods",	NULL, NULL, true, NULL },
-    { "gl.accountingPeriods",	tr("Accounting &Periods..."),	SLOT(sAccountingPeriods()),	calendarMenu,	"MaintainAccountingPeriods",	NULL, NULL, true, NULL },
+    { "gl.accountingYearPeriods",	tr("Fiscal &Years"),	SLOT(sAccountingYearPeriods()),	calendarMenu,	"MaintainAccountingPeriods",	NULL, NULL, true, NULL },
+    { "gl.accountingPeriods",	tr("Accounting &Periods"),	SLOT(sAccountingPeriods()),	calendarMenu,	"MaintainAccountingPeriods",	NULL, NULL, true, NULL },
     
     // Accounting | Account
     { "menu", tr("&Ledger Accounts"), (char*)coaMenu, mainMenu,	"true",	NULL, NULL, true, NULL },
-    { "gl.accountNumbers",	tr("&Chart of Accounts..."),	SLOT(sAccountNumbers()), coaMenu,	"MaintainChartOfAccounts",	NULL, NULL, true, NULL },
-    { "gl.companies",		tr("C&ompanies..."),		SLOT(sCompanies()),		coaMenu,	"MaintainChartOfAccounts", NULL, NULL, (_metrics->value("GLCompanySize").toInt() > 0), NULL },
-    { "gl.profitCenterNumber",	tr("&Profit Center Numbers..."),	SLOT(sProfitCenters()),	coaMenu,	"MaintainChartOfAccounts", NULL, NULL, (_metrics->value("GLProfitSize").toInt() > 0), NULL },
-    { "gl.subaccountNumbers",	tr("&Subaccount Numbers..."),	SLOT(sSubaccounts()), coaMenu,	"MaintainChartOfAccounts", NULL, NULL, (_metrics->value("GLSubaccountSize").toInt() > 0), NULL },
-    { "gl.subAccntTypes",	tr("Su&baccount Types..."),	SLOT(sSubAccntTypes()),	coaMenu,	"MaintainChartOfAccounts",	NULL, NULL, true, NULL },
+    { "gl.accountNumbers",	tr("&Chart of Accounts"),	SLOT(sAccountNumbers()), coaMenu,	"MaintainChartOfAccounts",	NULL, NULL, true, NULL },
+    { "gl.companies",		tr("C&ompanies"),		SLOT(sCompanies()),		coaMenu,	"MaintainChartOfAccounts", NULL, NULL, (_metrics->value("GLCompanySize").toInt() > 0), NULL },
+    { "gl.profitCenterNumber",	tr("&Profit Center Numbers"),	SLOT(sProfitCenters()),	coaMenu,	"MaintainChartOfAccounts", NULL, NULL, (_metrics->value("GLProfitSize").toInt() > 0), NULL },
+    { "gl.subaccountNumbers",	tr("&Subaccount Numbers"),	SLOT(sSubaccounts()), coaMenu,	"MaintainChartOfAccounts", NULL, NULL, (_metrics->value("GLSubaccountSize").toInt() > 0), NULL },
+    { "gl.subAccntTypes",	tr("Su&baccount Types"),	SLOT(sSubAccntTypes()),	coaMenu,	"MaintainChartOfAccounts",	NULL, NULL, true, NULL },
 
     // Accounting | Budget
     { "menu", tr("Bu&dget"), (char*)budgetMenu, mainMenu,	"true",	NULL, NULL, true, NULL },
-    { "gl.maintainBudget",	tr("&New Budget..."),	SLOT(sMaintainBudget()), budgetMenu,	"MaintainBudgets",	NULL, NULL, true, NULL },
-    { "gl.maintainBudgets",	tr("&List Budgets..."),	SLOT(sBudgets()),	 budgetMenu,	"MaintainBudgets ViewBudgets",	NULL, NULL, true, NULL },
+    { "gl.maintainBudget",	tr("&New Budget"),	SLOT(sMaintainBudget()), budgetMenu,	"MaintainBudgets",	NULL, NULL, true, NULL },
+    { "gl.maintainBudgets",	tr("&List Budgets"),	SLOT(sBudgets()),	 budgetMenu,	"MaintainBudgets ViewBudgets",	NULL, NULL, true, NULL },
 
     // Accounting | Tax
     { "menu", tr("&Tax"), (char*)taxMenu, mainMenu,	"true",	NULL, NULL, true, NULL },
-    { "gl.taxAuthorities",	tr("Tax &Authorities..."),	SLOT(sTaxAuthorities()),	taxMenu,	"MaintainTaxAuthorities ViewTaxAuthorities", NULL, NULL, true, NULL },
-    { "gl.taxZones",		tr("Tax &Zones..."),		SLOT(sTaxZones()),		taxMenu,	"MaintainTaxZones ViewTaxZones",             NULL, NULL, true, NULL }, 
-    { "gl.taxClasses",		tr("Tax &Classes..."),		SLOT(sTaxClasses()),		taxMenu,	"MaintainTaxClasses ViewTaxClasses",         NULL, NULL, true, NULL }, 
-    { "gl.taxCodes",		tr("Tax &Codes..."),		SLOT(sTaxCodes()),		taxMenu,	"MaintainTaxCodes ViewTaxCodes",             NULL, NULL, true, NULL },
-    { "gl.taxTypes",		tr("Tax &Types..."),		SLOT(sTaxTypes()),		taxMenu,	"MaintainTaxTypes ViewTaxTypes",             NULL, NULL, true, NULL },
-    { "gl.taxAssignments",	tr("Tax Assi&gnments..."),	SLOT(sTaxAssignments()),	taxMenu,	"MaintainTaxAssignments ViewTaxAssignments", NULL, NULL, true, NULL },
-    { "gl.taxRegistatrions",	tr("Tax &Registrations..."),	SLOT(sTaxRegistrations()),	taxMenu,	"MaintainTaxRegistrations ViewTaxRegistrations", NULL, NULL, true, NULL },
+    { "gl.taxAuthorities",	tr("Tax &Authorities"),	SLOT(sTaxAuthorities()),	taxMenu,	"MaintainTaxAuthorities ViewTaxAuthorities", NULL, NULL, true, NULL },
+    { "gl.taxZones",		tr("Tax &Zones"),		SLOT(sTaxZones()),		taxMenu,	"MaintainTaxZones ViewTaxZones",             NULL, NULL, true, NULL }, 
+    { "gl.taxClasses",		tr("Tax &Classes"),		SLOT(sTaxClasses()),		taxMenu,	"MaintainTaxClasses ViewTaxClasses",         NULL, NULL, true, NULL }, 
+    { "gl.taxCodes",		tr("Tax &Codes"),		SLOT(sTaxCodes()),		taxMenu,	"MaintainTaxCodes ViewTaxCodes",             NULL, NULL, true, NULL },
+    { "gl.taxTypes",		tr("Tax &Types"),		SLOT(sTaxTypes()),		taxMenu,	"MaintainTaxTypes ViewTaxTypes",             NULL, NULL, true, NULL },
+    { "gl.taxAssignments",	tr("Tax Assi&gnments"),	SLOT(sTaxAssignments()),	taxMenu,	"MaintainTaxAssignments ViewTaxAssignments", NULL, NULL, true, NULL },
+    { "gl.taxRegistatrions",	tr("Tax &Registrations"),	SLOT(sTaxRegistrations()),	taxMenu,	"MaintainTaxRegistrations ViewTaxRegistrations", NULL, NULL, true, NULL },
     { "separator",		NULL,			        NULL,			        taxMenu,	"true",	                                     NULL, NULL, true, NULL },
  
     // Accounting | Tax | Reports
     { "menu",			tr("&Reports"),	                (char*)taxReportsMenu,		taxMenu,	"true",			    NULL, NULL, true, NULL },
-    { "gl.dspTaxHistory",	tr("&Tax History..."),           SLOT(sDspTaxHistory()),        taxReportsMenu, "ViewTaxReconciliations",   NULL, NULL, true, NULL },
-    { "gl.dspTaxReturn",	tr("&Tax Return..."),            SLOT(sDspTaxReturn()),         taxReportsMenu, "ViewTaxReconciliations",   NULL, NULL, true, NULL },
-    { "gl.dspTax1099",	tr("&Info for 1099..."),                 SLOT(sDspTax1099()),           taxReportsMenu, "ViewTaxReconciliations",   NULL, NULL, true, NULL },
+    { "gl.dspTaxHistory",	tr("&Tax History"),           SLOT(sDspTaxHistory()),        taxReportsMenu, "ViewTaxReconciliations",   NULL, NULL, true, NULL },
+    { "gl.dspTaxReturn",	tr("&Tax Return"),            SLOT(sDspTaxReturn()),         taxReportsMenu, "ViewTaxReconciliations",   NULL, NULL, true, NULL },
+    { "gl.dspTax1099",	tr("&Info for 1099"),                 SLOT(sDspTax1099()),           taxReportsMenu, "ViewTaxReconciliations",   NULL, NULL, true, NULL },
     
     { "separator",		  NULL,					NULL,					mainMenu,		"true",					       NULL, NULL, true, NULL },
 
     // Accounting | Utilities
     { "menu",				tr("&Utilities"),			(char*)utilitiesMenu,		mainMenu,	"true",	NULL, NULL, true, NULL },
     { "gl.forwardUpdateAccounts",	tr("&Forward Update Accounts..."),	SLOT(sForwardUpdateAccounts()),	utilitiesMenu,	"ViewTrialBalances",	NULL, NULL, _metrics->boolean("ManualForwardUpdate"), NULL },
-    { "gl.duplicateAccountNumbers",      tr("&Duplicate Account Numbers..."),  SLOT(sDuplicateAccountNumbers()), utilitiesMenu,  "MaintainChartOfAccounts", NULL, NULL, true, NULL },
+    { "gl.duplicateAccountNumbers",      tr("&Duplicate Account Numbers"),  SLOT(sDuplicateAccountNumbers()), utilitiesMenu,  "MaintainChartOfAccounts", NULL, NULL, true, NULL },
     { "separator",		  NULL,					NULL,					utilitiesMenu,		"true",					       NULL, NULL, true, NULL },
     { "so.purgeInvoices", tr("Purge &Invoices..."), SLOT(sPurgeInvoices()), utilitiesMenu, "PurgeInvoices", NULL, NULL, true , NULL },
-    { "ar.updateLateCustCreditStatus", tr("&Update Late Customer Credit Status..."), SLOT(sUpdateLateCustCreditStatus()), utilitiesMenu, "UpdateCustomerCreditStatus", NULL, NULL, _metrics->boolean("AutoCreditWarnLateCustomers"), NULL },
+    { "ar.updateLateCustCreditStatus", tr("&Update Late Customer Credit Status"), SLOT(sUpdateLateCustCreditStatus()), utilitiesMenu, "UpdateCustomerCreditStatus", NULL, NULL, _metrics->boolean("AutoCreditWarnLateCustomers"), NULL },
 //    { "ar.createRecurringInvoices", tr("&Create Recurring Invoices..."), SLOT(sCreateRecurringInvoices()), utilitiesMenu, "MaintainMiscInvoices", NULL, NULL, true, NULL },
     { "separator",		  NULL,					NULL,					utilitiesMenu,		"true",					       NULL, NULL, _metrics->boolean("MultiCompanyFinancialConsolidation"), NULL },
     { "gl.syncCompanies",           tr("&Synchronize Companies"),        SLOT(sSyncCompanies()),           utilitiesMenu, "SynchronizeCompanies", NULL, NULL, _metrics->boolean("MultiCompanyFinancialConsolidation"), NULL },

--- a/guiclient/menuCRM.cpp
+++ b/guiclient/menuCRM.cpp
@@ -138,7 +138,7 @@ menuCRM::menuCRM(GUIClient *Pparent) :
     { "crm.contactMerge",                tr("&Merge Contacts..."), SLOT(sContactMerge()),        utilitiesMenu, "MergeContacts",          NULL, NULL, true, NULL },
     { "crm.crmaccountMerge",         tr("Merge &Accounts..."), SLOT(sCrmaccountMerge()),     utilitiesMenu, "MaintainAllCRMAccounts", NULL, NULL, true, NULL },
 
-    { "crm.setup",	tr("&Setup..."),	SLOT(sSetup()),	crmMenu,	NULL,	NULL,	NULL,	true, NULL}
+    { "crm.setup",	tr("&Setup"),	SLOT(sSetup()),	crmMenu,	NULL,	NULL,	NULL,	true, NULL}
 
   };
 

--- a/guiclient/menuCRM.cpp
+++ b/guiclient/menuCRM.cpp
@@ -83,24 +83,24 @@ menuCRM::menuCRM(GUIClient *Pparent) :
   actionProperties acts[] = {
     // CRM | Incident
     { "menu",			tr("&Incident"),	(char*)incidentMenu,		crmMenu,	"true", NULL, NULL, true	, NULL },
-    { "crm.incident",		tr("&New..."),		SLOT(sIncident()),		incidentMenu,	"MaintainPersonalIncidents MaintainAllIncidents", NULL, NULL, true , NULL },
-    { "crm.incidentList",	tr("&List..."),	SLOT(sIncidentWorkbench()),	incidentMenu,	"ViewPersonalIncidents MaintainPersonalIncidents ViewAllIncidents MaintainAllIncidents", new QPixmap(":/images/incidents.png"), toolBar, true , tr("Incident List") },
+    { "crm.incident",		tr("&New"),		SLOT(sIncident()),		incidentMenu,	"MaintainPersonalIncidents MaintainAllIncidents", NULL, NULL, true , NULL },
+    { "crm.incidentList",	tr("&List"),	SLOT(sIncidentWorkbench()),	incidentMenu,	"ViewPersonalIncidents MaintainPersonalIncidents ViewAllIncidents MaintainAllIncidents", new QPixmap(":/images/incidents.png"), toolBar, true , tr("Incident List") },
 
     // CRM / To Do
     { "menu",			tr("&To-Do"),	(char*)todoMenu,	crmMenu,	"true", NULL, NULL, true	, NULL },
-    { "crm.todoItem",		tr("&New..."),	SLOT(sTodoItem()),	todoMenu,	"MaintainPersonalToDoItems MaintainAllToDoItems", NULL, NULL, true	, NULL },
-    { "crm.todoList",		tr("&List..."),		SLOT(sTodoList()),	todoMenu,	"MaintainPersonalToDoItems ViewPersonalToDoItems MaintainAllToDoItems ViewAllToDoItems", new QPixmap(":/images/toDoList.png"), toolBar, true	, tr("To-Do List") },
+    { "crm.todoItem",		tr("&New"),	SLOT(sTodoItem()),	todoMenu,	"MaintainPersonalToDoItems MaintainAllToDoItems", NULL, NULL, true	, NULL },
+    { "crm.todoList",		tr("&List"),		SLOT(sTodoList()),	todoMenu,	"MaintainPersonalToDoItems ViewPersonalToDoItems MaintainAllToDoItems ViewAllToDoItems", new QPixmap(":/images/toDoList.png"), toolBar, true	, tr("To-Do List") },
     { "crm.todoListCalendar",		tr("&Calendar List..."),		SLOT(sTodoListCalendar()),	todoMenu,	"MaintainPersonalToDoItems ViewPersonalToDoItems MaintainAllToDoItems ViewAllToDoItems", NULL, NULL, true, NULL},
 
     //  Project
     { "menu", tr("Pro&ject"), (char*)projectsMenu, crmMenu, "true", NULL, NULL, true	, NULL },
     { "pm.newProject", tr("&New..."), SLOT(sNewProject()), projectsMenu, "MaintainPersonalProjects MaintainAllProjects", NULL, NULL, true , NULL },
-    { "pm.projects", tr("&List..."), SLOT(sProjects()), projectsMenu, "ViewPersonalProjects MaintainPersonalProjects ViewAllProjects MaintainAllProjects", new QPixmap(":/images/projects.png"), toolBar, true , tr("List Projects") },
+    { "pm.projects", tr("&List"), SLOT(sProjects()), projectsMenu, "ViewPersonalProjects MaintainPersonalProjects ViewAllProjects MaintainAllProjects", new QPixmap(":/images/projects.png"), toolBar, true , tr("List Projects") },
     
     // Opportunity
     { "menu",		tr("&Opportunity"),	(char*)opportunityMenu,	crmMenu,		"true", NULL, NULL, true	, NULL },
-    { "crm.newOpportunity", tr("&New..."), SLOT(sNewOpportunity()), opportunityMenu, "MaintainPersonalOpportunities MaintainAllOpportunities", NULL, NULL, true , NULL },
-    { "crm.listOpportunity", tr("&List..."), SLOT(sOpportunities()), opportunityMenu, "MaintainPersonalOpportunities ViewPersonalOpportunities MaintainAllOpportunities ViewAllOpportunities", NULL, NULL, true , NULL },
+    { "crm.newOpportunity", tr("&New"), SLOT(sNewOpportunity()), opportunityMenu, "MaintainPersonalOpportunities MaintainAllOpportunities", NULL, NULL, true , NULL },
+    { "crm.listOpportunity", tr("&List"), SLOT(sOpportunities()), opportunityMenu, "MaintainPersonalOpportunities ViewPersonalOpportunities MaintainAllOpportunities ViewAllOpportunities", NULL, NULL, true , NULL },
 
     { "separator",		NULL,				NULL,			crmMenu,	"true", NULL, NULL, true	, NULL },
 
@@ -112,22 +112,22 @@ menuCRM::menuCRM(GUIClient *Pparent) :
     
     // CRM | Account
     { "menu",		tr("&Account"),		(char*)accountsMenu,	crmMenu,		"true", NULL, NULL, true	, NULL },
-    { "crm.crmaccount",		tr("&New..."),	SLOT(sCRMAccount()),	accountsMenu,	"MaintainPersonalCRMAccounts MaintainAllCRMAccounts", NULL, NULL, true , NULL },
-    { "crm.crmaccounts",	tr("&List..."),	SLOT(sCRMAccounts()),	accountsMenu,	"MaintainPersonalCRMAccounts ViewPersonalCRMAccounts MaintainAllCRMAccounts ViewAllCRMAccounts", new QPixmap(":/images/accounts.png"), toolBar, true , tr("List Accounts") },
+    { "crm.crmaccount",		tr("&New"),	SLOT(sCRMAccount()),	accountsMenu,	"MaintainPersonalCRMAccounts MaintainAllCRMAccounts", NULL, NULL, true , NULL },
+    { "crm.crmaccounts",	tr("&List"),	SLOT(sCRMAccounts()),	accountsMenu,	"MaintainPersonalCRMAccounts ViewPersonalCRMAccounts MaintainAllCRMAccounts ViewAllCRMAccounts", new QPixmap(":/images/accounts.png"), toolBar, true , tr("List Accounts") },
       
     // CRM | Contact
     { "menu",		tr("&Contact"),		(char*)contactsMenu,	crmMenu,		"true", NULL, NULL, true	, NULL },
-    { "crm.contact",	tr("&New..."),		SLOT(sContact()),	contactsMenu,	"MaintainPersonalContacts MaintainAllContacts", NULL, NULL, true	, NULL },
-    { "crm.contacts",	tr("&List..."),		SLOT(sContacts()),	contactsMenu,	"MaintainPersonalContacts ViewPersonalContacts MaintainAllContacts ViewAllContacts", new QPixmap(":/images/contacts.png"), toolBar, true , tr("List Contacts") },
+    { "crm.contact",	tr("&New"),		SLOT(sContact()),	contactsMenu,	"MaintainPersonalContacts MaintainAllContacts", NULL, NULL, true	, NULL },
+    { "crm.contacts",	tr("&List"),		SLOT(sContacts()),	contactsMenu,	"MaintainPersonalContacts ViewPersonalContacts MaintainAllContacts ViewAllContacts", new QPixmap(":/images/contacts.png"), toolBar, true , tr("List Contacts") },
     
     // CRM | Address
     { "menu",		tr("A&ddress"),		(char*)addressMenu,	crmMenu,		"true", NULL, NULL, true	, NULL },
-    { "crm.address",	tr("&New..."),		SLOT(sAddress()),	addressMenu,	"MaintainAddresses", NULL, NULL, true	, NULL },
-    { "crm.addresses",	tr("&List..."),	        SLOT(sAddresses()),	addressMenu,	"MaintainAddresses ViewAddresses", NULL, NULL, true , NULL },
+    { "crm.address",	tr("&New"),		SLOT(sAddress()),	addressMenu,	"MaintainAddresses", NULL, NULL, true	, NULL },
+    { "crm.addresses",	tr("&List"),	        SLOT(sAddresses()),	addressMenu,	"MaintainAddresses ViewAddresses", NULL, NULL, true , NULL },
 
     // CRM | Documents
     { "menu",		tr("Documents"),        (char*)documentsMenu,	crmMenu,	"true", NULL, NULL, true	, NULL },
-    { "crm.documents",	tr("&List..."),	        SLOT(sDocuments()),	documentsMenu,	"ViewDocuments", NULL, NULL, true , NULL },
+    { "crm.documents",	tr("&List"),	        SLOT(sDocuments()),	documentsMenu,	"ViewDocuments", NULL, NULL, true , NULL },
 
     { "separator",		NULL,				NULL,			crmMenu,	"true", NULL, NULL, true	, NULL },
 

--- a/guiclient/menuInventory.cpp
+++ b/guiclient/menuInventory.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -202,8 +202,8 @@ menuInventory::menuInventory(GUIClient *Pparent) :
     //  Inventory |  Transfer Orders
     // TODO: switch between visibility of Inter-Warehouse Transfer and Transfer Orders based on config param?
     { "menu",                                tr("Transfer &Order"),          (char*)transferOrderMenu,                 mainMenu,          "true",                                      NULL, NULL, _metrics->boolean("MultiWhs"), NULL},
-    { "im.interWarehouseTransfer",           tr("&New..."),                  SLOT(sNewTransferOrder()),                transferOrderMenu, "MaintainTransferOrders",                    NULL, NULL, _metrics->boolean("MultiWhs"), NULL },
-    { "im.transferOrders",                   tr("&List Open..."),            SLOT(sTransferOrders()),                  transferOrderMenu, "ViewTransferOrders MaintainTransferOrders", NULL, NULL, _metrics->boolean("MultiWhs"), NULL },
+    { "im.interWarehouseTransfer",           tr("&New"),                  SLOT(sNewTransferOrder()),                transferOrderMenu, "MaintainTransferOrders",                    NULL, NULL, _metrics->boolean("MultiWhs"), NULL },
+    { "im.transferOrders",                   tr("&List Open"),            SLOT(sTransferOrders()),                  transferOrderMenu, "ViewTransferOrders MaintainTransferOrders", NULL, NULL, _metrics->boolean("MultiWhs"), NULL },
     { "separator",                           NULL,                           NULL,                                     transferOrderMenu, "true",                                      NULL, NULL, true,                          NULL},
     { "im.releaseTransferOrders",            tr("&Release by Agent..."),     SLOT(sReleaseTransferOrdersByAgent()),transferOrderMenu, "ReleaseTransferOrders",                     NULL, NULL, _metrics->boolean("MultiWhs"), NULL },
 
@@ -215,24 +215,24 @@ menuInventory::menuInventory(GUIClient *Pparent) :
     { "im.createCountTagsByPlannerCode",tr("by &Planner Code..."),             SLOT(sCreateCountTagsByPlannerCode()),physicalCreateTagsMenu, "IssueCountTags",  NULL, NULL, true, NULL },
     { "im.createCountTagsByClassCode",  tr("by &Class Code..."),               SLOT(sCreateCountTagsByClassCode()),  physicalCreateTagsMenu, "IssueCountTags",  NULL, NULL, true, NULL },
     { "im.createCountTagsByItem",       tr("by &Item..."),                     SLOT(sCreateCountTagsByItem()),       physicalCreateTagsMenu, "IssueCountTags",  NULL, NULL, true, NULL },
-    { "im.createCycleCountTags",        tr("Create C&ycle Count Tags..."),     SLOT(sCreateCycleCountTags()),        physicalMenu,           "IssueCountTags",  NULL, NULL, true, NULL },
+    { "im.createCycleCountTags",        tr("Create C&ycle Count Tags"),     SLOT(sCreateCycleCountTags()),        physicalMenu,           "IssueCountTags",  NULL, NULL, true, NULL },
     { "separator",                      NULL,                                  NULL,                                 physicalMenu,           "true",            NULL, NULL, true, NULL },
-    { "im.enterCountSlip",              tr("Enter Count &Slip..."),            SLOT(sEnterCountSlip()),              physicalMenu,           "EnterCountSlips", NULL, NULL, true, NULL },
-    { "im.enterCountTag",               tr("Enter Count &Tag..."),             SLOT(sEnterCountTags()),              physicalMenu,           "EnterCountTags",  NULL, NULL, true, NULL },
-    { "im.enterMiscInventoryCount",     tr("Enter &Misc. Inventory Count..."), SLOT(sEnterMiscCount()),              physicalMenu,           "EnterMiscCounts", NULL, NULL, true, NULL },
-    { "im.zeroUncountedCountTags",      tr("&Zero Uncounted Count Tags..."),   SLOT(sZeroUncountedTagsByWarehouse()),physicalMenu,           "ZeroCountTags",   NULL, NULL, true, NULL },
+    { "im.enterCountSlip",              tr("Enter Count &Slip"),            SLOT(sEnterCountSlip()),              physicalMenu,           "EnterCountSlips", NULL, NULL, true, NULL },
+    { "im.enterCountTag",               tr("Enter Count &Tag"),             SLOT(sEnterCountTags()),              physicalMenu,           "EnterCountTags",  NULL, NULL, true, NULL },
+    { "im.enterMiscInventoryCount",     tr("Enter &Misc. Inventory Count"), SLOT(sEnterMiscCount()),              physicalMenu,           "EnterMiscCounts", NULL, NULL, true, NULL },
+    { "im.zeroUncountedCountTags",      tr("&Zero Uncounted Count Tags"),   SLOT(sZeroUncountedTagsByWarehouse()),physicalMenu,           "ZeroCountTags",   NULL, NULL, true, NULL },
     { "separator",                      NULL,                                  NULL,                                 physicalMenu,           "true",            NULL, NULL, true, NULL },
     { "im.thawItemSitesByClassCode",    tr("Tha&w Item Sites..."),             SLOT(sThawItemSitesByClassCode()),    physicalMenu,           "ThawInventory",   NULL, NULL, true, NULL },
     { "separator",                      NULL,                                  NULL,                                 physicalMenu,           "true",            NULL, NULL, true, NULL },
-    { "im.postCountSlips",              tr("Post Count S&lips..."),            SLOT(sPostCountSlipsByWarehouse()),   physicalMenu,           "PostCountSlips",  NULL, NULL, true, NULL },
-    { "im.postCountTags",               tr("Post Count T&ags..."),             SLOT(sPostCountTags()),               physicalMenu,           "PostCountTags",   NULL, NULL, true, NULL },
+    { "im.postCountSlips",              tr("Post Count S&lips"),            SLOT(sPostCountSlipsByWarehouse()),   physicalMenu,           "PostCountSlips",  NULL, NULL, true, NULL },
+    { "im.postCountTags",               tr("Post Count T&ags"),             SLOT(sPostCountTags()),               physicalMenu,           "PostCountTags",   NULL, NULL, true, NULL },
     { "im.purgeCountSlips",             tr("&Purge Posted Count Slips..."),    SLOT(sPurgePostedCountSlips()),       physicalMenu,           "PurgeCountSlips", NULL, NULL, true, NULL },
     { "im.purgeCountTags",              tr("P&urge Posted Count Tags..."),     SLOT(sPurgePostedCountTags()),        physicalMenu,           "PurgeCountTags",  NULL, NULL, true, NULL },
     { "separator",                      NULL,                                  NULL,                                 physicalMenu,           "true",            NULL, NULL, true, NULL },      
 
     //  Inventory | Physical Inventory | Reports
     { "menu",                           tr("&Reports"),                   (char*)physicalReportsMenu,       physicalMenu,        "true",                NULL, NULL, true, NULL },
-    { "im.dspFrozenItemSites",          tr("&Frozen Item Sites..."),      SLOT(sDspFrozenItemSites()),      physicalReportsMenu, "ViewItemSites",       NULL, NULL, true, NULL },
+    { "im.dspFrozenItemSites",          tr("&Frozen Item Sites"),      SLOT(sDspFrozenItemSites()),      physicalReportsMenu, "ViewItemSites",       NULL, NULL, true, NULL },
     { "separator",                      NULL,                             NULL,                             physicalReportsMenu, "true",                NULL, NULL, true, NULL },
     { "im.dspCountSlipEditList",        tr("Count S&lip Edit List..."),   SLOT(sDspCountSlipEditList()),    physicalReportsMenu, "ViewCountTags",       NULL, NULL, true, NULL },
     { "im.dspCountTagEditList",         tr("Count Ta&g Edit List..."),    SLOT(sDspCountTagEditList()),     physicalReportsMenu, "ViewCountTags",       NULL, NULL, true, NULL },
@@ -249,8 +249,8 @@ menuInventory::menuInventory(GUIClient *Pparent) :
 
     //  Inventory | Receiving
     { "menu",            tr("R&eceiving"),                 (char*)receivingMenu,  mainMenu,      "true",          NULL, NULL, true, NULL },
-    { "sr.enterReceipt", tr("&New Receipt..."),            SLOT(sEnterReceipt()), receivingMenu, "EnterReceipts", NULL, NULL, true, NULL },
-    { "sr.postReceipts", tr("&List Unposted Receipts..."), SLOT(sPostReceipts()), receivingMenu, "EnterReceipts", new QPixmap(":/images/postReceipts.png"), toolBar,  true, tr("List Unposted Receipts") },
+    { "sr.enterReceipt", tr("&New Receipt"),            SLOT(sEnterReceipt()), receivingMenu, "EnterReceipts", NULL, NULL, true, NULL },
+    { "sr.postReceipts", tr("&List Unposted Receipts"), SLOT(sPostReceipts()), receivingMenu, "EnterReceipts", new QPixmap(":/images/postReceipts.png"), toolBar,  true, tr("List Unposted Receipts") },
     { "separator",       NULL,                             NULL,                  receivingMenu, "true",          NULL, NULL, true, NULL },
     { "sr.enterReturn",  tr("Purchase Order &Return..."),  SLOT(sEnterReturn()),  receivingMenu, "EnterReturns",  NULL, NULL, true, NULL },
     { "separator",       NULL,                             NULL,                  receivingMenu, "true",          NULL, NULL, true, NULL },
@@ -262,7 +262,7 @@ menuInventory::menuInventory(GUIClient *Pparent) :
     //  Inventory | Shipping
     { "menu",                        tr("&Shipping"),                      (char*)shippingMenu,           mainMenu,     "true",                 NULL, NULL, true, NULL },
     { "sr.issueToShipping",          tr("&Issue to Shipping..."),          SLOT(sIssueStockToShipping()), shippingMenu, "IssueStockToShipping", new QPixmap(":/images/issueStockToShipping.png"), toolBar,  true, tr("Issue to Shipping") },
-    { "sr.maintainShippingContents", tr("&Maintain Shipping Contents..."), SLOT(sDspShippingContents()),  shippingMenu, "ViewShipping",         NULL, NULL, true, NULL },
+    { "sr.maintainShippingContents", tr("&Maintain Shipping Contents"), SLOT(sDspShippingContents()),  shippingMenu, "ViewShipping",         NULL, NULL, true, NULL },
     { "separator",                   NULL,                                 NULL,                          shippingMenu, "true",                 NULL, NULL, true, NULL },
     { "sr.shipOrder",                tr("&Ship Order..."),                 SLOT(sShipOrders()),           shippingMenu, "ShipOrders",           NULL, NULL, true, NULL },
     { "sr.recallOrdersToShipping",   tr("R&ecall Orders to Shipping..."),  SLOT(sRecallOrders()),         shippingMenu, "RecallOrders",         NULL, NULL, true, NULL },
@@ -288,7 +288,7 @@ menuInventory::menuInventory(GUIClient *Pparent) :
     { "menu",                               tr("&Reports"),                (char*)shippingReportsMenu,               shippingMenu,        "true",            NULL, NULL, true, NULL },
 
     // Inventory | Shipping | Reports | Backlog
-    { "sr.dspBacklog",                tr("&Backlog..."),             SLOT(sDspBacklog()),                shippingReportsMenu,  "ViewSalesOrders", NULL, NULL, true, NULL },
+    { "sr.dspBacklog",                tr("&Backlog"),             SLOT(sDspBacklog()),                shippingReportsMenu,  "ViewSalesOrders", NULL, NULL, true, NULL },
 
     { "separator", NULL, NULL, shippingReportsMenu, "true", NULL, NULL, true, NULL },
 
@@ -354,12 +354,12 @@ menuInventory::menuInventory(GUIClient *Pparent) :
     // Inventory | Warehouse
     { "menu",                   tr("&Site"),            (char*)warehouseMenu,        mainMenu,      "true",                                             NULL, NULL, true, NULL },
     { whsModule,                whsLabel,               SLOT(sWarehouses()),         warehouseMenu, "MaintainWarehouses ViewWarehouses",                NULL, NULL, true, NULL },
-    { "im.warehousesLocations", tr("L&ocations..."),    SLOT(sWarehouseLocations()), warehouseMenu, "MaintainLocations ViewLocations",                  NULL, NULL, true, NULL },
+    { "im.warehousesLocations", tr("L&ocations"),    SLOT(sWarehouseLocations()), warehouseMenu, "MaintainLocations ViewLocations",                  NULL, NULL, true, NULL },
 
     // Inventory | Item Site
     { "menu",                           tr("&Item Site"),       (char*)itemSitesMenu,   mainMenu,       "true",              NULL, NULL, true, NULL },
-    { "im.newItemSite",                 tr("&New..."),          SLOT(sNewItemSite()),   itemSitesMenu,  "MaintainItemSites", NULL, NULL, true, NULL },
-    { "im.listItemSites",               tr("&List..."),         SLOT(sItemSites()),     itemSitesMenu,  "MaintainItemSites ViewItemSites", new QPixmap(":/images/itemSites.png"), toolBar, true, tr("List Item Sites") },
+    { "im.newItemSite",                 tr("&New"),          SLOT(sNewItemSite()),   itemSitesMenu,  "MaintainItemSites", NULL, NULL, true, NULL },
+    { "im.listItemSites",               tr("&List"),         SLOT(sItemSites()),     itemSitesMenu,  "MaintainItemSites ViewItemSites", new QPixmap(":/images/itemSites.png"), toolBar, true, tr("List Item Sites") },
     { "separator", NULL, NULL, itemSitesMenu,   "true", NULL, NULL, true, NULL },
     { "im.itemAvailabilityWorkbench",   tr("&Workbench..."),    SLOT(sDspItemAvailabilityWorkbench()),  itemSitesMenu, "ViewItemAvailabilityWorkbench", new QPixmap(":/images/itemAvailabilityWorkbench.png"), toolBar, true, tr("Item Availability Workbench") },
 
@@ -399,11 +399,11 @@ menuInventory::menuInventory(GUIClient *Pparent) :
     { "im.updateOrderUpToLevelsByClassCode",      tr("by &Class Code..."),                SLOT(sUpdateOUTLevelsByClassCode()),      updateItemInfoOutMenu, "UpdateOUTLevels",  NULL, NULL, true, NULL },
 
     { "im.summarizeTransactionHistoryByClassCode",tr("Summarize &Transaction History..."),SLOT(sSummarizeInvTransByClassCode()),    utilitiesMenu, "SummarizeInventoryTransactions", NULL, NULL, true, NULL },
-    { "im.createItemSitesByClassCode",            tr("&Create Item Sites..."),            SLOT(sCreateItemSitesByClassCode()),      utilitiesMenu, "MaintainItemSites",              NULL, NULL, true, NULL },
+    { "im.createItemSitesByClassCode",            tr("&Create Item Sites"),            SLOT(sCreateItemSitesByClassCode()),      utilitiesMenu, "MaintainItemSites",              NULL, NULL, true, NULL },
     { "separator",                                NULL,                                   NULL,                                     utilitiesMenu, "true",                           NULL, NULL, true, NULL },
     { "sr.externalShipping",          tr("Maintain E&xternal Shipping Records..."),       SLOT(sExternalShipping()),                utilitiesMenu, "MaintainExternalShipping", NULL, NULL, true, NULL },
     // Setup
-    { "im.setup",	                          tr("&Setup..."),                        SLOT(sSetup()),                           mainMenu,	   "true",                     NULL, NULL, true, NULL}
+    { "im.setup",	                          tr("&Setup"),                        SLOT(sSetup()),                           mainMenu,	   "true",                     NULL, NULL, true, NULL}
 
   };
 

--- a/guiclient/menuManufacture.cpp
+++ b/guiclient/menuManufacture.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -105,7 +105,7 @@ menuManufacture::menuManufacture(GUIClient *Pparent) :
   actionProperties acts[] = {
     // Production | Control
     { "menu",                              tr("&Work Order"), (char*)ordersMenu,                       mainMenu,   "true",                  0, 0, true, NULL },
-    { "wo.newWorkOrder",                       tr("&New..."), SLOT(sNewWorkOrder()),                   ordersMenu, "MaintainWorkOrders",    0, 0, true, NULL },
+    { "wo.newWorkOrder",                       tr("&New"), SLOT(sNewWorkOrder()),                   ordersMenu, "MaintainWorkOrders",    0, 0, true, NULL },
     { "separator",                                      NULL, NULL,                                    ordersMenu, "true",                  0, 0, true, NULL },
     { "wo.explodeWorkOrder",               tr("E&xplode..."), SLOT(sExplodeWorkOrder()),               ordersMenu, "ExplodeWorkOrders",     0, 0, true, NULL },
     { "wo.implodeWorkOrder",               tr("&Implode..."), SLOT(sImplodeWorkOrder()),               ordersMenu, "ImplodeWorkOrders",     0, 0, true, NULL },
@@ -118,7 +118,7 @@ menuManufacture::menuManufacture(GUIClient *Pparent) :
 
     //  Production | W/O Materials
     { "menu",                               tr("&Materials"), (char*)materialsMenu,                 mainMenu,      "true",                0, 0, true, NULL },
-    { "wo.createWoMaterialRequirement",        tr("&New..."), SLOT(sCreateWoMaterialRequirement()), materialsMenu, "MaintainWoMaterials", 0, 0, true, NULL },
+    { "wo.createWoMaterialRequirement",        tr("&New"), SLOT(sCreateWoMaterialRequirement()), materialsMenu, "MaintainWoMaterials", 0, 0, true, NULL },
     { "wo.maintainWoMaterialRequirements",tr("&Maintain..."), SLOT(sMaintainWoMaterials()),         materialsMenu, "MaintainWoMaterials", 0, 0, true, NULL },
 
     { "separator",                  NULL,                   NULL,                          mainMenu,          "true",  0, 0, true, NULL },
@@ -188,7 +188,7 @@ menuManufacture::menuManufacture(GUIClient *Pparent) :
     { "separator",              NULL,                               NULL,                           mainMenu,      "true",            0, 0, true, NULL },
     { "menu",                   tr("&Utilities"),                   (char*)utilitiesMenu,           mainMenu,      "true",            0, 0, true, NULL },
     { "wo.purgeClosedWorkOrder",tr("Pur&ge Closed Work Orders..."), SLOT(sPurgeClosedWorkOrders()), utilitiesMenu, "PurgeWorkOrders", 0, 0, true, NULL },
-    { "wo.setup",	tr("&Setup..."),	SLOT(sSetup()),	mainMenu,	NULL,	NULL,	NULL,	true, NULL}
+    { "wo.setup",	tr("&Setup"),	SLOT(sSetup()),	mainMenu,	NULL,	NULL,	NULL,	true, NULL}
   };
 
   addActionsToMenu(acts, sizeof(acts) / sizeof(acts[0]));

--- a/guiclient/menuProducts.cpp
+++ b/guiclient/menuProducts.cpp
@@ -145,18 +145,18 @@ menuProducts::menuProducts(GUIClient *Pparent) :
 
   // Product | Items
   { "menu",	tr("&Item"), (char*)itemsMenu,	mainMenu, "true", NULL, NULL, true , NULL },
-  { "pd.enterNewItem", tr("&New..."), SLOT(sNewItem()), itemsMenu, "MaintainItemMasters", NULL, NULL, true , NULL },
-  { "pd.listItems", tr("&List..."), SLOT(sItems()), itemsMenu, "MaintainItemMasters ViewItemMasters", new QPixmap(":/images/items.png"), toolBar, true , tr("List Items") },
+  { "pd.enterNewItem", tr("&New"), SLOT(sNewItem()), itemsMenu, "MaintainItemMasters", NULL, NULL, true , NULL },
+  { "pd.listItems", tr("&List"), SLOT(sItems()), itemsMenu, "MaintainItemMasters ViewItemMasters", new QPixmap(":/images/items.png"), toolBar, true , tr("List Items") },
   { "pd.copyItem", tr("&Copy..."), SLOT(sCopyItem()), itemsMenu, "MaintainItemMasters" , NULL, NULL, true, NULL },
   { "separator", NULL, NULL, itemsMenu,	"true", NULL, NULL, true , NULL },
   { "pd.itemAvailabilityWorkbench", tr("&Workbench..."), SLOT(sDspItemAvailabilityWorkbench()), itemsMenu, "ViewItemAvailabilityWorkbench", NULL, NULL, true , NULL },
   { "separator", NULL, NULL, itemsMenu,	"true", NULL, NULL, true , NULL },
-  { "pd.itemGroups", tr("&Groups..."), SLOT(sItemGroups()), itemsMenu, "MaintainItemGroups ViewItemGroups", NULL, NULL, true , NULL },
+  { "pd.itemGroups", tr("&Groups"), SLOT(sItemGroups()), itemsMenu, "MaintainItemGroups ViewItemGroups", NULL, NULL, true , NULL },
   { "pd.itemImages", tr("&Images..."), SLOT(sItemImages()), itemsMenu, "MaintainItemMasters ViewItemMasters", NULL, NULL, true , NULL },
 
   // Product | Bill of Materials
   { "menu",	tr("Bill Of Ma&terials"), (char*)bomMenu,	mainMenu, "true", NULL, NULL, true , NULL },
-  { "pd.enterNewBOM", tr("&New..."), SLOT(sNewBOM()), bomMenu, "MaintainBOMs", NULL, NULL, true , NULL },
+  { "pd.enterNewBOM", tr("&New"), SLOT(sNewBOM()), bomMenu, "MaintainBOMs", NULL, NULL, true , NULL },
   { "pd.listBOMs", tr("&List..."), SLOT(sBOMs()), bomMenu, "MaintainBOMs ViewBOMs", new QPixmap(":/images/boms.png"), toolBar, true , tr("List Bill of Materials") },
   { "pd.copyBOM", tr("&Copy..."), SLOT(sCopyBOM()), bomMenu, "MaintainBOMs", NULL, NULL, true , NULL },
   { "separator", NULL, NULL, bomMenu,	"true", NULL, NULL, true , NULL },
@@ -212,14 +212,14 @@ menuProducts::menuProducts(GUIClient *Pparent) :
   //  Produt | Utilies
   { "menu",	tr("&Utilities"), (char*)utilitiesMenu, mainMenu, "true", NULL, NULL, true , NULL },
   { "pd.dspUnusedPurchasedItems", tr("Unused &Purchased Items..."), SLOT(sDspUnusedPurchasedItems()), utilitiesMenu, "ViewBOMs", NULL, NULL, true , NULL },
-  { "pd.dspUndefinedManufacturedItems", tr("Undefined &Manufactured Items..."), SLOT(sDspUndefinedManufacturedItems()), utilitiesMenu, "ViewBOMs ViewBOOs", NULL, NULL, true , NULL },
-  { "pd.dspBillsOfMaterialsWithoutComponentItemSites", tr("Bills of Ma&terials without Component Item Sites..."), SLOT(sDspInvalidBillsOfMaterials()), utilitiesMenu, "ViewBOMs", NULL, NULL, true , NULL },
+  { "pd.dspUndefinedManufacturedItems", tr("Undefined &Manufactured Items"), SLOT(sDspUndefinedManufacturedItems()), utilitiesMenu, "ViewBOMs ViewBOOs", NULL, NULL, true , NULL },
+  { "pd.dspBillsOfMaterialsWithoutComponentItemSites", tr("Bills of Ma&terials without Component Item Sites"), SLOT(sDspInvalidBillsOfMaterials()), utilitiesMenu, "ViewBOMs", NULL, NULL, true , NULL },
   { "separator", NULL, NULL, utilitiesMenu,	"true", NULL, NULL, true , NULL },
   { "pd.reassignClassCodeByClassCode", tr("Reassign &Class Codes..."), SLOT(sReassignClassCodeByClassCode()), utilitiesMenu, "MaintainItemMasters", NULL, NULL, true , NULL },
   { "pd.reassignProductCategoryByProductCategory", tr("&Reassign Product Categories..."), SLOT(sReassignProductCategoryByProductCategory()), utilitiesMenu, "MaintainItemMasters", NULL, NULL, true , NULL },
 
   // Setup
-  { "pd.setup",	    tr("&Setup..."),	  SLOT(sSetup()),     mainMenu,	"true",	NULL, NULL,  true, NULL}
+  { "pd.setup",	    tr("&Setup"),	  SLOT(sSetup()),     mainMenu,	"true",	NULL, NULL,  true, NULL}
 
   };
 

--- a/guiclient/menuPurchase.cpp
+++ b/guiclient/menuPurchase.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -129,8 +129,8 @@ menuPurchase::menuPurchase(GUIClient *Pparent) :
 
     //  Purchase | Purchase Order
     { "menu", tr("&Purchase Order"), (char*)ordersMenu, mainMenu, "true", NULL, NULL, true , NULL },
-    { "po.newPurchaseOrder", tr("&New..."), SLOT(sNewPurchaseOrder()), ordersMenu, "MaintainPurchaseOrders", NULL, NULL, true , NULL },
-    { "po.listUnpostedPurchaseOrders", tr("&List Open..."), SLOT(sPurchaseOrderEditList()), ordersMenu, "MaintainPurchaseOrders ViewPurchaseOrders", new QPixmap(":/images/listUnpostedPo.png"), toolBar, true , tr("List Open Purchase Orders") },
+    { "po.newPurchaseOrder", tr("&New"), SLOT(sNewPurchaseOrder()), ordersMenu, "MaintainPurchaseOrders", NULL, NULL, true , NULL },
+    { "po.listUnpostedPurchaseOrders", tr("&List Open"), SLOT(sPurchaseOrderEditList()), ordersMenu, "MaintainPurchaseOrders ViewPurchaseOrders", new QPixmap(":/images/listUnpostedPo.png"), toolBar, true , tr("List Open Purchase Orders") },
     { "separator", NULL, NULL, ordersMenu, "true", NULL, NULL, true , NULL },
     { "po.postPurchaseOrder", tr("&Release..."), SLOT(sPostPurchaseOrder()), ordersMenu, "ReleasePurchaseOrders", NULL, NULL, true , NULL },
     { "po.postPurchaseOrdersByAgent", tr("Release by A&gent..."), SLOT(sPostPurchaseOrdersByAgent()), ordersMenu, "ReleasePurchaseOrders", NULL, NULL, true , NULL },
@@ -142,9 +142,9 @@ menuPurchase::menuPurchase(GUIClient *Pparent) :
 
     //  Purchasing | Voucher
     { "menu", tr("&Voucher"), (char*)vouchersMenu, mainMenu, "true", NULL, NULL, true , NULL },
-    { "po.enterNewVoucher", tr("&New..."), SLOT(sEnterVoucher()), vouchersMenu, "MaintainVouchers", NULL, NULL, true , NULL },
-    { "po.enterNewMiscVoucher", tr("New &Miscellaneous..."), SLOT(sEnterMiscVoucher()), vouchersMenu, "MaintainVouchers", NULL, NULL, true , NULL },
-    { "po.listUnpostedVouchers", tr("&List Unposted..."), SLOT(sUnpostedVouchers()), vouchersMenu, "MaintainVouchers ViewVouchers", NULL, NULL, true , NULL },
+    { "po.enterNewVoucher", tr("&New"), SLOT(sEnterVoucher()), vouchersMenu, "MaintainVouchers", NULL, NULL, true , NULL },
+    { "po.enterNewMiscVoucher", tr("New &Miscellaneous"), SLOT(sEnterMiscVoucher()), vouchersMenu, "MaintainVouchers", NULL, NULL, true , NULL },
+    { "po.listUnpostedVouchers", tr("&List Unposted"), SLOT(sUnpostedVouchers()), vouchersMenu, "MaintainVouchers ViewVouchers", NULL, NULL, true , NULL },
     { "separator", NULL, NULL, vouchersMenu, "true", NULL, NULL, true , NULL },
     { "po.postVouchers", tr("&Post..."), SLOT(sPostVouchers()), vouchersMenu, "PostVouchers", NULL, NULL, true , NULL },
     { "separator", NULL, NULL, mainMenu, "true", NULL, NULL, true , NULL },
@@ -178,10 +178,10 @@ menuPurchase::menuPurchase(GUIClient *Pparent) :
     //  Purchasing | Reports
     { "menu", tr("&Reports"), (char*)reportsMenu, mainMenu, "true", NULL, NULL, true , NULL },
     
-    { "po.itemSites", tr("Item &Sites..."), SLOT(sItemSites()), reportsMenu, "ViewItemSites", NULL, NULL, true , NULL },
+    { "po.itemSites", tr("Item &Sites"), SLOT(sItemSites()), reportsMenu, "ViewItemSites", NULL, NULL, true , NULL },
     
     // Purchasing | Reports | Item Sources
-    { "po.dspItemSourcePrices", tr("&Item Source Prices..."), SLOT(sDspItemSourcePrices()), reportsMenu, "ViewItemSources", NULL, NULL, true , NULL },
+    { "po.dspItemSourcePrices", tr("&Item Source Prices"), SLOT(sDspItemSourcePrices()), reportsMenu, "ViewItemSources", NULL, NULL, true , NULL },
     { "po.dspBuyCard", tr("&Buy Card..."), SLOT(sDspBuyCard()), reportsMenu, "ViewItemSources", NULL, NULL, true , NULL },
     { "separator", NULL, NULL, reportsMenu, "true", NULL, NULL, true , NULL },
  
@@ -195,7 +195,7 @@ menuPurchase::menuPurchase(GUIClient *Pparent) :
     { "po.dspReceiptsAndReturnsByDate", tr("by &Date..."), SLOT(sDspReceiptsReturnsByDate()), reportsRcptRtrnMenu, "ViewReceiptsReturns", NULL, NULL, true , NULL },
     { "po.dspReceiptsAndReturnsByItem", tr("by &Item..."), SLOT(sDspReceiptsReturnsByItem()), reportsRcptRtrnMenu, "ViewReceiptsReturns", NULL, NULL, true , NULL },
 
-    { "po.uninvoicedReceipts", tr("&Uninvoiced Receipts and Returns..."), SLOT(sDspUninvoicedReceipts()), reportsMenu, "ViewUninvoicedReceipts MaintainUninvoicedReceipts", NULL, NULL, true , NULL },
+    { "po.uninvoicedReceipts", tr("&Uninvoiced Receipts and Returns"), SLOT(sDspUninvoicedReceipts()), reportsMenu, "ViewUninvoicedReceipts MaintainUninvoicedReceipts", NULL, NULL, true , NULL },
     
     { "separator", NULL, NULL, reportsMenu, "true", NULL, NULL, true , NULL },
     
@@ -215,8 +215,8 @@ menuPurchase::menuPurchase(GUIClient *Pparent) :
 
     //  Purchasing | Vendor
     { "menu", tr("V&endor"), (char*)vendorMenu, mainMenu, "true", NULL, NULL, true , NULL },
-    { "po.newVendor", tr("&New..."), SLOT(sNewVendor()), vendorMenu, "MaintainVendors", NULL, NULL, true , NULL },
-    { "po.vendors", tr("&List..."), SLOT(sVendors()), vendorMenu, "MaintainVendors ViewVendors", NULL, NULL, true , NULL },
+    { "po.newVendor", tr("&New"), SLOT(sNewVendor()), vendorMenu, "MaintainVendors", NULL, NULL, true , NULL },
+    { "po.vendors", tr("&List"), SLOT(sVendors()), vendorMenu, "MaintainVendors ViewVendors", NULL, NULL, true , NULL },
     { "separator", NULL, NULL, vendorMenu, "true", NULL, NULL, true , NULL },
     { "po.vendorWorkBench", tr("&Workbench..."), SLOT(sVendorWorkBench()), vendorMenu, "MaintainVendors", NULL, NULL, true , NULL },
 
@@ -224,24 +224,24 @@ menuPurchase::menuPurchase(GUIClient *Pparent) :
 
     //  P/O | Contract
     { "menu", tr("&Contract"), (char*)contractsMenu, mainMenu, "true", NULL, NULL, true , NULL },
-    { "po.enterNewContract", tr("&New..."), SLOT(sNewContract()), contractsMenu, "MaintainItemSources", NULL, NULL, true , NULL },
-    { "po.listContracts", tr("&List..."), SLOT(sContracts()), contractsMenu, "MaintainItemSources ViewItemSources", NULL, NULL, true , NULL },
+    { "po.enterNewContract", tr("&New"), SLOT(sNewContract()), contractsMenu, "MaintainItemSources", NULL, NULL, true , NULL },
+    { "po.listContracts", tr("&List"), SLOT(sContracts()), contractsMenu, "MaintainItemSources ViewItemSources", NULL, NULL, true , NULL },
 
     //  P/O | Item Source
     { "menu", tr("&Item Source"), (char*)itemSourcesMenu, mainMenu, "true", NULL, NULL, true , NULL },
-    { "po.enterNewItemSource", tr("&New..."), SLOT(sNewItemSource()), itemSourcesMenu, "MaintainItemSources", NULL, NULL, true , NULL },
-    { "po.listItemSources", tr("&List..."), SLOT(sDspItemSources()), itemSourcesMenu, "MaintainItemSources ViewItemSources", NULL, NULL, true , NULL },
+    { "po.enterNewItemSource", tr("&New"), SLOT(sNewItemSource()), itemSourcesMenu, "MaintainItemSources", NULL, NULL, true , NULL },
+    { "po.listItemSources", tr("&List"), SLOT(sDspItemSources()), itemSourcesMenu, "MaintainItemSources ViewItemSources", NULL, NULL, true , NULL },
 
     { "separator", NULL, NULL, mainMenu, "true", NULL, NULL, true , NULL },
 
     // Purchasing | Utilities
     { "menu", tr("&Utilities"), (char*)utilitiesMenu, mainMenu, "true", NULL, NULL, true , NULL },
-    { "po.itemsWithoutItemSources", tr("&Items without Item Sources..."), SLOT(sItemsWithoutItemSources()), utilitiesMenu, "ViewItemMasters", NULL, NULL, true , NULL },
+    { "po.itemsWithoutItemSources", tr("&Items without Item Sources"), SLOT(sItemsWithoutItemSources()), utilitiesMenu, "ViewItemMasters", NULL, NULL, true , NULL },
     { "po.assignItemToPlannerCode", tr("&Assign Item to Planner Code..."), SLOT(sAssignItemToPlannerCode()), utilitiesMenu, "AssignItemsToPlannerCode", NULL, NULL, true , NULL },
     { "po.assignItemsToPlannerCodeByClassCode", tr("Assign Item&s to Planner Code..."), SLOT(sAssignClassCodeToPlannerCode()), utilitiesMenu, "AssignItemsToPlannerCode", NULL, NULL, true , NULL },
 
     // Setup
-    { "po.setup",	tr("&Setup..."),	SLOT(sSetup()),	mainMenu,	NULL,	NULL,	NULL,	true, NULL}
+    { "po.setup",	tr("&Setup"),	SLOT(sSetup()),	mainMenu,	NULL,	NULL,	NULL,	true, NULL}
   };
 
   addActionsToMenu(acts, sizeof(acts) / sizeof(acts[0]));

--- a/guiclient/menuSales.cpp
+++ b/guiclient/menuSales.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2017 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -168,37 +168,37 @@ menuSales::menuSales(GUIClient *pParent) :
   actionProperties acts[] = {
     // Sales | Quotes
     { "menu",	tr("&Quote"),	(char*)quotesMenu,	mainMenu,	"true",	NULL, NULL, true, NULL },
-    { "so.newQuote", tr("&New..."),	SLOT(sNewQuote()), quotesMenu, "MaintainQuotes",	NULL, NULL, true, NULL },
-    { "so.listQuotes", tr("&List..."),	SLOT(sQuotes()), quotesMenu, "MaintainQuotes ViewQuotes",	NULL, NULL, true, NULL },
+    { "so.newQuote", tr("&New"),	SLOT(sNewQuote()), quotesMenu, "MaintainQuotes",	NULL, NULL, true, NULL },
+    { "so.listQuotes", tr("&List"),	SLOT(sQuotes()), quotesMenu, "MaintainQuotes ViewQuotes",	NULL, NULL, true, NULL },
     
     // Sales | Sales Order
     { "menu",	tr("&Sales Order"),	(char*)ordersMenu,	mainMenu,	"true",	NULL, NULL, true, NULL },
-    { "so.newSalesOrderSimple",  tr("&New Simple..."),		SLOT(sNewSalesOrderSimple()),   ordersMenu, "MaintainSimpleSalesOrders", NULL, NULL, _metrics->boolean("SSOSEnabled"), NULL },
-    { "so.newSalesOrder", 	     tr("&New..."),		SLOT(sNewSalesOrder()),   ordersMenu, "MaintainSalesOrders", NULL, NULL,	 true, NULL },
-    { "so.listOpenSalesOrders",  tr("&List Open..."),	SLOT(sOpenSalesOrders()), ordersMenu, "MaintainSalesOrders ViewSalesOrders", new QPixmap(":/images/listOpenSalesOrders.png"), toolBar,  true, tr("List Open Sales Orders") },
-    { "so.listSalesOrders",      tr("&Search Orders..."),	SLOT(sSalesOrders()), ordersMenu, "MaintainSalesOrders ViewSalesOrders", NULL, NULL, true, NULL },
+    { "so.newSalesOrderSimple",  tr("&New Simple"),		SLOT(sNewSalesOrderSimple()),   ordersMenu, "MaintainSimpleSalesOrders", NULL, NULL, _metrics->boolean("SSOSEnabled"), NULL },
+    { "so.newSalesOrder", 	     tr("&New"),		SLOT(sNewSalesOrder()),   ordersMenu, "MaintainSalesOrders", NULL, NULL,	 true, NULL },
+    { "so.listOpenSalesOrders",  tr("&List Open"),	SLOT(sOpenSalesOrders()), ordersMenu, "MaintainSalesOrders ViewSalesOrders", new QPixmap(":/images/listOpenSalesOrders.png"), toolBar,  true, tr("List Open Sales Orders") },
+    { "so.listSalesOrders",      tr("&Search Orders"),	SLOT(sSalesOrders()), ordersMenu, "MaintainSalesOrders ViewSalesOrders", NULL, NULL, true, NULL },
 
     // Sales | Billing
     { "menu",	tr("&Billing"),     (char*)billingMenu,		mainMenu,	"true",	NULL, NULL, true, NULL },
     
     // Sales | Billing | Invoice
     { "menu",	tr("&Invoice"),   (char*)billingInvoicesMenu,	billingMenu,	"true",	NULL, NULL, true, NULL },
-    { "so.uninvoicedShipments",		     tr("&Uninvoiced Shipments..."),			SLOT(sUninvoicedShipments()), 		billingInvoicesMenu, "SelectBilling",	 new QPixmap(":/images/uninvoicedShipments"), toolBar, true, tr("Uninvoiced Shipments") },
+    { "so.uninvoicedShipments",		     tr("&Uninvoiced Shipment."),			SLOT(sUninvoicedShipments()), 		billingInvoicesMenu, "SelectBilling",	 new QPixmap(":/images/uninvoicedShipments"), toolBar, true, tr("Uninvoiced Shipments") },
     { "so.selectAllShippedOrdersForBilling", tr("Approve &All Shipped Orders for Billing..."),	SLOT(sSelectShippedOrdersForBilling()), billingInvoicesMenu, "SelectBilling",	NULL, NULL, true, NULL },
     { "so.selectOrderForBilling",	     tr("Approve &Order for Billing..."),			SLOT(sSelectOrderForBilling()),		billingInvoicesMenu, "SelectBilling",	NULL, NULL, true, NULL },
     { "separator",	NULL,	NULL,	billingInvoicesMenu,	"true",		NULL, NULL, true, NULL },
-    { "so.dspBillingSelections",	     tr("Billing &Approvals..."),	SLOT(sDspBillingSelections()), billingInvoicesMenu, "SelectBilling", new QPixmap(":/images/billingSelections"), toolBar, true, tr("Billing Approvals") },
+    { "so.dspBillingSelections",	     tr("Billing &Approvals"),	SLOT(sDspBillingSelections()), billingInvoicesMenu, "SelectBilling", new QPixmap(":/images/billingSelections"), toolBar, true, tr("Billing Approvals") },
     { "so.createInvoices",	     tr("&Create Invoices..."),	SLOT(sCreateInvoices()), billingInvoicesMenu, "SelectBilling",	NULL, NULL, true, NULL },
     { "separator",	NULL,	NULL,	billingInvoicesMenu,	"true",		NULL, NULL, true, NULL },
-    { "so.createInvoice", tr("&New Invoice..."), SLOT(sCreateInvoice()), billingInvoicesMenu, "MaintainMiscInvoices", NULL, NULL, true , NULL },
-    { "so.listUnpostedInvoices",	     tr("&List Unposted Invoices..."),	SLOT(sUnpostedInvoices()), billingInvoicesMenu, "SelectBilling",	NULL, NULL,  true, NULL },
+    { "so.createInvoice", tr("&New Invoice"), SLOT(sCreateInvoice()), billingInvoicesMenu, "MaintainMiscInvoices", NULL, NULL, true , NULL },
+    { "so.listUnpostedInvoices",	     tr("&List Unposted Invoices"),	SLOT(sUnpostedInvoices()), billingInvoicesMenu, "SelectBilling",	NULL, NULL,  true, NULL },
     { "so.postInvoices",		     tr("Post &Invoices..."),		SLOT(sPostInvoices()), billingInvoicesMenu, "PostMiscInvoices",	NULL, NULL, true, NULL },
 
     // Sales | Billing | Credit Memos
     { "menu",	tr("&Sales Credit"), (char*)billingCreditMemosMenu,	billingMenu,	"true",	NULL, NULL, true, NULL },
-    { "so.newCreditMemo",		     tr("&New..."),		SLOT(sNewCreditMemo()), billingCreditMemosMenu, "MaintainCreditMemos",	NULL, NULL, true, NULL },
-    { "so.listUnpostedCreditMemos",	     tr("&List Unposted..."),	SLOT(sUnpostedCreditMemos()), billingCreditMemosMenu, "MaintainCreditMemos ViewCreditMemos",	NULL, NULL, true, NULL },
-    { "so.creditMemoEditList",		     tr("&Edit List..."),	SLOT(sCreditMemoEditList()), billingCreditMemosMenu, "MaintainCreditMemos ViewCreditMemos",	NULL, NULL, true, NULL },
+    { "so.newCreditMemo",		     tr("&New"),		SLOT(sNewCreditMemo()), billingCreditMemosMenu, "MaintainCreditMemos",	NULL, NULL, true, NULL },
+    { "so.listUnpostedCreditMemos",	     tr("&List Unposted"),	SLOT(sUnpostedCreditMemos()), billingCreditMemosMenu, "MaintainCreditMemos ViewCreditMemos",	NULL, NULL, true, NULL },
+    { "so.creditMemoEditList",		     tr("&Edit List"),	SLOT(sCreditMemoEditList()), billingCreditMemosMenu, "MaintainCreditMemos ViewCreditMemos",	NULL, NULL, true, NULL },
     { "separator",	NULL,	NULL,	billingCreditMemosMenu,	"true",		NULL, NULL, true, NULL },
     { "so.postCreditMemos",		     tr("&Post..."),	SLOT(sPostCreditMemos()), billingCreditMemosMenu, "PostARDocuments",	NULL, NULL, true, NULL },
 
@@ -214,8 +214,8 @@ menuSales::menuSales(GUIClient *pParent) :
 
     // Sales | Return Authorizations
     { "menu",	tr("&Return Auth."),	(char*)returnsMenu,	mainMenu, "true",	NULL, NULL,  _metrics->boolean("EnableReturnAuth"), NULL },
-    { "so.newReturn", tr("&New..."),	SLOT(sNewReturn()), returnsMenu, "MaintainReturns",	NULL, NULL, true, NULL },
-    { "so.openReturns", tr("&List Open..."),	SLOT(sOpenReturns()), returnsMenu, "MaintainReturns ViewReturns",	NULL, NULL, true, NULL },
+    { "so.newReturn", tr("&New"),	SLOT(sNewReturn()), returnsMenu, "MaintainReturns",	NULL, NULL, true, NULL },
+    { "so.openReturns", tr("&List Open"),	SLOT(sOpenReturns()), returnsMenu, "MaintainReturns ViewReturns",	NULL, NULL, true, NULL },
     { "separator",	NULL,	NULL,	returnsMenu,	"true",		NULL, NULL, true , NULL },
     { "so.returnsWorkbench", tr("&Workbench..."),	SLOT(sReturnsWorkbench()), returnsMenu, "MaintainReturns ViewReturns",	NULL, NULL, true, NULL },
 
@@ -231,12 +231,12 @@ menuSales::menuSales(GUIClient *pParent) :
     
     // Sales | Lookup | Sales Order Lookup
     { "menu",	tr("&Sales Order"),           (char*)lookupSoMenu,	lookupMenu,	"true",	NULL, NULL, true, NULL },
-    { "so.listSalesOrders",      tr("&Search Orders..."),	SLOT(sSalesOrders()), lookupSoMenu, "MaintainSalesOrders ViewSalesOrders", NULL, NULL, true, NULL },
+    { "so.listSalesOrders",      tr("&Search Orders"),	SLOT(sSalesOrders()), lookupSoMenu, "MaintainSalesOrders ViewSalesOrders", NULL, NULL, true, NULL },
     { "so.dspSalesOrderLookupByItem", tr("by &Item..."),	SLOT(sDspOrderLookupByItem()), lookupSoMenu, "MaintainSalesOrders ViewSalesOrders",	NULL, NULL, true, NULL },
     
     // Sales | Lookup | Return Auth. Lookup
     { "menu",	tr("&Return Auth."),           (char*)lookupRaMenu,	lookupMenu,	"true",	NULL, NULL, _metrics->boolean("EnableReturnAuth"), NULL },
-    { "so.dspReturnAuthLookup",       tr("&Search RAs..."),	SLOT(sDspReturnAuthLookup())      , lookupRaMenu, "ViewReturns",	NULL, NULL, true, NULL },
+    { "so.dspReturnAuthLookup",       tr("&Search RAs"),	SLOT(sDspReturnAuthLookup())      , lookupRaMenu, "ViewReturns",	NULL, NULL, true, NULL },
     { "so.dspReturnAuthLookupByItem", tr("by &Item..."),	SLOT(sDspReturnAuthLookupByItem()), lookupRaMenu, "ViewReturns",	NULL, NULL, true, NULL },
     
     { "separator",	NULL,	NULL,	lookupMenu,	"true",		NULL, NULL, true, NULL },
@@ -253,66 +253,66 @@ menuSales::menuSales(GUIClient *pParent) :
 
     // Sales | Reports
     { "menu",	tr("&Reports"),           (char*)reportsMenu,	mainMenu,	"true",	NULL, NULL, true, NULL },
-    { "so.dspSummarizedBacklogByWarehouse", tr("Su&mmarized Backlog..."),	SLOT(sDspSummarizedBacklogByWarehouse()), reportsMenu, "ViewSalesOrders",	new QPixmap(":/images/dspSummarizedBacklogByWhse.png"), toolBar,  true, tr("Summarized Backlog") },
+    { "so.dspSummarizedBacklogByWarehouse", tr("Su&mmarized Backlog"),	SLOT(sDspSummarizedBacklogByWarehouse()), reportsMenu, "ViewSalesOrders",	new QPixmap(":/images/dspSummarizedBacklogByWhse.png"), toolBar,  true, tr("Summarized Backlog") },
 
     // Sales | Reports | Backlog
-    { "so.dspBacklog", tr("&Backlog..."),	SLOT(sDspBacklog()), reportsMenu, "ViewSalesOrders",	NULL, NULL, true, NULL },
-    { "so.dspPartiallyShippedOrders", tr("&Partially Shipped Orders..."),	SLOT(sDspPartiallyShippedOrders()), reportsMenu, "ViewSalesOrders",	NULL, NULL, true, NULL },
+    { "so.dspBacklog", tr("&Backlog"),	SLOT(sDspBacklog()), reportsMenu, "ViewSalesOrders",	NULL, NULL, true, NULL },
+    { "so.dspPartiallyShippedOrders", tr("&Partially Shipped Orders"),	SLOT(sDspPartiallyShippedOrders()), reportsMenu, "ViewSalesOrders",	NULL, NULL, true, NULL },
     { "so.dspReservations", tr("Reservations by Item..."),	SLOT(sDspReservations()), reportsMenu, "ViewInventoryAvailability",	NULL, NULL, _metrics->boolean("EnableSOReservations"), NULL },    
     { "separator",	NULL,	NULL,	reportsMenu,	"true",		NULL, NULL, true, NULL },   
     
     // Sales | Reports | Inventory Availability
-    { "so.dspInventoryAvailability", tr("Inventory &Availability..."),	SLOT(sDspInventoryAvailability()), reportsMenu, "ViewInventoryAvailability",	NULL, NULL, true, NULL },
+    { "so.dspInventoryAvailability", tr("Inventory &Availability"),	SLOT(sDspInventoryAvailability()), reportsMenu, "ViewInventoryAvailability",	NULL, NULL, true, NULL },
     { "so.dspInventoryAvailabilityBySalesOrder", tr("Availability by &Sales Order..."),	SLOT(sDspInventoryAvailabilityBySalesOrder()), reportsMenu, "ViewInventoryAvailability",	NULL, NULL, true, NULL },
     { "so.dspInventoryAvailabilityByCustomerType", tr("Availability by &Customer Type..."),	SLOT(sDspInventoryAvailabilityByCustomerType()), reportsMenu, "ViewInventoryAvailability",	NULL, NULL, true, NULL },
 
     { "separator",	NULL,	NULL,	reportsMenu,	"true",		NULL, NULL, true, NULL },
-    { "so.dspEarnedCommissions", tr("&Earned Commissions..."),	SLOT(sDspEarnedCommissions()), reportsMenu, "ViewCommissions",	NULL, NULL, true, NULL },
-    { "so.dspBriefEarnedCommissions", tr("B&rief Earned Commissions..."),	SLOT(sDspBriefEarnedCommissions()), reportsMenu, "ViewCommissions",	NULL, NULL, true, NULL },
-    { "so.dspTaxHistory", tr("Tax History..."),	SLOT(sDspTaxHistory()), reportsMenu, "ViewTaxReconciliations",	NULL, NULL, true, NULL },
+    { "so.dspEarnedCommissions", tr("&Earned Commissions"),	SLOT(sDspEarnedCommissions()), reportsMenu, "ViewCommissions",	NULL, NULL, true, NULL },
+    { "so.dspBriefEarnedCommissions", tr("B&rief Earned Commissions"),	SLOT(sDspBriefEarnedCommissions()), reportsMenu, "ViewCommissions",	NULL, NULL, true, NULL },
+    { "so.dspTaxHistory", tr("Tax History"),	SLOT(sDspTaxHistory()), reportsMenu, "ViewTaxReconciliations",	NULL, NULL, true, NULL },
 
     { "separator",	NULL,	NULL,	reportsMenu,	"true",		NULL, NULL, true, NULL },
     
     // Sales | Analysis
     { "menu",	tr("&Analysis"),           (char*)analysisMenu,	mainMenu,	"true",	NULL, NULL, true, NULL },
-    { "sa.dspBookings", tr("&Bookings..."), SLOT(sDspBookings()), analysisMenu, "ViewSalesOrders", NULL, NULL, true , NULL },
-    { "sa.dspTimePhasedBookings", tr("T&ime Phased Bookings..."), SLOT(sDspTimePhasedBookings()), analysisMenu, "ViewSalesOrders", NULL, NULL, true , NULL },
+    { "sa.dspBookings", tr("&Bookings"), SLOT(sDspBookings()), analysisMenu, "ViewSalesOrders", NULL, NULL, true , NULL },
+    { "sa.dspTimePhasedBookings", tr("T&ime Phased Bookings"), SLOT(sDspTimePhasedBookings()), analysisMenu, "ViewSalesOrders", NULL, NULL, true , NULL },
     { "separator",	NULL,	NULL,	analysisMenu,	"true",		NULL, NULL, true, NULL },
-    { "sa.dspSalesHistory", tr("Sales &History..."), SLOT(sDspSalesHistory()), analysisMenu, "ViewSalesHistory", NULL, NULL, true , NULL },
-    { "sa.dspBriefSalesHistory", tr("Brie&f Sales History..."), SLOT(sDspBriefSalesHistory()), analysisMenu, "ViewSalesHistory", NULL, NULL, true , NULL },
-    { "sa.dspSummarizedSalesHistory", tr("Summari&zed Sales History..."), SLOT(sDspSummarizedSales()), analysisMenu, "ViewSalesHistory", NULL, NULL, true , NULL },
-    { "sa.dspTimePhasedSalesHistory", tr("Time &Phased Sales History..."), SLOT(sDspTimePhasedSales()), analysisMenu, "ViewSalesHistory", NULL, NULL, true , NULL },
+    { "sa.dspSalesHistory", tr("Sales &History"), SLOT(sDspSalesHistory()), analysisMenu, "ViewSalesHistory", NULL, NULL, true , NULL },
+    { "sa.dspBriefSalesHistory", tr("Brie&f Sales History"), SLOT(sDspBriefSalesHistory()), analysisMenu, "ViewSalesHistory", NULL, NULL, true , NULL },
+    { "sa.dspSummarizedSalesHistory", tr("Summari&zed Sales History"), SLOT(sDspSummarizedSales()), analysisMenu, "ViewSalesHistory", NULL, NULL, true , NULL },
+    { "sa.dspTimePhasedSalesHistory", tr("Time &Phased Sales History"), SLOT(sDspTimePhasedSales()), analysisMenu, "ViewSalesHistory", NULL, NULL, true , NULL },
 
     { "separator",	NULL,	NULL,	mainMenu,	"true",		NULL, NULL, true, NULL },
 
     // Sales | Prospect
     { "menu",	tr("&Prospect"),       (char*)prospectMenu,	mainMenu,	"true",	NULL, NULL, true, NULL },
-    { "so.enterNewProspect", tr("&New..."),	SLOT(sNewProspect()), prospectMenu, "MaintainProspectMasters",	NULL, NULL, true, NULL },
-    { "so.prospects", tr("&List..."),	SLOT(sProspects()), prospectMenu, "MaintainProspectMasters ViewProspectMasters",	NULL, NULL, true, NULL },
+    { "so.enterNewProspect", tr("&New"),	SLOT(sNewProspect()), prospectMenu, "MaintainProspectMasters",	NULL, NULL, true, NULL },
+    { "so.prospects", tr("&List"),	SLOT(sProspects()), prospectMenu, "MaintainProspectMasters ViewProspectMasters",	NULL, NULL, true, NULL },
 
     // Sales | Customer
     { "menu",	tr("&Customer"),       (char*)customerMenu,	mainMenu,	"true",	NULL, NULL, true, NULL },
-    { "so.enterNewCustomer", tr("&New..."),	SLOT(sNewCustomer()), customerMenu, "MaintainCustomerMasters",	NULL, NULL, true, NULL },
-    { "so.customers", tr("&List..."),	SLOT(sCustomers()), customerMenu, "MaintainCustomerMasters ViewCustomerMasters",	NULL, NULL, true, NULL },
+    { "so.enterNewCustomer", tr("&New"),	SLOT(sNewCustomer()), customerMenu, "MaintainCustomerMasters",	NULL, NULL, true, NULL },
+    { "so.customers", tr("&List"),	SLOT(sCustomers()), customerMenu, "MaintainCustomerMasters ViewCustomerMasters",	NULL, NULL, true, NULL },
     { "separator",	NULL,	NULL,	customerMenu,	"true",		NULL, NULL, true, NULL },
     { "so.customerWorkbench", tr("&Workbench..."),	SLOT(sCustomerWorkbench()), customerMenu, "MaintainCustomerMasters ViewCustomerMasters",	new QPixmap(":/images/customerInformationWorkbench.png"), toolBar,  true, tr("Customer Workbench") },
     { "separator",	NULL,	NULL,	customerMenu,	"true",		NULL, NULL, true, NULL },
-    { "so.customerGroups", tr("&Groups..."),	SLOT(sCustomerGroups()), customerMenu, "MaintainCustomerGroups ViewCustomerGroups",	NULL, NULL, true, NULL },
+    { "so.customerGroups", tr("&Groups"),	SLOT(sCustomerGroups()), customerMenu, "MaintainCustomerGroups ViewCustomerGroups",	NULL, NULL, true, NULL },
    
     // Sales | Pricing
     { "menu",	tr("Pricing"),       (char*)pricingMenu,	mainMenu,	"true",	NULL, NULL, true, NULL },
     { "so.itemListPrice", tr("Item &List Price..."),	SLOT(sItemListPrice()), pricingMenu, "MaintainListPrices ViewListPrices",	NULL, NULL, true, NULL },
     { "so.updateListPricesByProductCategory", tr("&Update List Prices..."),	SLOT(sUpdateListPricesByProductCategory()), pricingMenu, "MaintainListPrices",	NULL, NULL, true, NULL },
     { "separator",	NULL,	NULL,	pricingMenu,	"true",		NULL, NULL, true, NULL },
-    { "so.listPricingSchedules", tr("List Pricing &Schedules..."),	SLOT(sListPricingSchedules()), pricingMenu, "MaintainListPrices ViewListPrices",	NULL, NULL, _metrics->boolean("AllowListPriceSchedules"), NULL },
+    { "so.listPricingSchedules", tr("List Pricing &Schedules"),	SLOT(sListPricingSchedules()), pricingMenu, "MaintainListPrices ViewListPrices",	NULL, NULL, _metrics->boolean("AllowListPriceSchedules"), NULL },
     { "so.updateListPricingSchedules", tr("Update List Pricing Schedules..."),	SLOT(sUpdateListPrices()), pricingMenu, "UpdatePricingSchedules",	NULL, NULL, _metrics->boolean("AllowListPriceSchedules"), NULL },
-    { "so.listPricingScheduleAssignments", tr("List Pricing Schedule Assi&gnments..."),	SLOT(sListPricingScheduleAssignments()), pricingMenu, "AssignPricingSchedules",	NULL, NULL, _metrics->boolean("AllowListPriceSchedules"), NULL },
+    { "so.listPricingScheduleAssignments", tr("List Pricing Schedule Assi&gnments"),	SLOT(sListPricingScheduleAssignments()), pricingMenu, "AssignPricingSchedules",	NULL, NULL, _metrics->boolean("AllowListPriceSchedules"), NULL },
     { "separator",	NULL,	NULL,	pricingMenu,	"true",		NULL, NULL, _metrics->boolean("AllowListPriceSchedules"), NULL },
-    { "so.pricingSchedules", tr("Pricing &Schedules..."),	SLOT(sPricingSchedules()), pricingMenu, "MaintainListPrices ViewListPrices",	NULL, NULL, true, NULL },
+    { "so.pricingSchedules", tr("Pricing &Schedules"),	SLOT(sPricingSchedules()), pricingMenu, "MaintainListPrices ViewListPrices",	NULL, NULL, true, NULL },
     { "so.updatePricingSchedules", tr("Update Pricing Schedules..."),	SLOT(sUpdatePrices()), pricingMenu, "UpdatePricingSchedules",	NULL, NULL, true, NULL },
-    { "so.pricingScheduleAssignments", tr("Pricing Schedule Assi&gnments..."),	SLOT(sPricingScheduleAssignments()), pricingMenu, "AssignPricingSchedules",	NULL, NULL, true, NULL },
+    { "so.pricingScheduleAssignments", tr("Pricing Schedule Assi&gnments"),	SLOT(sPricingScheduleAssignments()), pricingMenu, "AssignPricingSchedules",	NULL, NULL, true, NULL },
     { "separator",	NULL,	NULL,	pricingMenu,	"true",		NULL, NULL, true, NULL },
-    { "so.sales", tr("S&ales..."),	SLOT(sSales()), pricingMenu, "CreateSales",	NULL, NULL, true, NULL },
+    { "so.sales", tr("S&ales"),	SLOT(sSales()), pricingMenu, "CreateSales",	NULL, NULL, true, NULL },
     { "separator",	NULL,	NULL,	pricingMenu,	"true",		NULL, NULL, true, NULL },
 
     // Sales | Pricing | Reports
@@ -338,7 +338,7 @@ menuSales::menuSales(GUIClient *pParent) :
     { "sa.archieveSalesHistory", tr("&Archive Sales History..."), SLOT(sArchiveSalesHistory()), utilitiesMenu, "ArchiveSalesHistory", NULL, NULL, true , NULL },
     { "sa.restoreSalesHistory", tr("Restore &Sales History..."), SLOT(sRestoreSalesHistory()), utilitiesMenu, "RestoreSalesHistory", NULL, NULL, true , NULL },
 
-    { "so.setup",	tr("&Setup..."),	SLOT(sSetup()),	mainMenu,	NULL,	NULL,	NULL,	true, NULL	},
+    { "so.setup",	tr("&Setup"),	SLOT(sSetup()),	mainMenu,	NULL,	NULL,	NULL,	true, NULL	},
 
   };
 

--- a/guiclient/menuSystem.cpp
+++ b/guiclient/menuSystem.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -101,11 +101,11 @@ menuSystem::menuSystem(GUIClient *Pparent) :
 
   actionProperties acts[] = {
 
-    { "sys.eventManager",             tr("E&vent Manager..."),              SLOT(sEventManager()),             systemMenu, "true",                                      NULL, NULL, true },
-    { "sys.viewDatabaseLog",          tr("View Database &Log..."),          SLOT(sErrorLog()),                 systemMenu, "true",                                      NULL, NULL, true },
+    { "sys.eventManager",             tr("E&vent Manager"),                 SLOT(sEventManager()),             systemMenu, "true",                                      NULL, NULL, true },
+    { "sys.viewDatabaseLog",          tr("View Database &Log"),          SLOT(sErrorLog()),                 systemMenu, "true",                                      NULL, NULL, true },
     { "separator",                    NULL,                                 NULL,                              systemMenu, "true",                                      NULL, NULL, true },
-    { "sys.preferences",              tr("&Preferences..."),                SLOT(sPreferences()),              systemMenu, "MaintainPreferencesSelf MaintainPreferencesOthers",  NULL,   NULL,   true },
-    { "sys.hotkeys",                  tr("&Hot Keys..."),                   SLOT(sHotKeys()),                  systemMenu, "true",  NULL,   NULL,   !(_privileges->check("MaintainPreferencesSelf") || _privileges->check("MaintainPreferencesOthers")) },
+    { "sys.preferences",              tr("&Preferences"),                SLOT(sPreferences()),              systemMenu, "MaintainPreferencesSelf MaintainPreferencesOthers",  NULL,   NULL,   true },
+    { "sys.hotkeys",                  tr("&Hot Keys"),                   SLOT(sHotKeys()),                  systemMenu, "true",  NULL,   NULL,   !(_privileges->check("MaintainPreferencesSelf") || _privileges->check("MaintainPreferencesOthers")) },
     { "sys.rescanPrivileges",         tr("Rescan &Privileges"),             SLOT(sRescanPrivileges()),         systemMenu, "true",                                      NULL, NULL, true },
     { "separator",                    NULL,                                 NULL,                              systemMenu, "true",                                      NULL, NULL, true },
     { "sys.maintainUsers",            tr("Maintain &User Accounts..."),     SLOT(sMaintainUsers()),            systemMenu, "MaintainUsers",                             NULL, NULL, true },
@@ -113,25 +113,25 @@ menuSystem::menuSystem(GUIClient *Pparent) :
     { "sys.userPrivileges",           tr("User Privilege Audit..."),        SLOT(sUserPrivileges()),           systemMenu, "MaintainUsers MaintainGroups",              NULL, NULL, true },
 
     { "menu",                         tr("&Employees"),                     (char*)employeeMenu,               systemMenu, "true",                                      NULL, NULL, true },
-    { "sys.employee",                 tr("&New..."),               	    SLOT(sNewEmployee()),            employeeMenu, "MaintainEmployees",                         NULL, NULL, true },
-    { "sys.listEmployees",            tr("&List..."),             	    SLOT(sListEmployees()),          employeeMenu, "ViewEmployees MaintainEmployees",           NULL, NULL, true },
-    { "sys.searchEmployees",          tr("&Search..."),       		    SLOT(sSearchEmployees()),        employeeMenu, "ViewEmployees MaintainEmployees",           NULL, NULL, true },
+    { "sys.employee",                 tr("&New"),               	    SLOT(sNewEmployee()),            employeeMenu, "MaintainEmployees",                         NULL, NULL, true },
+    { "sys.listEmployees",            tr("&List"),             	    SLOT(sListEmployees()),          employeeMenu, "ViewEmployees MaintainEmployees",           NULL, NULL, true },
+    { "sys.searchEmployees",          tr("&Search"),       		    SLOT(sSearchEmployees()),        employeeMenu, "ViewEmployees MaintainEmployees",           NULL, NULL, true },
     { "separator",                    NULL,                                 NULL,                            employeeMenu, "true",                                      NULL, NULL, true },
-    { "sys.employeeGroups",           tr("Employee &Groups..."),            SLOT(sEmployeeGroups()),         employeeMenu, "ViewEmployeeGroups MaintainEmployeeGroups", NULL, NULL, true },
+    { "sys.employeeGroups",           tr("Employee &Groups"),            SLOT(sEmployeeGroups()),         employeeMenu, "ViewEmployeeGroups MaintainEmployeeGroups", NULL, NULL, true },
 
     { "separator",                    NULL,                                 NULL,                              systemMenu, "true",                                      NULL, NULL, true },
 
   //  Design
     { "menu",           tr("&Design"),                (char*)designMenu,      systemMenu, "true",                        NULL, NULL, true },
-    { "sys.reports",    tr("&Reports..."),            SLOT(sReports()),       designMenu, "MaintainReports",             NULL, NULL, true },
-    { "sys.metasqls",   tr("&MetaSQL Statements..."), SLOT(sMetasqls()),      designMenu, "MaintainMetaSQL ViewMetaSQL", NULL, NULL, true },
+    { "sys.reports",    tr("&Reports"),            SLOT(sReports()),       designMenu, "MaintainReports",             NULL, NULL, true },
+    { "sys.metasqls",   tr("&MetaSQL Statements"), SLOT(sMetasqls()),      designMenu, "MaintainMetaSQL ViewMetaSQL", NULL, NULL, true },
     { "separator",      NULL,                         NULL,                   designMenu, "true",                        NULL, NULL, true },
-    { "sys.uiforms",    tr("S&creens..."),            SLOT(sUIForms()),       designMenu, "MaintainScreens",             NULL, NULL, true },
-    { "sys.scripts",    tr("Scr&ipts..."),            SLOT(sScripts()),       designMenu, "MaintainScripts",             NULL, NULL, true },
+    { "sys.uiforms",    tr("S&creens"),            SLOT(sUIForms()),       designMenu, "MaintainScreens",             NULL, NULL, true },
+    { "sys.scripts",    tr("Scr&ipts"),            SLOT(sScripts()),       designMenu, "MaintainScripts",             NULL, NULL, true },
     { "separator",      NULL,                         NULL,                   designMenu, "true",                        NULL, NULL, true },
-    { "sys.customCommands",tr("Custom Command&s..."), SLOT(sCustomCommands()),designMenu, "MaintainCustomCommands",      NULL, NULL, true },
+    { "sys.customCommands",tr("Custom Command&s"), SLOT(sCustomCommands()),designMenu, "MaintainCustomCommands",      NULL, NULL, true },
     { "separator",      NULL,                         NULL,                   designMenu, "true",                        NULL, NULL, true },
-    { "sys.packages",   tr("&Packages..."),           SLOT(sPackages()),      designMenu, "ViewPackages",                NULL, NULL, true },
+    { "sys.packages",   tr("&Packages"),           SLOT(sPackages()),      designMenu, "ViewPackages",                NULL, NULL, true },
 
   // Utilities
     { "menu",              tr("&Utilities"),(char*)sysUtilsMenu, systemMenu,    "true",                            NULL, NULL, true },
@@ -146,9 +146,9 @@ menuSystem::menuSystem(GUIClient *Pparent) :
     { "sys.printAlignmentPage",	tr("Print &Alignment Page..."),	SLOT(sPrintAlignment()),	sysUtilsMenu,	"true",	NULL,	NULL,	true	},
 
     // Setup
-    { "sys.setup",	tr("&Setup..."),	SLOT(sSetup()),	systemMenu,	"true",	NULL,	NULL,	true	},
+    { "sys.setup",	tr("&Setup"),	SLOT(sSetup()),	systemMenu,	"true",	NULL,	NULL,	true	},
     { "separator",		NULL,				NULL,				systemMenu,	"true",	NULL,	NULL,	true	},
-    { "sys.exit",	tr("E&xit xTuple ERP..."), SLOT(sExit()),				systemMenu,	"true",	NULL,	NULL,	true	},
+    { "sys.exit",	tr("E&xit xTuple ERP"), SLOT(sExit()),				systemMenu,	"true",	NULL,	NULL,	true	},
 
   };
 

--- a/guiclient/menuWindow.cpp
+++ b/guiclient/menuWindow.cpp
@@ -1,7 +1,7 @@
 /*
  * This file is part of the xTuple ERP: PostBooks Edition, a free and
  * open source Enterprise Resource Planning software suite,
- * Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+ * Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
  * It is licensed to you under the Common Public Attribution License
  * version 1.0, the full text of which (including xTuple-specific Exhibits)
  * is available at www.xtuple.com/CPAL.  By using this software, you agree

--- a/guiclient/uiforms.ui
+++ b/guiclient/uiforms.ui
@@ -2,7 +2,7 @@
 <ui version="4.0">
  <comment>This file is part of the xTuple ERP: PostBooks Edition, a free and
 open source Enterprise Resource Planning software suite,
-Copyright (c) 1999-2014 by OpenMFG LLC, d/b/a xTuple.
+Copyright (c) 1999-2018 by OpenMFG LLC, d/b/a xTuple.
 It is licensed to you under the Common Public Attribution License
 version 1.0, the full text of which (including xTuple-specific Exhibits)
 is available at www.xtuple.com/CPAL.  By using this software, you agree
@@ -91,7 +91,7 @@ to be bound by its terms.</comment>
         <bool>false</bool>
        </property>
        <property name="text">
-        <string>&amp;Edit</string>
+        <string>&amp;Edit...</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Removed ellipses from all 'New','List' and 'Setup' menu options.
Removed ellipses from other places where window is expected to open but user is not required to provide extra info or make a decision (e.g. `Inventory>Site>Locations` opens a window that lists all locations but the user is not asked to do anything. The user can filter the locations afterwards, but the action `Show me the Locations` was performed without extra steps)