### PR TITLE
[33376]  VoucherItem window mishandles distributions when user cancels Voucher Item

### DIFF
--- a/common/storedProcErrorLookup.cpp
+++ b/common/storedProcErrorLookup.cpp
@@ -1485,17 +1485,16 @@ const struct {
 
   { "postValueIntoInvBalance", -1, QT_TRANSLATE_NOOP("storedProcErrorLookup", "An inventory balance record was not found "
                                "for item %1.  This is typically caused by that item missing standard costs"), 0, "" },
-
-  { "postVoucher",	-5, QT_TRANSLATE_NOOP("storedProcErrorLookup", "The Cost Category for one or more Item Sites "
-			       "for the Purchase Order covered by this Voucher "
-			       "is not configured with Purchase Price Variance "
-			       "or P/O Liability Clearing Account Numbers or "
-			       "the Vendor of this Voucher is not configured "
-			       "with an A/P Account Number. Because of this, "
-			       "G/L Transactions cannot be posted for this "
-			       "Voucher."),
-								0, "" },
-
+  { "postVoucher",	-1, QT_TRANSLATE_NOOP("storedProcErrorLookup", " Cannot Post Voucher for a negative or zero amount "),0, "" },
+  { "postVoucher",	-2, QT_TRANSLATE_NOOP("storedProcErrorLookup", " Cannot Post Voucher with negative or zero distributions"),0, "" },
+  { "postVoucher",	-3, QT_TRANSLATE_NOOP("storedProcErrorLookup", " Cannot Post Voucher with distributions greater than the voucher amount"),0, "" },
+  { "postVoucher",	-4, QT_TRANSLATE_NOOP("storedProcErrorLookup", " Cannot Post Voucher with distributions less than the voucher amount"),0, "" },
+  { "postVoucher",	-6, QT_TRANSLATE_NOOP("storedProcErrorLookup", " Cannot Post Voucher as one or more of the line items have already been fully vouchered"),0, "" },
+  { "postVoucher",	-7, QT_TRANSLATE_NOOP("storedProcErrorLookup", " Cannot Post Voucher due to unassigned G/L Accounts"),0, "" },
+  { "postVoucher",	-8, QT_TRANSLATE_NOOP("storedProcErrorLookup", " Cannot Post Voucher due to unassigned G/L Accounts"),0, "" },
+  { "postVoucher",	-9, QT_TRANSLATE_NOOP("storedProcErrorLookup", " Cannot Post Voucher #% due to an unassigned A/P Account"),0, " " },
+  { "postVoucher",	-10, QT_TRANSLATE_NOOP("storedProcErrorLookup", " Cannot post Voucher #% as it is already posted "),0, "" },
+  { "postVoucher",	-11, QT_TRANSLATE_NOOP("storedProcErrorLookup", " Cannot post Voucher as it has items without any tagged receipts or without distributions"),0, "" },
   { "_raheadBeforeUpdateTrigger", -1, QT_TRANSLATE_NOOP("storedProcErrorLookup", "You do not have privileges to change "
                                "a Return Authorization."), 0, "" },
   { "_raheadBeforeUpdateTrigger", -2, QT_TRANSLATE_NOOP("storedProcErrorLookup", "Returns may not be saved with disposition "

--- a/guiclient/voucherItem.cpp
+++ b/guiclient/voucherItem.cpp
@@ -745,10 +745,9 @@ void voucherItem::reject()
     ;
     if (GuiErrorCheck::reportErrors(this, tr("Cannot Cancel Voucher Item"), errors))
     {
-      int ret =  QMessageBox::question(this, tr("Cancel Anyway?"),
+      if(QMessageBox::question(this, tr("Cancel Anyway?"),
                                           tr("Would you like to cancel anyway?"),
-                                          QMessageBox::Yes | QMessageBox::No);
-      if(ret == 65536) // 16384 = 0x00010000  = "No"
+                                          QMessageBox::Yes | QMessageBox::No)) == QMessageBox::No;
         return;
     }
   } 

--- a/guiclient/voucherItem.cpp
+++ b/guiclient/voucherItem.cpp
@@ -495,7 +495,7 @@ void voucherItem::sDelete()
 {
   XSqlQuery voucherDelete;
   voucherDelete.prepare( "DELETE FROM vodist "
-                         "WHERE (vodist_id=:vodist_id);" );
+                         " WHERE (vodist_id=:vodist_id);" );
   voucherDelete.bindValue(":vodist_id", _vodist->id());
   voucherDelete.exec();
   if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Deleting Voucher Item Information"),
@@ -693,12 +693,12 @@ void voucherItem::rollback()
   //Undo 'tagged' status stored in rev_vohead_id to initial state stored in recv_voitem_id
 
   rollback.prepare( "UPDATE recv "
-                      "SET recv_vohead_id=CASE WHEN (recv_voitem_id IS NULL) THEN NULL ELSE :vohead_id END "
-                      "WHERE ( (NOT recv_invoiced) "
-                      "AND     (recv_posted) "
-                      "AND     ((recv_vohead_id IS NULL) OR (recv_vohead_id=:vohead_id)) "
-                      "AND     (recv_order_type='PO') "
-                      "AND     (recv_orderitem_id=:poitem_id) );" );
+                    "  SET recv_vohead_id=CASE WHEN (recv_voitem_id IS NULL) THEN NULL ELSE :vohead_id END "
+                    " WHERE ( (NOT recv_invoiced) "
+                    "   AND     (recv_posted) "
+                    "   AND     ((recv_vohead_id IS NULL) OR (recv_vohead_id=:vohead_id)) "
+                    "   AND     (recv_order_type='PO') "
+                    "   AND     (recv_orderitem_id=:poitem_id) );" );
   rollback.bindValue(":vohead_id", _voheadid);
   rollback.bindValue(":poitem_id", _poitemid);
   rollback.exec();
@@ -729,10 +729,10 @@ void voucherItem::reject()
 
     // Check to make sure there is at least 1 distribution for this Voucher Item
     voucherSave.prepare( "SELECT vodist_id "
-              "FROM vodist "
-              "WHERE ( (vodist_vohead_id=:vohead_id)"
-              " AND (vodist_poitem_id=:poitem_id) ) "
-              "LIMIT 1;" );
+                         "  FROM vodist "
+                         " WHERE ( (vodist_vohead_id=:vohead_id)"
+                         "   AND (vodist_poitem_id=:poitem_id) ) "
+                         " LIMIT 1;" );
     voucherSave.bindValue(":vohead_id", _voheadid);
     voucherSave.bindValue(":poitem_id", _poitemid);
     voucherSave.exec();

--- a/guiclient/voucherItem.cpp
+++ b/guiclient/voucherItem.cpp
@@ -747,7 +747,7 @@ void voucherItem::reject()
     {
       if(QMessageBox::question(this, tr("Cancel Anyway?"),
                                           tr("Would you like to cancel anyway?"),
-                                          QMessageBox::Yes | QMessageBox::No)) == QMessageBox::No;
+                                          QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
         return;
     }
   } 


### PR DESCRIPTION
- Only rollback when the user has not saved a voItem yet (_voitemid == -1)
- delete all distributions when rolling back
- check if `Qty to Voucher == 0` or `no distribution items` when saving or canceling

Also added check to postVoucher function in xtuple repo.
-added translations to all exceptions in postVoucher function