### PR TITLE
[30544] Vendor Addresses could be altered without privs

### DIFF
--- a/guiclient/address.h
+++ b/guiclient/address.h
@@ -42,6 +42,7 @@ protected slots:
     virtual void sEditVendor();
     virtual void sEditVendorAddress();
     virtual void sEditWarehouse();
+    virtual void sHandleSelection();
     virtual void sPopulate();
     virtual void sPopulateMenu(QMenu *);
     virtual void sSave();
@@ -56,8 +57,9 @@ protected slots:
     virtual void setVisible(bool);
 
 private:
-    int _mode;
-    int _addrid;
+    int  _mode;
+    int  _editableMode;
+    int  _addrid;
     bool _captive;
     bool _close;
     AppLock _lock;

--- a/guiclient/address.ui
+++ b/guiclient/address.ui
@@ -192,54 +192,5 @@ to be bound by its terms.</comment>
   <tabstop>_notes</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>_uses</sender>
-   <signal>itemSelected(int)</signal>
-   <receiver>_editAddrUse</receiver>
-   <slot>animateClick()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>380</x>
-     <y>511</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>380</x>
-     <y>511</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>_uses</sender>
-   <signal>valid(bool)</signal>
-   <receiver>_editAddrUse</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>380</x>
-     <y>511</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>380</x>
-     <y>511</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>_uses</sender>
-   <signal>valid(bool)</signal>
-   <receiver>_viewAddrUse</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>380</x>
-     <y>511</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>380</x>
-     <y>511</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/guiclient/contact.cpp
+++ b/guiclient/contact.cpp
@@ -558,10 +558,13 @@ void contact::sSave()
   }
   if (saveResult < 0)   // check from errors for CHECK and CHANGE* saves
   {
-    ErrorReporter::error(QtCriticalMsg, this, tr("Saving Address"),
-                         tr("<p>There was an error saving this Address (%1). "
-                            "Check the database server log for errors.")
-                         .arg(saveResult), __FILE__, __LINE__);
+    if (saveResult == -99)
+      return; // Privilege fail, message already presented.
+    else
+      ErrorReporter::error(QtCriticalMsg, this, tr("Saving Address"),
+                           tr("<p>There was an error saving this Address (%1). "
+                              "Check the database server log for errors.")
+                           .arg(saveResult), __FILE__, __LINE__);
     return;
   }
 

--- a/guiclient/vendor.cpp
+++ b/guiclient/vendor.cpp
@@ -271,44 +271,36 @@ SetResponse vendor::set(const ParameterList &pParams)
       _mode = cNew;
       emit newMode(_mode);
 
-      
       clear();
       _accountingTab->setEnabled(false);
-
-      if (_privileges->check("MaintainVendorAddresses"))
-      {
-        connect(_vendaddr, SIGNAL(valid(bool)), _editAddress, SLOT(setEnabled(bool)));
-        connect(_vendaddr, SIGNAL(valid(bool)), _deleteAddress, SLOT(setEnabled(bool)));
-        connect(_vendaddr, SIGNAL(itemSelected(int)), _editAddress, SLOT(animateClick()));
-      }
-      else
-      {
-        _newAddress->setEnabled(false);
-        connect(_vendaddr, SIGNAL(itemSelected(int)), _viewAddress, SLOT(animateClick()));
-      }
     }
     else if (param.toString() == "edit")
     {
       _mode = cEdit;
       emit newMode(_mode);
-
-      if (_privileges->check("MaintainVendorAddresses"))
-      {
-        connect(_vendaddr, SIGNAL(valid(bool)), _editAddress, SLOT(setEnabled(bool)));
-        connect(_vendaddr, SIGNAL(valid(bool)), _deleteAddress, SLOT(setEnabled(bool)));
-        connect(_vendaddr, SIGNAL(itemSelected(int)), _editAddress, SLOT(animateClick()));
-      }
-      else
-      {
-        _newAddress->setEnabled(false);
-        connect(_vendaddr, SIGNAL(itemSelected(int)), _viewAddress, SLOT(animateClick()));
-      }
     }
     else if (param.toString() == "view")
     {
       setViewMode();
     }
     _tempMode = _mode;
