### PR TITLE
[33827] Attaching file from UNC path raises DB exception

### DIFF
--- a/widgets/docAttach.cpp
+++ b/widgets/docAttach.cpp
@@ -559,10 +559,9 @@ void docAttach::sSave()
         return;
       }
       bytarr = sourceFile.readAll();
-      url.setPath(fi.fileName().remove(" "));
+      url.setPath(fi.filePath().remove(" "));
       url.setScheme("");
     }
-
     if (_mode == "new" && bytarr.isNull())
     {
       newDocass.prepare( "INSERT INTO docass ("

--- a/widgets/docAttach.cpp
+++ b/widgets/docAttach.cpp
@@ -604,7 +604,7 @@ void docAttach::sSave()
 
     newDocass.bindValue(":url_id", _id);
     newDocass.bindValue(":title", title);
-    newDocass.bindValue(":url", url.url());
+    newDocass.bindValue(":url", url.toString());
   }
   else
   {

--- a/widgets/docAttach.cpp
+++ b/widgets/docAttach.cpp
@@ -559,9 +559,10 @@ void docAttach::sSave()
         return;
       }
       bytarr = sourceFile.readAll();
-      url.setPath(fi.filePath().remove(" "));
+      url.setUrl(fi.fileName().remove(" "));
       url.setScheme("");
     }
+
     if (_mode == "new" && bytarr.isNull())
     {
       newDocass.prepare( "INSERT INTO docass ("
@@ -603,7 +604,7 @@ void docAttach::sSave()
 
     newDocass.bindValue(":url_id", _id);
     newDocass.bindValue(":title", title);
-    newDocass.bindValue(":url", url.toString());
+    newDocass.bindValue(":url", url.url());
   }
   else
   {


### PR DESCRIPTION
This bug only occurred when `Save to Database` was checked. The `setPath()` function would produce a null value for the url value causing the exception. 