### PR TITLE
[30460] properly calculate WO start date whenever due date is changed

### DIFF
--- a/guiclient/salesOrderItem.cpp
+++ b/guiclient/salesOrderItem.cpp
@@ -3082,11 +3082,11 @@ void salesOrderItem::sHandleSupplyOrder()
               applychange = true;
             if (applychange)
             {
-              ordq.prepare("SELECT changeWoDates(:wo_id, wo_startdate + (:dueDate-wo_duedate), :dueDate, true) AS result "
-                           "FROM wo "
-                           "WHERE (wo_id=:wo_id);");
+              ordq.prepare("SELECT changeWoDates(:wo_id, calculatenextworkingdate(:whs_id, :dueDate, :leadTime), :dueDate, true) AS result; ");
               ordq.bindValue(":wo_id", _supplyOrderId);
               ordq.bindValue(":dueDate", _scheduledDate->date());
+              ordq.bindValue(":leadTime", -1*_leadTime);
+              ordq.bindValue(":whs_id", _itemsiteLastWarehousid);
               ordq.exec();
               if (ordq.first())
               {
@@ -3108,11 +3108,11 @@ void salesOrderItem::sHandleSupplyOrder()
           } // end scheduled date changed
           else if (_supplyOrderDueDate->date() != _supplyOrderDueDateCache)
           { // supply ord due date changed
-            ordq.prepare("SELECT changeWoDates(:wo_id, wo_startdate + (:dueDate-wo_duedate), :dueDate, true) AS result "
-                         "FROM wo "
-                         "WHERE (wo_id=:wo_id);");
+            ordq.prepare("SELECT changeWoDates(:wo_id, calculatenextworkingdate(:whs_id, :dueDate, :leadTime), :dueDate, true) AS result; ");
             ordq.bindValue(":wo_id", _supplyOrderId);
             ordq.bindValue(":dueDate", _supplyOrderDueDate->date());
+            ordq.bindValue(":leadTime", -1*_leadTime);
+            ordq.bindValue(":whs_id", _supplyWarehouse->id());
             ordq.exec();
             if (ordq.first())
             {

--- a/guiclient/salesOrderItem.cpp
+++ b/guiclient/salesOrderItem.cpp
@@ -3082,7 +3082,12 @@ void salesOrderItem::sHandleSupplyOrder()
               applychange = true;
             if (applychange)
             {
-              ordq.prepare("SELECT changeWoDates(:wo_id, calculatenextworkingdate(:whs_id, :dueDate, :leadTime), :dueDate, true) AS result; ");
+              QString sql;
+              if(_metrics->boolean("UseSiteCalendar"))
+                sql = "SELECT changeWoDates(:wo_id, calculatenextworkingdate(:whs_id, :dueDate, :leadTime), :dueDate, true) AS result; ";
+              else 
+                sql = "SELECT changeWoDates(:wo_id, wo_startdate + (:dueDate - wo_duedate), :dueDate, true) AS result;";
+              ordq.prepare(sql);
               ordq.bindValue(":wo_id", _supplyOrderId);
               ordq.bindValue(":dueDate", _scheduledDate->date());
               ordq.bindValue(":leadTime", -1*_leadTime);
@@ -3108,7 +3113,12 @@ void salesOrderItem::sHandleSupplyOrder()
           } // end scheduled date changed
           else if (_supplyOrderDueDate->date() != _supplyOrderDueDateCache)
           { // supply ord due date changed
-            ordq.prepare("SELECT changeWoDates(:wo_id, calculatenextworkingdate(:whs_id, :dueDate, :leadTime), :dueDate, true) AS result; ");
+            QString sql;
+            if(_metrics->boolean("UseSiteCalendar"))
+              sql = "SELECT changeWoDates(:wo_id, calculatenextworkingdate(:whs_id, :dueDate, :leadTime), :dueDate, true) AS result; ";
+            else 
+              sql = "SELECT changeWoDates(:wo_id, wo_startdate + (:dueDate - wo_duedate), :dueDate, true) AS result;";
+            ordq.prepare(sql);
             ordq.bindValue(":wo_id", _supplyOrderId);
             ordq.bindValue(":dueDate", _supplyOrderDueDate->date());
             ordq.bindValue(":leadTime", -1*_leadTime);


### PR DESCRIPTION
when changing wo dates, the startDate would be set to `wo_startdate + (:dueDate-wo_duedate)` which could be a non work day or an exception. but we never check to see if the new startDate is actually a work date