### PR TITLE
[33304] *Project not saved when releasing planned orders to purchase request

### DIFF
--- a/guiclient/purchaseRequest.cpp
+++ b/guiclient/purchaseRequest.cpp
@@ -271,11 +271,10 @@ void purchaseRequest::sSave()
         purchaseCreate.bindValue(":pr_id",  _prid);
         purchaseCreate.bindValue(":prj_id", _project->id());
         purchaseCreate.exec();
-
-        purchaseCreate.prepare("SELECT releasePlannedOrder(:planord_id, false) AS result;");
-        purchaseCreate.bindValue(":planord_id", _planordid);
-        purchaseCreate.exec();
       }
+      purchaseCreate.prepare("SELECT releasePlannedOrder(:planord_id, false) AS result;");
+      purchaseCreate.bindValue(":planord_id", _planordid);
+      purchaseCreate.exec();
     }
     else
     {

--- a/guiclient/purchaseRequest.cpp
+++ b/guiclient/purchaseRequest.cpp
@@ -265,9 +265,23 @@ void purchaseRequest::sSave()
     {
       _prid = purchaseCreate.value("prid").toInt();
 
-      purchaseCreate.prepare("SELECT releasePlannedOrder(:planord_id, false) AS result;");
-      purchaseCreate.bindValue(":planord_id", _planordid);
-      purchaseCreate.exec();
+      if (_prid != -1)
+      {
+        purchaseCreate.prepare("UPDATE pr SET pr_prj_id=:prj_id WHERE (pr_id=:pr_id);");
+        purchaseCreate.bindValue(":pr_id",  _prid);
+        purchaseCreate.bindValue(":prj_id", _project->id());
+        purchaseCreate.exec();
+
+        purchaseCreate.prepare("SELECT releasePlannedOrder(:planord_id, false) AS result;");
+        purchaseCreate.bindValue(":planord_id", _planordid);
+        purchaseCreate.exec();
+      }
+    }
+    else
+    {
+      ErrorReporter::error(QtCriticalMsg, this, tr("Error Saving Purchase Request"),
+                           purchaseCreate, __FILE__, __LINE__);
+      return;
     }
   }
 


### PR DESCRIPTION
The query for updating the `pr_prj_id` column was only present in the `cNew` code but not the `cRelease` code.
Also added an error check if createPr() does not return a valid value