### PR TITLE
[34545] *enterMiscCount always returns 0 as a dialog code

### DIFF
--- a/guiclient/enterMiscCount.cpp
+++ b/guiclient/enterMiscCount.cpp
@@ -106,7 +106,7 @@ void enterMiscCount::sPost()
   {
     return;
   }
-#pragma comment(linker,"/SUBSYSTEM:CONSOLE")
+
   enterPost.prepare( "SELECT postMiscCount(itemsite_id, :qty, :comments) AS cnttag_id "
              "FROM itemsite "
              "WHERE ( (itemsite_item_id=:item_id)"

--- a/guiclient/enterMiscCount.cpp
+++ b/guiclient/enterMiscCount.cpp
@@ -106,7 +106,7 @@ void enterMiscCount::sPost()
   {
     return;
   }
-
+#pragma comment(linker,"/SUBSYSTEM:CONSOLE")
   enterPost.prepare( "SELECT postMiscCount(itemsite_id, :qty, :comments) AS cnttag_id "
              "FROM itemsite "
              "WHERE ( (itemsite_item_id=:item_id)"
@@ -134,7 +134,7 @@ void enterMiscCount::sPost()
   }
 
   if (_captive)
-    done(enterPost.value("cnttag_id").toInt());
+    done(QDialog::Accepted);
   else
   {
     _item->setId(-1);


### PR DESCRIPTION
The return code returned by enterMiscCount() is in some cases used to update an XTreeWidget using `sFillList`. Therefore, it is necessary to return `1` or `QDialog::Accepted`