### PR TITLE
Fix segfault at application exit by clearing message handler

### DIFF
--- a/guiclient/main.cpp
+++ b/guiclient/main.cpp
@@ -807,6 +807,7 @@ int main(int argc, char *argv[])
   app.exec();
 
 //  Clean up
+  qInstallMessageHandler(nullptr);
   delete _metrics;
   delete _preferences;
   delete _privileges;

--- a/guiclient/main.cpp
+++ b/guiclient/main.cpp
@@ -807,7 +807,7 @@ int main(int argc, char *argv[])
   app.exec();
 
 //  Clean up
-  qInstallMessageHandler(nullptr);
+  qInstallMessageHandler(0);
   delete _metrics;
   delete _preferences;
   delete _privileges;


### PR DESCRIPTION
The application segfaults every time you close it, however since it is a GUI application the error isn't noticeable unless you start it from a shell. It is caused by our [debug log handler](https://github.com/xtuple/qt-client/blob/4_12_x/guiclient/errorLog.cpp#L134) using objects from Qt long after that stuff has been destroyed. First it is QDateTime, but then xSettings is next if you comment out the QDateTime usage, and so forth.

At that point in the applications life-cycle we do not need to continue our own message handling, simply adding a call to clear the message handler before final termination prevents the crash.

Sample gdb output below, from before the fix:
```
Thread 1 "xtuple" received signal SIGSEGV, Segmentation fault.
0x00007ffff588f9c6 in QLocale::monthName(int, QLocale::FormatType) const () from /usr/lib/libQt5Core.so.5
(gdb) bt
#0  0x00007ffff588f9c6 in QLocale::monthName(int, QLocale::FormatType) const () at /usr/lib/libQt5Core.so.5
#1  0x00007ffff58781db in QDate::toString(Qt::DateFormat) const () at /usr/lib/libQt5Core.so.5
#2  0x00007ffff5880e8a in QDateTime::toString(Qt::DateFormat) const () at /usr/lib/libQt5Core.so.5
#3  0x0000555555dbfd83 in xTupleMessageOutput(QtMsgType, QMessageLogContext const&, QString const&) ()
#4  0x00007ffff582b446 in  () at /usr/lib/libQt5Core.so.5
#5  0x00007ffff582b809 in  () at /usr/lib/libQt5Core.so.5
#6  0x00007ffff582baaa in QMessageLogger::debug(char const*, ...) const () at /usr/lib/libQt5Core.so.5
#7  0x00007fff51ff6540 in QVTKWidgetPlugin::~QVTKWidgetPlugin() () at /usr/lib/qt/plugins/designer/libQVTKWidgetPlugin.so
#8  0x00007fff51ff6a76 in QVTKPlugin::~QVTKPlugin() () at /usr/lib/qt/plugins/designer/libQVTKWidgetPlugin.so
#9  0x00007fff51ff6b19 in QVTKPlugin::~QVTKPlugin() () at /usr/lib/qt/plugins/designer/libQVTKWidgetPlugin.so
#10 0x00007ffff59e7317 in  () at /usr/lib/libQt5Core.so.5
#11 0x00007ffff59e895d in  () at /usr/lib/libQt5Core.so.5
#12 0x00007ffff52bc997 in __cxa_finalize () at /usr/lib/libc.so.6
#13 0x00007ffff5817a38 in  () at /usr/lib/libQt5Core.so.5
#14 0x00007fffffffda80 in  ()
#15 0x00007ffff7fe38de in _dl_fini () at /lib64/ld-linux-x86-64.so.2
```

And after:
```
[Thread 0x7ffff044c700 (LWP 10412) exited]
[Thread 0x7fffee832700 (LWP 10413) exited]
QVTKWidgetPlugin destructed

[Thread 0x7fff4ebc3700 (LWP 10415) exited]
[Thread 0x7ffff1752c80 (LWP 10411) exited]
[Inferior 1 (process 10411) exited normally]
(gdb) quit

```
