### PR TITLE
[9618] populate uom programatically poitem quick entry (poitemtableview)

### DIFF
--- a/guiclient/poitemTableModel.cpp
+++ b/guiclient/poitemTableModel.cpp
@@ -224,7 +224,7 @@ bool PoitemTableModel::submitAll()
 Qt::ItemFlags PoitemTableModel::flags(const QModelIndex& index) const
 {
   Qt::ItemFlags flags = QSqlRelationalTableModel::flags(index);
-  if (index.column() == POITEM_VEND_UOM_COL || index.column() == EXTPRICE_COL)
+  if (index.column() == EXTPRICE_COL)
     flags &= ~(Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsEnabled);
 
   return flags;

--- a/guiclient/poitemTableView.cpp
+++ b/guiclient/poitemTableView.cpp
@@ -567,7 +567,9 @@ void PoitemTableDelegate::setModelData(QWidget *editor, QAbstractItemModel *pMod
               hitError = true;
               break;
             }
-	  }
+      else
+        model->setData(model->index(index.row(), POITEM_VEND_UOM_COL), item->uom());
+    }
 	}
       }
       break;


### PR DESCRIPTION
The column for `vendor_uom` could not be populated using `setData()` because it was flagged as `not editable`.
This would make sense if the column appeared in the quick entry table but it does not. An editor is never created for the column. This ensures that the user cannot edit the `vendor uom` from the UI (which is probably the motivation behind setting the flag for that column in the first place).
Additionally, if there is no `itemsrc` for the item created we default to item's inventory UOM 