### PR TITLE
[34294] Correctly release AR/AP memo numbers when cancelling document

### DIFF
--- a/guiclient/apOpenItem.cpp
+++ b/guiclient/apOpenItem.cpp
@@ -342,6 +342,12 @@ void apOpenItem::sSave()
   }
 }
 
+void apOpenItem::closeEvent(QCloseEvent *pEvent)
+{
+  sClose();
+  XDialog::closeEvent(pEvent);
+}
+
 void apOpenItem::sClose()
 {
   XSqlQuery deleteOpenItem;

--- a/guiclient/apOpenItem.h
+++ b/guiclient/apOpenItem.h
@@ -42,6 +42,7 @@ public slots:
     virtual void sToggleAccount();
     virtual void sCalcBalance();
     virtual void sViewMode();
+    virtual void closeEvent( QCloseEvent *pEvent );
 
 protected slots:
     virtual void languageChange();

--- a/guiclient/arOpenItem.cpp
+++ b/guiclient/arOpenItem.cpp
@@ -345,6 +345,12 @@ void arOpenItem::sSave()
   }
 }
 
+void arOpenItem::closeEvent(QCloseEvent *pEvent)
+{
+  sClose();
+  XDialog::closeEvent(pEvent);
+}
+
 void arOpenItem::sClose()
 {
   XSqlQuery deleteARDocument;

--- a/guiclient/arOpenItem.h
+++ b/guiclient/arOpenItem.h
@@ -42,6 +42,7 @@ public slots:
     virtual void sPrintOnPost(int temp_id);
     virtual void sTaxDetail();
     virtual void sReleaseNumber();
+    virtual void closeEvent( QCloseEvent *pEvent );
 
 protected slots:
     virtual void languageChange();


### PR DESCRIPTION
Was already releasing when Cancel button pressed but did not when cancelled via X window button.

Issue raised reflected problem with A/P memos but same issue applies to A/R memos