### PR TITLE
[33843] Resolve Documents list numbering, plus other bugs

### DIFF
--- a/guiclient/displays/dspDocuments.cpp
+++ b/guiclient/displays/dspDocuments.cpp
@@ -217,7 +217,9 @@ void dspDocuments::sOpenAssignment()
   else
     params.append("mode", "view");
 
-  doc.prepare("SELECT source_key_field, source_uiform_name, docass_source_id "
+// Have to fudge for inconsistent salesOrder.cpp parameter
+  doc.prepare("SELECT REPLACE(source_key_field, 'cohead_id', 'sohead_id') AS source_key_field, "
+              "       source_uiform_name, docass_source_id "
               "  FROM source "
               "  JOIN docass on source_name = docass_source_type "
               " WHERE docass_id = :docid;" );
@@ -237,7 +239,6 @@ void dspDocuments::sOpenAssignment()
     QMessageBox::critical(this, tr("Invalid Source"), tr("Could not determine the ui form to open"));
     return;
   }
-
   QWidget *w = ScriptableWidget::_guiClientInterface->openWindow(ui, params, this, 
                                                                   Qt::NonModal, Qt::Window);
   QDialog* newdlg = qobject_cast<QDialog*>(w);

--- a/guiclient/displays/dspDocuments.cpp
+++ b/guiclient/displays/dspDocuments.cpp
@@ -217,9 +217,7 @@ void dspDocuments::sOpenAssignment()
   else
     params.append("mode", "view");
 
-// Have to fudge for inconsistent salesOrder.cpp parameter
-  doc.prepare("SELECT REPLACE(source_key_field, 'cohead_id', 'sohead_id') AS source_key_field, "
-              "       source_uiform_name, docass_source_id "
+  doc.prepare("SELECT source_key_field, source_uiform_name, docass_source_id "
               "  FROM source "
               "  JOIN docass on source_name = docass_source_type "
               " WHERE docass_id = :docid;" );

--- a/guiclient/salesOrder.cpp
+++ b/guiclient/salesOrder.cpp
@@ -637,6 +637,8 @@ enum SetResponse salesOrder::set(const ParameterList &pParams)
     _opportunity->setId(param.toInt());
 
   param = pParams.value("sohead_id", &valid);
+  if (! valid)
+    param = pParams.value("cohead_id", &valid);
   if (valid)
   {
     _soheadid = param.toInt();

--- a/widgets/docAttach.cpp
+++ b/widgets/docAttach.cpp
@@ -741,41 +741,46 @@ void docAttach::sPopulateDocPrivs()
                  " FROM grp "
                  " WHERE grp_id NOT IN (SELECT filegrp_grp_id FROM filegrp WHERE filegrp_file_id=:file);" );
    privs.bindValue(":file", _charid);
-   if (privs.exec() && privs.first())
-     _fileAvailable->populate(privs);
-   else if (ErrorReporter::error(QtCriticalMsg, 0, tr("Error Retrieving Permissions"),
-                                 privs, __FILE__, __LINE__))
+   privs.exec();
+   if (ErrorReporter::error(QtCriticalMsg, 0, tr("Error Retrieving Permissions"),
+                            privs, __FILE__, __LINE__))
      return;
+   else
+     _fileAvailable->populate(privs);
 
    privs.prepare("SELECT grp_id, grp_name AS file_assigned "
                  " FROM filegrp "
                  " JOIN grp ON filegrp_grp_id=grp_id AND filegrp_file_id=:file;" );
    privs.bindValue(":file", _charid);
-   if (privs.exec() && privs.first())
-     _fileAssigned->populate(privs);
-   else if (ErrorReporter::error(QtCriticalMsg, 0, tr("Error Retrieving Permissions"),
-                                 privs, __FILE__, __LINE__))
+   privs.exec();
+   if (ErrorReporter::error(QtCriticalMsg, 0, tr("Error Retrieving Permissions"),
+                            privs, __FILE__, __LINE__))
      return;
+   else
+     _fileAssigned->populate(privs);
 
    privs.prepare("SELECT grp_id, grp_name AS url_available "
                  " FROM grp "
                  " WHERE grp_id NOT IN (SELECT filegrp_grp_id FROM filegrp WHERE filegrp_file_id=:url);" );
    privs.bindValue(":url", _charid);
-   if (privs.exec() && privs.first())
-     _urlAvailable->populate(privs);
-   else if (ErrorReporter::error(QtCriticalMsg, 0, tr("Error Retrieving Permissions"),
-                                 privs, __FILE__, __LINE__))
+   privs.exec();
+   if (ErrorReporter::error(QtCriticalMsg, 0, tr("Error Retrieving Permissions"),
+                            privs, __FILE__, __LINE__))
      return;
+   else
+     _urlAvailable->populate(privs);
 
    privs.prepare("SELECT grp_id, grp_name AS url_assigned "
                  " FROM filegrp "
                  " JOIN grp ON filegrp_grp_id=grp_id AND filegrp_file_id=:url;" );
    privs.bindValue(":url", _charid);
-   if (privs.exec() && privs.first())
-     _urlAssigned->populate(privs);
-   else if (ErrorReporter::error(QtCriticalMsg, 0, tr("Error Retrieving Permissions"),
+   privs.exec();
+   if (ErrorReporter::error(QtCriticalMsg, 0, tr("Error Retrieving Permissions"),
                                  privs, __FILE__, __LINE__))
      return;
+   else
+     _urlAssigned->populate(privs);
+
 }
 
 void docAttach::sAddFilePriv()

--- a/widgets/documents.cpp
+++ b/widgets/documents.cpp
@@ -262,7 +262,7 @@ void Documents::sOpenDoc(QString mode)
   QString docType = _doc->currentItem()->rawValue("target_type").toString();
   int targetid;
 
-  targetid = isFile.contains(docType) ? _doc->currentItem()->rawValue("target_number").toInt()
+  targetid = isFile.contains(docType) ? _doc->currentItem()->id()
                                       : _doc->currentItem()->id("target_number");
 
   ParameterList params;


### PR DESCRIPTION
Document number was inconsistent between screen (file ID versus assignment ID).
Also found link to Sales Orders not working due to inconsistent set parameter naming, plus file privilege assignment was not refreshing correctly.

requires xtuple/xtuple#3493