### PR TITLE
[33965] OrderCluster does not emit the newId(int) signal

### DIFF
--- a/guiclient/enterMiscCount.cpp
+++ b/guiclient/enterMiscCount.cpp
@@ -106,7 +106,7 @@ void enterMiscCount::sPost()
   {
     return;
   }
-
+#pragma comment(linker,"/SUBSYSTEM:CONSOLE")
   enterPost.prepare( "SELECT postMiscCount(itemsite_id, :qty, :comments) AS cnttag_id "
              "FROM itemsite "
              "WHERE ( (itemsite_item_id=:item_id)"
@@ -134,7 +134,7 @@ void enterMiscCount::sPost()
   }
 
   if (_captive)
-    done(enterPost.value("cnttag_id").toInt());
+    done(QDialog::Accepted);
   else
   {
     _item->setId(-1);

--- a/guiclient/enterMiscCount.cpp
+++ b/guiclient/enterMiscCount.cpp
@@ -106,7 +106,7 @@ void enterMiscCount::sPost()
   {
     return;
   }
-#pragma comment(linker,"/SUBSYSTEM:CONSOLE")
+
   enterPost.prepare( "SELECT postMiscCount(itemsite_id, :qty, :comments) AS cnttag_id "
              "FROM itemsite "
              "WHERE ( (itemsite_item_id=:item_id)"
@@ -134,7 +134,7 @@ void enterMiscCount::sPost()
   }
 
   if (_captive)
-    done(QDialog::Accepted);
+    done(enterPost.value("cnttag_id").toInt());
   else
   {
     _item->setId(-1);

--- a/widgets/ordercluster.cpp
+++ b/widgets/ordercluster.cpp
@@ -322,6 +322,7 @@ OrderLineEdit::~OrderLineEdit()
 void OrderLineEdit::sNewId(const int p)
 {
   emit newId(p, _name);
+  emit newId(p);
   emit numberChanged(text(), _name);
 }
 

--- a/widgets/ordercluster.h
+++ b/widgets/ordercluster.h
@@ -87,6 +87,7 @@ class XTUPLEWIDGETS_EXPORT OrderLineEdit : public VirtualClusterLineEdit
 
   signals:
     void newId(const int, const QString &);
+    void newId(const int);
     void numberChanged(const QString &, const QString &);
 
   protected:


### PR DESCRIPTION
Added an extra signal to `OrderLineEdit`
Emit new signal whenever `sNewId()` is called