### PR TITLE
[33967] product cost not updating to invoice

### DIFF
--- a/guiclient/salesOrderItem.ui
+++ b/guiclient/salesOrderItem.ui
@@ -2361,9 +2361,6 @@ to be bound by its terms.</comment>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
               </property>
-              <property name="enabled">
-                <bool>false</bool>
-              </property>
              </widget>
             </item>
             <item row="8" column="1">

--- a/guiclient/salesOrderItem.ui
+++ b/guiclient/salesOrderItem.ui
@@ -2341,6 +2341,9 @@ to be bound by its terms.</comment>
               <property name="currencyVisible">
                <bool>false</bool>
               </property>
+              <property name="enabled">
+                <bool>false</bool>
+              </property>
              </widget>
             </item>
             <item row="0" column="1">
@@ -2357,6 +2360,9 @@ to be bound by its terms.</comment>
              <widget class="XLineEdit" name="_markupFromUnitCost">
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="enabled">
+                <bool>false</bool>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
After speaking with Jim and Mike, it seems that adjusting the item cost from a sales order creates too many accounting complications regardless of the costing method. The user should not be allowed to edit the cost item at this stage