### PR TITLE
[35168] Set customer widget as initial data entry point in Invoice

### DIFF
--- a/guiclient/invoice.cpp
+++ b/guiclient/invoice.cpp
@@ -145,6 +145,7 @@ invoice::invoice(QWidget* parent, const char* name, Qt::WindowFlags fl)
     _taxExemptLit->hide();
     _taxExempt->hide();
   }
+  _cust->setFocus();
 }
 
 invoice::~invoice()

--- a/guiclient/invoice.ui
+++ b/guiclient/invoice.ui
@@ -1539,8 +1539,8 @@ to be bound by its terms.</comment>
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>_invoiceDate</tabstop>
   <tabstop>_cust</tabstop>
+  <tabstop>_invoiceDate</tabstop>
   <tabstop>_copyToShipto</tabstop>
   <tabstop>_invoiceNumber</tabstop>
   <tabstop>_terms</tabstop>


### PR DESCRIPTION
Sets the Customer as the initial data entry widget when creating an Invoice.  Previously no widget was default/initial so forced user to have to click on a widget first before being able to enter _any_ data.