### PR TITLE
[34489] Split out Employee deletion SQL

### DIFF
--- a/guiclient/employees.cpp
+++ b/guiclient/employees.cpp
@@ -84,15 +84,39 @@ void employees::sDelete()
                             QMessageBox::No | QMessageBox::Default) == QMessageBox::No)
     return;
 
+  XSqlQuery rollbackq;
+  rollbackq.prepare("ROLLBACK;");
+  XSqlQuery begin("BEGIN;");
+
   XSqlQuery delq;
-  delq.prepare("DELETE FROM charass WHERE charass_target_type = 'EMP' AND charass_target_id = :emp_id;"
-               "DELETE FROM empgrpitem WHERE groupsitem_reference_id = :emp_id;"
-               "DELETE FROM emp WHERE emp_id = :emp_id;");
+  delq.prepare("DELETE FROM charass WHERE charass_target_type = 'EMP' AND charass_target_id = :emp_id;");
   delq.bindValue(":emp_id", list()->id());
   delq.exec();
-  if (ErrorReporter::error(QtCriticalMsg, this, tr("Error deleting Employee"),
+  if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Deleting Employee"),
                            delq, __FILE__, __LINE__))
+  {
+    rollbackq.exec();
     return;
+  }
+  delq.prepare("DELETE FROM empgrpitem WHERE groupsitem_reference_id = :emp_id;");
+  delq.exec();
+  if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Deleting Employee"),
+                           delq, __FILE__, __LINE__))
+  {
+    rollbackq.exec();
+    return;
+  }
+  delq.prepare("DELETE FROM emp WHERE emp_id = :emp_id;");
+  delq.bindValue(":emp_id", list()->id());
+  delq.exec();
+  if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Deleting Employee"),
+                           delq, __FILE__, __LINE__))
+  {
+    rollbackq.exec();
+    return;
+  }
+
+  delq.exec("COMMIT;");
   sFillList();
 }
 

--- a/guiclient/employees.cpp
+++ b/guiclient/employees.cpp
@@ -78,45 +78,21 @@ void employees::sView()
 
 void employees::sDelete()
 {
+  XSqlQuery delq;
+
   if (QMessageBox::question(this, tr("Delete?"),
                             tr("Are you sure you want to delete this Employee?"),
                             QMessageBox::Yes,
                             QMessageBox::No | QMessageBox::Default) == QMessageBox::No)
     return;
 
-  XSqlQuery rollbackq;
-  rollbackq.prepare("ROLLBACK;");
-  XSqlQuery begin("BEGIN;");
-
-  XSqlQuery delq;
-  delq.prepare("DELETE FROM charass WHERE charass_target_type = 'EMP' AND charass_target_id = :emp_id;");
-  delq.bindValue(":emp_id", list()->id());
-  delq.exec();
-  if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Deleting Employee"),
-                           delq, __FILE__, __LINE__))
-  {
-    rollbackq.exec();
-    return;
-  }
-  delq.prepare("DELETE FROM empgrpitem WHERE groupsitem_reference_id = :emp_id;");
-  delq.exec();
-  if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Deleting Employee"),
-                           delq, __FILE__, __LINE__))
-  {
-    rollbackq.exec();
-    return;
-  }
   delq.prepare("DELETE FROM emp WHERE emp_id = :emp_id;");
   delq.bindValue(":emp_id", list()->id());
   delq.exec();
   if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Deleting Employee"),
                            delq, __FILE__, __LINE__))
-  {
-    rollbackq.exec();
     return;
-  }
 
-  delq.exec("COMMIT;");
   sFillList();
 }
 


### PR DESCRIPTION
This code was masking an underlying SQL error preventing the deletion of employees.

I originally did not replicate the error in version 4.12 but this was due to my Db not having `xtte` installed.  This change can possibly be backported to 4.12.  Related change to `xtte` package possibly makes this change redundant, but updated the code to current standards regardless.

requires xtuple/xtuple#3595