### PR TITLE
[34489] Split out Employee deletion SQL

### DIFF
--- a/guiclient/employees.cpp
+++ b/guiclient/employees.cpp
@@ -80,45 +80,21 @@ void employees::sView()
 
 void employees::sDelete()
 {
+  XSqlQuery delq;
+
   if (QMessageBox::question(this, tr("Delete?"),
                             tr("Are you sure you want to delete this Employee?"),
                             QMessageBox::Yes,
                             QMessageBox::No | QMessageBox::Default) == QMessageBox::No)
     return;
 
-  XSqlQuery rollbackq;
-  rollbackq.prepare("ROLLBACK;");
-  XSqlQuery begin("BEGIN;");
-
-  XSqlQuery delq;
-  delq.prepare("DELETE FROM charass WHERE charass_target_type = 'EMP' AND charass_target_id = :emp_id;");
-  delq.bindValue(":emp_id", list()->id());
-  delq.exec();
-  if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Deleting Employee"),
-                           delq, __FILE__, __LINE__))
-  {
-    rollbackq.exec();
-    return;
-  }
-  delq.prepare("DELETE FROM empgrpitem WHERE groupsitem_reference_id = :emp_id;");
-  delq.exec();
-  if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Deleting Employee"),
-                           delq, __FILE__, __LINE__))
-  {
-    rollbackq.exec();
-    return;
-  }
   delq.prepare("DELETE FROM emp WHERE emp_id = :emp_id;");
   delq.bindValue(":emp_id", list()->id());
   delq.exec();
   if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Deleting Employee"),
                            delq, __FILE__, __LINE__))
-  {
-    rollbackq.exec();
     return;
-  }
 
-  delq.exec("COMMIT;");
   sFillList();
 }
 

--- a/guiclient/employees.cpp
+++ b/guiclient/employees.cpp
@@ -86,15 +86,39 @@ void employees::sDelete()
                             QMessageBox::No | QMessageBox::Default) == QMessageBox::No)
     return;
 
+  XSqlQuery rollbackq;
+  rollbackq.prepare("ROLLBACK;");
+  XSqlQuery begin("BEGIN;");
+
   XSqlQuery delq;
-  delq.prepare("DELETE FROM charass WHERE charass_target_type = 'EMP' AND charass_target_id = :emp_id;"
-               "DELETE FROM empgrpitem WHERE empgrpitem_emp_id = :emp_id;"
-               "DELETE FROM emp WHERE emp_id = :emp_id;");
+  delq.prepare("DELETE FROM charass WHERE charass_target_type = 'EMP' AND charass_target_id = :emp_id;");
   delq.bindValue(":emp_id", list()->id());
   delq.exec();
-  if (ErrorReporter::error(QtCriticalMsg, this, tr("Error deleting Employee"),
+  if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Deleting Employee"),
                            delq, __FILE__, __LINE__))
+  {
+    rollbackq.exec();
     return;
+  }
+  delq.prepare("DELETE FROM empgrpitem WHERE groupsitem_reference_id = :emp_id;");
+  delq.exec();
+  if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Deleting Employee"),
+                           delq, __FILE__, __LINE__))
+  {
+    rollbackq.exec();
+    return;
+  }
+  delq.prepare("DELETE FROM emp WHERE emp_id = :emp_id;");
+  delq.bindValue(":emp_id", list()->id());
+  delq.exec();
+  if (ErrorReporter::error(QtCriticalMsg, this, tr("Error Deleting Employee"),
+                           delq, __FILE__, __LINE__))
+  {
+    rollbackq.exec();
+    return;
+  }
+
+  delq.exec("COMMIT;");
   sFillList();
 }
 


### PR DESCRIPTION
This was masking an underlying SQL error preventing the deletion of employees.

cherry picked from 5_0_x branch as error not originally reproduced in 4.12 system due to missing package.  Moved logic to deletion triggers.

requires xtuple/xtuple#3596