+  }
+
+  if (_mode != cView)
+  {
+    if (_privileges->check("MaintainVendorAddresses"))
+    {
+      connect(_vendaddr, SIGNAL(valid(bool)), _editAddress, SLOT(setEnabled(bool)));
+      connect(_vendaddr, SIGNAL(valid(bool)), _deleteAddress, SLOT(setEnabled(bool)));
+      connect(_vendaddr, SIGNAL(itemSelected(int)), _editAddress, SLOT(animateClick()));
+    }
+    else
+    {
+      _address->setEnabled(false);
+      _newAddress->setEnabled(false);
+      if (_privileges->check("ViewVendorAddresses"))
+        connect(_vendaddr, SIGNAL(valid(bool)), _viewAddress, SLOT(setEnabled(bool)));
+    }
   }
 
   param = pParams.value("crmacct_id", &valid);

--- a/guiclient/vendor.ui
+++ b/guiclient/vendor.ui
@@ -1947,22 +1947,6 @@ and Purchase Order amounts</string>
    </hints>
   </connection>
   <connection>
-   <sender>_vendaddr</sender>
-   <signal>valid(bool)</signal>
-   <receiver>_viewAddress</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>54</x>
-     <y>467</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>126</x>
-     <y>467</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>_accountSelected</sender>
    <signal>toggled(bool)</signal>
    <receiver>_account</receiver>

--- a/guiclient/vendors.cpp
+++ b/guiclient/vendors.cpp
@@ -29,7 +29,6 @@ vendors::vendors(QWidget* parent, const char*, Qt::WindowFlags fl)
   setReportName("VendorMasterList");
   setMetaSQLOptions("vendors", "detail");
   setParameterWidgetVisible(true);
-  setNewVisible(true);
   setSearchVisible(true);
   setQueryOnStartEnabled(true);
 

--- a/widgets/addressCluster.cpp
+++ b/widgets/addressCluster.cpp
@@ -196,7 +196,7 @@ AddressCluster::SaveFlags AddressCluster::askForSaveMode(int pAddrId, QWidget *p
   params.append("contact",  tr("Contact"));
   params.append("shipto",   tr("Ship-to Address"));
   params.append("vendor",   tr("Vendor"));
-  params.append("vendaddr", tr("Vendor addresss"));
+  params.append("vendaddr", tr("Vendor address"));
   params.append("whs",      tr("Site"));
 
   MetaSQLQuery mql(_guiClientInterface->getMqlHash()->value("address", "uses"));
@@ -218,7 +218,17 @@ AddressCluster::SaveFlags AddressCluster::askForSaveMode(int pAddrId, QWidget *p
 
   QStringList countlist;
   foreach (QString type, count.keys())
-    countlist << QString("%1 - %2").arg(type).arg(count[type]);
+  {
+    if (type == tr("Vendor address") && _x_privileges && !_x_privileges->check("MaintainVendorAddresses"))
+    {
+      QMessageBox::warning(pParent, tr("Saving Shared Address"),
+                           tr("<p>This address is shared by a Vendor Address and you do not have "
+                              "privileges to edit Vendor Addresses."));
+      return PRIV;
+    }
+    else
+      countlist << QString("%1 - %2").arg(type).arg(count[type]);
+  }
 
   QString message = tr("There are multiple uses of this address:<UL><li>%1</li></UL>"
                        "<p>Would you like to save just this one use, save all "
@@ -518,6 +528,9 @@ void AddressCluster::setDataWidgetMap(XDataWidgetMapper* m)
  */
 int AddressCluster::save(enum SaveFlags flag)
 {
+
+  if (flag == PRIV)
+    return -99;
 
   if (_number->text() == "" &&
       _addr1->text() == "" && _addr2->text() == "" &&

--- a/widgets/addresscluster.h
+++ b/widgets/addresscluster.h
@@ -98,7 +98,7 @@ class XTUPLEWIDGETS_EXPORT AddressCluster : public VirtualCluster
     friend class AddressSearch;
 
     public:
-	enum SaveFlags { CHECK = 0, CHANGEONE = 1, CHANGEALL = 2 }; 
+        enum SaveFlags { CHECK = 0, CHANGEONE = 1, CHANGEALL = 2, PRIV = 99 };
         Q_ENUM(SaveFlags)
         enum Mode      { Edit, View, Select };
         Q_ENUM(Mode)


### PR DESCRIPTION
MaintainVendorAddresses priv was not being applied outside of the Vendor screen.  Also tidied up ViewVendorAddresses which also did not seem to do much.

Plus various screens could be accessed from the Address uses list in edit mode without appropriate privileges.