### PR TITLE
[34342] backport initial fix and add more

### DIFF
--- a/guiclient/salesOrderItem.cpp
+++ b/guiclient/salesOrderItem.cpp
@@ -5135,6 +5135,7 @@ void salesOrderItem::handleFieldsOnModeChange(int pMode)
   }
   else
   {
+    _subItemList->setVisible(ISNEW(pMode) || ISEDIT(pMode));
     _comments->setType(Comments::SalesOrderItem);
     prevButtonSql = "SELECT EXISTS(SELECT 1 FROM coitem"
                     "               WHERE coitem_cohead_id = :head_id) AS hasLines;";
@@ -5146,8 +5147,8 @@ void salesOrderItem::handleFieldsOnModeChange(int pMode)
   _save->setEnabled(false);
   _save->setVisible(ISNEW(_initialMode) || ISEDIT(_initialMode));
 
-  _comments->setReadOnly(pMode == cNewQuote);   // prior code really is this specific
-  _item->setReadOnly(ISEDIT(pMode) || ISVIEW(pMode));
+  _comments->setReadOnly(pMode == cNewQuote || ISVIEW(pMode));
+  _item    ->setReadOnly(ISEDIT(pMode)      || ISVIEW(pMode));
 
   _cancel->setEnabled(ISEDIT(pMode) || ISVIEW(pMode));
   _next  ->setEnabled(ISEDIT(pMode) || ISVIEW(pMode));

--- a/guiclient/salesOrderItem.h
+++ b/guiclient/salesOrderItem.h
@@ -101,6 +101,8 @@ class salesOrderItem : public XDialog, public Ui::salesOrderItem
     virtual void  reject();
 
   private:
+    virtual void  handleFieldsOnModeChange(int pMode);
+
     double  _priceRatio;
     int     _preferredWarehouseid;
     int     _saletypeid;


### PR DESCRIPTION
The additional problems were found when using the NEXT and PREVIOUS
buttons on the Sales Order Item window through kit and enhanced pricing
sublines. Once the window had been put into view mode for the sublines,
the `_mode` variable would get set properly but the various fields
would not get re-enabled.