### PR TITLE
[34506] Resolve incorrect GL postings for manually distributed PO reject

### DIFF
--- a/guiclient/voucherItem.cpp
+++ b/guiclient/voucherItem.cpp
@@ -401,7 +401,6 @@ void voucherItem::sSave()
   }
 
   //Save 'tagged' status stored in rev_vohead_id to recv_voitem_id
-
   voucherSave.prepare( "UPDATE recv "
                        "SET recv_voitem_id=CASE WHEN (recv_vohead_id IS NULL) THEN NULL ELSE :voitem_id END "
                        "WHERE ( (NOT recv_invoiced) "
@@ -409,6 +408,23 @@ void voucherItem::sSave()
                        "AND     ((recv_vohead_id IS NULL) OR (recv_vohead_id=:vohead_id)) "
                        "AND     (recv_order_type='PO') "
                        "AND     (recv_orderitem_id=:poitem_id) );" );
+  voucherSave.bindValue(":voitem_id", _voitemid);
+  voucherSave.bindValue(":vohead_id", _voheadid);
+  voucherSave.bindValue(":poitem_id", _poitemid);
+  voucherSave.exec();
+  if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Saving Voucher Item Information"),
+                                voucherSave, __FILE__, __LINE__))
+  {
+    reject();
+    return;
+  }
+
+  //Save 'tagged' status stored in poreject_vohead_id to poreject_voitem_id
+  voucherSave.prepare( "UPDATE poreject "
+                       "   SET poreject_voitem_id=CASE WHEN (poreject_vohead_id IS NULL) THEN NULL ELSE :voitem_id END "
+                       "WHERE  poreject_poitem_id=:poitem_id "
+                       "  AND  poreject_posted "
+                       "  AND  poreject_vohead_id IS NULL OR poreject_vohead_id=:vohead_id;" );
   voucherSave.bindValue(":voitem_id", _voitemid);
   voucherSave.bindValue(":vohead_id", _voheadid);
   voucherSave.bindValue(":poitem_id", _poitemid);

--- a/guiclient/voucherItem.cpp
+++ b/guiclient/voucherItem.cpp
@@ -424,7 +424,7 @@ void voucherItem::sSave()
                        "   SET poreject_voitem_id=CASE WHEN (poreject_vohead_id IS NULL) THEN NULL ELSE :voitem_id END "
                        "WHERE  poreject_poitem_id=:poitem_id "
                        "  AND  poreject_posted "
-                       "  AND  poreject_vohead_id IS NULL OR poreject_vohead_id=:vohead_id;" );
+                       "  AND  (poreject_vohead_id IS NULL OR poreject_vohead_id=:vohead_id);" );
   voucherSave.bindValue(":voitem_id", _voitemid);
   voucherSave.bindValue(":vohead_id", _voheadid);
   voucherSave.bindValue(":poitem_id", _poitemid);


### PR DESCRIPTION
PO Reject records were being updated before the Voucher Item was created.  This follows the same path as Received records and updates once the voitem is saved.

Should be able to directly backport to 4.12

