### PR TITLE
[32178] 'Open...' not active on Owner field in Account window

### DIFF
--- a/widgets/usernameCluster.cpp
+++ b/widgets/usernameCluster.cpp
@@ -19,7 +19,7 @@ UsernameLineEdit::UsernameLineEdit(QWidget* pParent, const char* pName) :
 {
   setTitles(tr("User Name"), tr("User Names"));
   setUiName("user");
-  setEditPriv("EditOwner");
+  setEditPriv("MaintainUsers");
   setShowInactive(true);
   if (_x_preferences && !_x_preferences->boolean("ClusterButtons"))
   {

--- a/widgets/usernameCluster.cpp
+++ b/widgets/usernameCluster.cpp
@@ -19,6 +19,7 @@ UsernameLineEdit::UsernameLineEdit(QWidget* pParent, const char* pName) :
 {
   setTitles(tr("User Name"), tr("User Names"));
   setUiName("user");
+  setEditPriv("EditOwner");
   setShowInactive(true);
   if (_x_preferences && !_x_preferences->boolean("ClusterButtons"))
   {


### PR DESCRIPTION
Edit privileges were not being set correctly, therefore virtualClusterLineEdit disabled the 'open' menu action