### PR TITLE
[33351] *PO Line from WO can't be modified

### DIFF
--- a/guiclient/purchaseOrderItem.cpp
+++ b/guiclient/purchaseOrderItem.cpp
@@ -454,7 +454,7 @@ void purchaseOrderItem::populate()
       _overriddenUnitPrice = true;
 
     if(purchasepopulate.value("poitem_order_id") != -1 && 
-       purchasepopulate.value("demand_type").toString()=="Sales Order #")
+       purchasepopulate.value("poitem_order_type").toString()=="S")
     {
       _ordered->setEnabled(false);
       _dueDate->setEnabled(false);

--- a/guiclient/purchaseOrderItem.cpp
+++ b/guiclient/purchaseOrderItem.cpp
@@ -453,7 +453,8 @@ void purchaseOrderItem::populate()
     if(purchasepopulate.value("override_cost").toDouble() > 0)
       _overriddenUnitPrice = true;
 
-    if(purchasepopulate.value("poitem_order_id") != -1)
+    if(purchasepopulate.value("poitem_order_id") != -1 && 
+       purchasepopulate.value("demand_type").toString()=="Sales Order #")
     {
       _ordered->setEnabled(false);
       _dueDate->setEnabled(false);


### PR DESCRIPTION
The old code is the result of changes made for [9062]. The comment thread pointed to a requirements doc that mentioned that:

> The quantity and date of a Purchase Order should not be editable if the header is linked to a Sales Order.

However, the code disabled those fields for all Purchase Orders