### PR TITLE
[33322] Enable Regexp search across all fields in XDisplay list

### DIFF
--- a/guiclient/display.cpp
+++ b/guiclient/display.cpp
@@ -316,6 +316,13 @@ bool displayPrivate::setParams(ParameterList &params)
     params.append("search_pattern", _search->text());
     QString searchon =  QApplication::translate("display", "Search On:", 0);
     filter.prepend(searchon + " " + _search->text() + "\n");
+
+    // Pass list of displayed columns to be applied against the search pattern
+    QList<QVariant> searchFields;
+    for (int i = 0; i < _list->columnCount(); i++)
+      searchFields.append(_list->column(i));
+
+    params.append("search_fields", searchFields);
   }
   params.append("filter", filter);
 


### PR DESCRIPTION
Introduces an automatic list of XDisplay list columns into the metaSQL parameters that can be used in MQL queries with the following pattern:

```
WITH _contact AS (SELECT blah from cntct)
SELECT * FROM _contact
WHERE true
<? if exists("search_pattern") ?>
  AND ( FALSE
  <? foreach("search_fields") ?>
    OR <? literal("search_fields") ?>::TEXT ~* <? value("search_pattern") ?>
  <? endforeach ?>
)
<? endif ?>
```
This allows the regexp search expression to be applied to all columns in the list without the need to individually specify/maintain columns to search on.
