### PR TITLE
make initializePlugin backwards call-compatibile

### DIFF
--- a/guiclient/main.cpp
+++ b/guiclient/main.cpp
@@ -638,7 +638,7 @@ int main(int argc, char *argv[])
 
   _taxIntegration = TaxIntegration::getTaxIntegration();
 
-  initializePlugin(_preferences, _metrics, _privileges, _taxIntegration, omfgThis->username(), omfgThis->workspace());
+  initializePlugin(_preferences, _metrics, _privileges, omfgThis->username(), omfgThis->workspace(), _taxIntegration);
 
 // START code for updating the locale settings if they haven't been already
   XSqlQuery lc;

--- a/widgets/widgets.cpp
+++ b/widgets/widgets.cpp
@@ -205,7 +205,7 @@ Privileges  *_x_privileges = 0;
 QString     _x_username;
 TaxIntegration * _x_taxIntegration = 0;
 
-void initializePlugin(Preferences *pPreferences, Metrics *pMetrics, Privileges *pPrivileges, TaxIntegration* pTaxIntegration, QString pUsername, QMdiArea *pWorkspace)
+void initializePlugin(Preferences *pPreferences, Metrics *pMetrics, Privileges *pPrivileges, QString pUsername, QMdiArea *pWorkspace, TaxIntegration* pTaxIntegration)
 {
   _x_preferences = pPreferences;
   _x_metrics = pMetrics;

--- a/widgets/xtupleplugin.h
+++ b/widgets/xtupleplugin.h
@@ -33,6 +33,6 @@ class xTuplePlugin : public QObject, public QDesignerCustomWidgetCollectionInter
     QList<QDesignerCustomWidgetInterface*> m_plugins;
 };
 
-void XTUPLEWIDGETS_EXPORT initializePlugin(Preferences *, Metrics *, Privileges *, TaxIntegration *, QString, QMdiArea *);
+void XTUPLEWIDGETS_EXPORT initializePlugin(Preferences *pPreferences, Metrics *pMetrics, Privileges *pPrivileges, QString pUsername, QMdiArea *pWorkspace = 0, TaxIntegration *pTax = 0);
 
 #endif


### PR DESCRIPTION
This allows the Batch Manager in xTuple Connect to build with both 4_12_x and 5_0_x branches of qt-client.