### PR TITLE
[33615] create sales order without Default Ship To 

### DIFF
--- a/guiclient/salesOrder.cpp
+++ b/guiclient/salesOrder.cpp
@@ -2078,8 +2078,7 @@ void salesOrder::populateShipto(int pShiptoid)
                     "       shipto_preferred_warehous_id, "
                     "       shipto_salesrep_id, shipto_commission AS commission"
                     "  FROM shiptoinfo"
-                    " WHERE shipto_active " 
-                    "   AND shipto_id = :shipto_id;" );
+                    " WHERE shipto_id = :shipto_id;" );
     shipto.bindValue(":shipto_id", pShiptoid);
     shipto.exec();
     if (shipto.first())

--- a/guiclient/salesOrder.cpp
+++ b/guiclient/salesOrder.cpp
@@ -1869,6 +1869,7 @@ void salesOrder::sPopulateFOB(int pWarehousid)
 // Is the first SELECT here responsible for the bug where the Currency kept disappearing?
 void salesOrder::sPopulateCustomerInfo(int pCustid)
 {
+  qDebug() << "\n\n ********* c++ sPopulateCustomerInfo ";
   ENTERED << "with" << pCustid;
   _holdType->setCode("N");
 
@@ -2066,6 +2067,8 @@ void salesOrder::sParseShipToNumber()
 
 void salesOrder::populateShipto(int pShiptoid)
 {
+#pragma comment(linker,"/SUBSYSTEM:CONSOLE")
+  qDebug() << "\n\n ********* c++ populateShipto ";  
   ENTERED << "with" << pShiptoid;
   if (pShiptoid != -1)
   {
@@ -2078,7 +2081,8 @@ void salesOrder::populateShipto(int pShiptoid)
                     "       shipto_preferred_warehous_id, "
                     "       shipto_salesrep_id, shipto_commission AS commission"
                     "  FROM shiptoinfo"
-                    " WHERE shipto_id = :shipto_id;" );
+                    " WHERE shipto_active = 't'" 
+                    "   AND shipto_id = :shipto_id;" );
     shipto.bindValue(":shipto_id", pShiptoid);
     shipto.exec();
     if (shipto.first())

--- a/guiclient/salesOrder.cpp
+++ b/guiclient/salesOrder.cpp
@@ -1869,7 +1869,6 @@ void salesOrder::sPopulateFOB(int pWarehousid)
 // Is the first SELECT here responsible for the bug where the Currency kept disappearing?
 void salesOrder::sPopulateCustomerInfo(int pCustid)
 {
-  qDebug() << "\n\n ********* c++ sPopulateCustomerInfo ";
   ENTERED << "with" << pCustid;
   _holdType->setCode("N");
 
@@ -2067,8 +2066,6 @@ void salesOrder::sParseShipToNumber()
 
 void salesOrder::populateShipto(int pShiptoid)
 {
-#pragma comment(linker,"/SUBSYSTEM:CONSOLE")
-  qDebug() << "\n\n ********* c++ populateShipto ";  
   ENTERED << "with" << pShiptoid;
   if (pShiptoid != -1)
   {

--- a/guiclient/salesOrder.cpp
+++ b/guiclient/salesOrder.cpp
@@ -2078,7 +2078,7 @@ void salesOrder::populateShipto(int pShiptoid)
                     "       shipto_preferred_warehous_id, "
                     "       shipto_salesrep_id, shipto_commission AS commission"
                     "  FROM shiptoinfo"
-                    " WHERE shipto_active = 't'" 
+                    " WHERE shipto_active " 
                     "   AND shipto_id = :shipto_id;" );
     shipto.bindValue(":shipto_id", pShiptoid);
     shipto.exec();

--- a/guiclient/shipTo.cpp
+++ b/guiclient/shipTo.cpp
@@ -229,6 +229,8 @@ void shipTo::sSave()
 
   saveq.bindValue(":shipto_id", _shiptoid);
   saveq.bindValue(":shipto_active", QVariant(_active->isChecked()));
+  if(!_active->isChecked()) // if shipTo is inactive, default should be false
+    _default->setChecked(false);
   saveq.bindValue(":shipto_default", QVariant(_default->isChecked()));
   saveq.bindValue(":shipto_cust_id", _custid);
   saveq.bindValue(":shipto_num", _shipToNumber->text().trimmed());


### PR DESCRIPTION
This bug was reported in the Distribution Edition, but the fix needs to be applied here as well.
The main fix is in `salesOrder.cpp`. 
The changes in `shipTo.cpp` make sure that if a ship-to is inactive then it can't be the default ship-to