### PR TITLE
[35203] set() before exec() ensures the dialog is initialized properly

### DIFF
--- a/guiclient/viewCheckRun.cpp
+++ b/guiclient/viewCheckRun.cpp
@@ -203,8 +203,8 @@ void viewCheckRun::sPost()
   params.append("check_id", _check->id());
 
   postCheck newdlg(this, "", true);
-  newdlg.exec();
   newdlg.set(params);
+  newdlg.exec();
 }
 
 void viewCheckRun::sAltExchRate()


### PR DESCRIPTION
tested related [32113] to make sure that still works