### PR TITLE
Post Misc. Production Backdating issue #34641

### DIFF
--- a/guiclient/configureWO.cpp
+++ b/guiclient/configureWO.cpp
@@ -38,6 +38,7 @@ configureWO::configureWO(QWidget* parent, const char* name, bool /*modal*/, Qt::
   _autoExplode->setChecked(_metrics->boolean("AutoExplodeWO"));
   _issueToExplodedWO->setChecked(_metrics->boolean("IssueToExplodedWO"));
   _workOrderChangeLog->setChecked(_metrics->boolean("WorkOrderChangeLog"));
+  _requireMiscProdTransDate->setChecked(_metrics->boolean("RequireMiscProdDateEntry"));
 
   _woNumGeneration->append(0, tr("Automatic"),                  "A");
   _woNumGeneration->append(1, tr("Manual"),                     "M");
@@ -87,6 +88,7 @@ bool configureWO::sSave()
   _metrics->set("AutoExplodeWO", _autoExplode->isChecked());
   _metrics->set("IssueToExplodedWO", _issueToExplodedWO->isChecked());
   _metrics->set("WorkOrderChangeLog", _workOrderChangeLog->isChecked());
+  _metrics->set("RequireMiscProdDateEntry", _requireMiscProdTransDate->isChecked());
 
   _metrics->set("WONumberGeneration", _woNumGeneration->code());
 

--- a/guiclient/configureWO.ui
+++ b/guiclient/configureWO.ui
@@ -110,6 +110,16 @@ to be bound by its terms.</comment>
        </property>
       </widget>
      </item>
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="_requireMiscProdTransDate">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>Require Misc. Production Trans. Date Entry</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
@@ -225,6 +235,8 @@ to be bound by its terms.</comment>
   <tabstop>_woNumGeneration</tabstop>
   <tabstop>_autoExplode</tabstop>
   <tabstop>_workOrderChangeLog</tabstop>
+  <tabstop>_requireMiscProdTransDate</tabstop>
+  <tabstop>_issueToExplodedWO</tabstop>
   <tabstop>_explodeDateEffective</tabstop>
   <tabstop>_startDateEffective</tabstop>
   <tabstop>_singleLevel</tabstop>

--- a/guiclient/postMiscProduction.ui
+++ b/guiclient/postMiscProduction.ui
@@ -306,6 +306,20 @@ to be bound by its terms.</comment>
          </layout>
         </item>
         <item>
+         <layout class="QGridLayout" name="_transactionDateGrid">
+          <item row="0" column="0">
+           <widget class="XLabel" name="_transactionDateLit">
+            <property name="text">
+             <string>Trans. Date:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="DLineEdit" name="_transactionDate"/>
+          </item>
+         </layout>
+        </item>
+        <item>
          <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -392,6 +406,12 @@ to be bound by its terms.</comment>
  <layoutdefault spacing="5" margin="5"/>
  <customwidgets>
   <customwidget>
+   <class>DLineEdit</class>
+   <extends>QWidget</extends>
+   <header>datecluster.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>ItemCluster</class>
    <extends>QWidget</extends>
    <header>itemcluster.h</header>
@@ -434,6 +454,7 @@ to be bound by its terms.</comment>
   <tabstop>_transferWarehouse</tabstop>
   <tabstop>_post</tabstop>
   <tabstop>_close</tabstop>
+  <tabstop>_transactionDate</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
[34641] Add config re:required trans date entry

This implements the configuration point for the optional feature allowing the
new Post Misc. Production transaction date field to require the user enter a
value rather than defaulting a value.  By default, this value is false/unchecked
meaning that the new transaction date field is defaulted to the workstation's
current date (mimicking the behavior prior to this feature existing).

[34641] Add trans date field handling

This adds handling for the new transaction date field.  Specifically we manage
the permission checks and whether or not we should default the date depending
on the AlterTransactionDates permission and the RequireMiscProdDataEntry
configuration point.  We perform a sanity check on the date prior to allowing
the user to complete a post operation.

[34641] Add transaction date field to UI

This commit adds a new transaction date field to the user interface in support
of backdating misc. production postings.

[34641] Update queries to pass transaction date

In this commit we remove the hard coded references to "CURRENT_DATE" and "now()"
where they establish the transaction date.  These date should now honor the new
transaction date field from the form.