### PR TITLE
Minor tweak to display to allow setupCharacteristics multiple times

### DIFF
--- a/guiclient/display.cpp
+++ b/guiclient/display.cpp
@@ -295,11 +295,14 @@ void displayPrivate::setupCharacteristics(QStringList uses)
     }
     else if (chartype == characteristic::Date)
     {
-      _charidsdate.append(chars.value("char_id").toInt());
-      QString start = QApplication::translate("display", "Start Date", 0);
-      QString end = QApplication::translate("display", "End Date", 0);
-      _parameterWidget->append(name + " " + start, column + "startDate", ParameterWidget::Date);
-      _parameterWidget->append(name + " " + end, column + "endDate", ParameterWidget::Date);
+      if (!_charidslist.contains(chars.value("char_id").toInt()))
+      {
+        _charidsdate.append(chars.value("char_id").toInt());
+        QString start = QApplication::translate("display", "Start Date", 0);
+        QString end = QApplication::translate("display", "End Date", 0);
+        _parameterWidget->append(name + " " + start, column + "startDate", ParameterWidget::Date);
+        _parameterWidget->append(name + " " + end, column + "endDate", ParameterWidget::Date);
+      }
     }
   }
 }

--- a/guiclient/display.cpp
+++ b/guiclient/display.cpp
@@ -266,23 +266,32 @@ void displayPrivate::setupCharacteristics(QStringList uses)
     _list->addColumn(name, -1, Qt::AlignLeft , false, column );
     if (chartype == characteristic::Text)
     {
-      _charidstext.append(chars.value("char_id").toInt());
-      _parameterWidget->append(name, column, ParameterWidget::Text);
+      if (!_charidstext.contains(chars.value("char_id").toInt()))
+      {
+        _charidstext.append(chars.value("char_id").toInt());
+        _parameterWidget->append(name, column, ParameterWidget::Text);
+      }
     }
     if (chartype == characteristic::Number)
     {
-      _charidstext.append(chars.value("char_id").toInt());
-      _parameterWidget->append(name, column, ParameterWidget::Numeric);
+      if (!_charidstext.contains(chars.value("char_id").toInt()))
+      {
+        _charidstext.append(chars.value("char_id").toInt());
+        _parameterWidget->append(name, column, ParameterWidget::Numeric);
+      }
     }
     else if (chartype == characteristic::List)
     {
-      _charidslist.append(chars.value("char_id").toInt());
-      QString sql = QString("SELECT charopt_value, charopt_value"
-                            "  FROM charopt"
-                            " WHERE charopt_char_id = %1"
-                            " ORDER BY charopt_order, charopt_value;")
-          .arg(chars.value("char_id").toInt());
-      _parameterWidget->append(name, column, ParameterWidget::Multiselect, QVariant(), false, sql);
+      if (!_charidslist.contains(chars.value("char_id").toInt()))
+      {
+        _charidslist.append(chars.value("char_id").toInt());
+        QString sql = QString("SELECT charopt_value, charopt_value"
+                              "  FROM charopt"
+                              " WHERE charopt_char_id = %1"
+                              " ORDER BY charopt_order, charopt_value;")
+            .arg(chars.value("char_id").toInt());
+        _parameterWidget->append(name, column, ParameterWidget::Multiselect, QVariant(), false, sql);
+      }
     }
     else if (chartype == characteristic::Date)
     {

--- a/guiclient/display.cpp
+++ b/guiclient/display.cpp
@@ -295,7 +295,7 @@ void displayPrivate::setupCharacteristics(QStringList uses)
     }
     else if (chartype == characteristic::Date)
     {
-      if (!_charidslist.contains(chars.value("char_id").toInt()))
+      if (!_charidsdate.contains(chars.value("char_id").toInt()))
       {
         _charidsdate.append(chars.value("char_id").toInt());
         QString start = QApplication::translate("display", "Start Date", 0);


### PR DESCRIPTION
If setupCharacteristics() is called more than once in a screen or script, duplicate column errors occur.  This is needed in the Inventory Days package where we rebuild the list columns before each fillList() due to variable columns based on filter selection.

Minor change that checks whether the arrays already contain the characteristic and appends if they do not.

Might need porting back to 4.12 depending on customer requirement.