### PR TITLE
Resolve a number of S/O Item signal problems

### DIFF
--- a/guiclient/salesOrderItem.cpp
+++ b/guiclient/salesOrderItem.cpp
@@ -896,7 +896,6 @@ void salesOrderItem::clear()
     disconnect(_supplyDropShip,    SIGNAL(toggled(bool)),                this, SLOT(sHandleSupplyOrder()));
   }
 
-  _soheadid                      = -1;
   _soitemid                      = -1;
 
   _autoord                       = true;
@@ -918,7 +917,6 @@ void salesOrderItem::clear()
   _itemsubsLastItemid            = -1;
   _itemsubsLastWarehousid        = -1;
   _leadTime                      = 999;
-  _mode                          = cView;
   _modified                      = false;
   _originalQtyOrd                = 0.0;
   _partialsaved                  = false;
@@ -1863,7 +1861,6 @@ void salesOrderItem::sRecalcPrice()
 void salesOrderItem::sDeterminePrice(bool force)
 {
   ENTERED << "with" << force;
-  if (DEBUG) qDebug() << "sDeterminePrice(force) entered with" << force;
   XSqlQuery salesDeterminePrice;
   // Determine if we can or should update the price
   if ( _mode == cView ||
@@ -4516,7 +4513,7 @@ void salesOrderItem::reject()
   ENTERED;
   XSqlQuery salesreject;
   bool saved = false;
-  if (_modified)
+  if (_modified && _item->id() > 0)
   {
     switch ( QMessageBox::question( this, tr("Unsaved Changed"),
                                     tr("<p>You have made some changes which have not yet been saved!\n"


### PR DESCRIPTION
Including extraneous user dialog popups, plus issues entering multiple SO Items in a row (without closing/reopening the SO Item screen)

@gilmoskowitz can you please check this as it reverts a couple of changes you recently introduced.

Should also be upmerged to 5_0_x